### PR TITLE
Added OneShot Shodan API

### DIFF
--- a/plugins/analytics/public/shodan_api.py
+++ b/plugins/analytics/public/shodan_api.py
@@ -1,0 +1,67 @@
+from pprint import pformat
+import shodan
+from core.analytics import OneShotAnalytics
+from core.entities import Company
+from core.observables import Text, Hostname, Tag
+
+
+class ShodanApi(object):
+    settings = {
+        "shodan_api_key": {
+            "name": "Shodan API Key",
+            "description": "API Key provided by Shodan.io."
+        }
+    }
+
+    @staticmethod
+    def fetch(observable, api_key):
+        try:
+            r = shodan.Shodan(api_key).host(observable.value)
+        except shodan.APIError, e:
+            print 'Error: %s' % e
+        return r
+
+
+class ShodanQuery(OneShotAnalytics, ShodanApi):
+    default_values = {
+        "name": "Shodan",
+        "description": "Perform a Shodan query on the IP address and tries to"
+                       " extract relevant information."
+    }
+
+    ACTS_ON = "Ip"
+
+    @staticmethod
+    def analyze(ip, results):
+        links = set()
+        result = ShodanApi.fetch(ip, results.settings['shodan_api_key'])
+        results.update(raw=pformat(result))
+
+        if 'tag' in result and result['tag'] is not None:
+            o_tag = Tag.get_or_create(result['tag'])
+
+        if 'asn' in result and result['asn'] is not None:
+            o_asn = Text.get_or_create(value=result['asn'])
+            links.update(ip.active_link_to(o_asn, 'asn#', 'Shodan Query'))
+
+        if 'hostnames' in result and result['hostnames'] is not None:
+            for hostname in result['hostnames']:
+                h = Hostname.get_or_create(value=hostname)
+                links.update(ip.active_link_to(h, 'hosts', 'Shodan Query'))
+
+        if 'isp' in result and result['isp'] is not None:
+            o_isp = Company.get_or_create(name=result['isp'])
+            links.update(ip.active_link_to(o_isp, 'hosting', 'Shodan Query'))
+
+        # Add the network whois to the context if not already present
+        for context in ip.context:
+            if context['source'] == 'shodan_query':
+                break
+        else:
+            # Remove the nets info (the main one was copied)
+            result.pop("data", None)
+
+            result['source'] = 'shodan_query'
+            ip.add_context(result)
+
+        return list(links)

--- a/plugins/analytics/public/shodan_api.py
+++ b/plugins/analytics/public/shodan_api.py
@@ -37,8 +37,8 @@ class ShodanQuery(OneShotAnalytics, ShodanApi):
         result = ShodanApi.fetch(ip, results.settings['shodan_api_key'])
         results.update(raw=pformat(result))
 
-        if 'tag' in result and result['tag'] is not None:
-            o_tag = Tag.get_or_create(result['tag'])
+        if 'tags' in result and result['tags'] is not None:
+            ip.tag(result['tags'])
 
         if 'asn' in result and result['asn'] is not None:
             o_asn = Text.get_or_create(value=result['asn'])
@@ -47,18 +47,17 @@ class ShodanQuery(OneShotAnalytics, ShodanApi):
         if 'hostnames' in result and result['hostnames'] is not None:
             for hostname in result['hostnames']:
                 h = Hostname.get_or_create(value=hostname)
-                links.update(ip.active_link_to(h, 'hosts', 'Shodan Query'))
+                links.update(ip.active_link_to(h, 'A record', 'Shodan Query'))
 
         if 'isp' in result and result['isp'] is not None:
             o_isp = Company.get_or_create(name=result['isp'])
             links.update(ip.active_link_to(o_isp, 'hosting', 'Shodan Query'))
 
-        # Add the network whois to the context if not already present
         for context in ip.context:
             if context['source'] == 'shodan_query':
                 break
         else:
-            # Remove the nets info (the main one was copied)
+            # Remove the data part (Shodan Crawler Data, etc.)
             result.pop("data", None)
 
             result['source'] = 'shodan_query'

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ sphinx_rtd_theme
 sphinxcontrib-httpdomain
 geoip2
 psutil
+shodan


### PR DESCRIPTION
What:
* Register for user supplied setting: -> shodan_api_key
* Depends on python shodan package (mentioned in requirements)
* Acts on: Ip (for now)
* Uses shodan.host(query) to query shodan.io API for that Observable
* Creates Tag if shodan has one (but actually don't link|use it
* Create_or_Update Text Observable for ASN
*      "    Hostname Observable for all Hostnames
*      "    Company Entitiy for Shodan's ISP Field
* Drops all Crawler Data and put the rest to context

Issue #24

Comments for further enhancements are very welcome.