### PR TITLE
pip requirements - use git+https to be proxy aware

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ flask-negotiation
 flask-mongoengine
 flask-login
 tldextract
-git+git://github.com/joepie91/python-whois#egg=pythonwhois
+git+https://github.com/joepie91/python-whois#egg=pythonwhois
 ipwhois
 blinker
 simplejson


### PR DESCRIPTION
Some may not be able to use native git protocol for outgoing connections

Issue #46