### PR TITLE
Configuration file + MISP feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Thumbs.db
 exports/*
 storage/*
 celerybeat.pid
+yeti.conf
 
 # Frontend Dependencies
 node_modules

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -8,7 +8,7 @@ from core.analytics import ScheduledAnalytics
 from core.config.config import yeti_config
 
 connect(
-    'yeti',
+    yeti_config.mongodb.database,
     host=yeti_config.mongodb.host,
     port=yeti_config.mongodb.port,
     username=yeti_config.mongodb.username,

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -5,4 +5,13 @@ from core.exports import Export
 from core.feed import Feed
 from core.analytics import ScheduledAnalytics
 
-connect('yeti', connect=False)
+from core.config.config import yeti_config
+
+connect(
+    'yeti',
+    host=yeti_config.mongodb.host,
+    port=yeti_config.mongodb.port,
+    username=yeti_config.mongodb.username,
+    password=yeti_config.mongodb.password,
+    connect=False
+)

--- a/core/config/celeryctl.py
+++ b/core/config/celeryctl.py
@@ -1,13 +1,13 @@
 from __future__ import unicode_literals
 
 from celery import Celery
+from core.config.config import yeti_config
 
 celery_app = Celery('yeti')
 
 
 class CeleryConfig:
-    # BROKER_URL = 'mongodb://localhost:27017/'
-    BROKER_URL = 'redis://localhost:6379/0'
+    BROKER_URL = 'redis://{}:{}/{}'.format(yeti_config.redis.host, yeti_config.redis.port, yeti_config.redis.database)
     CELERY_TASK_SERIALIZER = 'json'
     CELERY_ACCEPT_CONTENT = ['json']
     CELERY_IMPORTS = ('core.config.celeryimports', 'core.analytics_tasks', 'core.exports.export', 'core.feed')

--- a/core/config/config.py
+++ b/core/config/config.py
@@ -1,0 +1,59 @@
+import os
+import ConfigParser
+
+from core.constants import YETI_ROOT
+
+
+class Dictionary(dict):
+
+    def __getattr__(self, key):
+        return self.get(key, None)
+
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+
+class Config:
+
+    def __init__(self):
+        config = ConfigParser.SafeConfigParser(allow_no_value=True)
+        config.read(os.path.join(YETI_ROOT, "yeti.conf"))
+
+        for section in config.sections():
+            setattr(self, section, Dictionary())
+            for name in config.options(section):
+                try:
+                    value = config.getint(section, name)
+                except ValueError:
+                    try:
+                        value = config.getboolean(section, name)
+                    except ValueError:
+                        value = config.get(section, name)
+
+                getattr(self, section)[name] = value
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def set_default_value(self, section, key, value):
+        if not hasattr(self, section):
+            setattr(self, section, Dictionary())
+
+        if key not in self[section]:
+            self[section][key] = value
+
+    def get(self, section, key, default=None):
+        if not hasattr(self, section) or key not in self[section]:
+            return default
+        else:
+            return self[section][key]
+
+
+yeti_config = Config()
+yeti_config.set_default_value('mongodb', 'host', '127.0.0.1')
+yeti_config.set_default_value('mongodb', 'port', 27017)
+yeti_config.set_default_value('mongodb', 'username', None)
+yeti_config.set_default_value('mongodb', 'password', None)
+yeti_config.set_default_value('redis', 'host', '127.0.0.1')
+yeti_config.set_default_value('redis', 'port', 6379)
+yeti_config.set_default_value('redis', 'database', 0)

--- a/core/config/config.py
+++ b/core/config/config.py
@@ -52,6 +52,7 @@ class Config:
 yeti_config = Config()
 yeti_config.set_default_value('mongodb', 'host', '127.0.0.1')
 yeti_config.set_default_value('mongodb', 'port', 27017)
+yeti_config.set_default_value('mongodb', 'database', 'yeti')
 yeti_config.set_default_value('mongodb', 'username', None)
 yeti_config.set_default_value('mongodb', 'password', None)
 yeti_config.set_default_value('redis', 'host', '127.0.0.1')

--- a/core/observables/observable.py
+++ b/core/observables/observable.py
@@ -55,8 +55,12 @@ class Observable(Node):
             "tags",
             "last_analyses",
             "created",
+            {
+                "fields": ["#value"],
+                "cls": False
+            }
         ],
-        "index_backgroud": True,
+        "index_background": True,
         "ordering": ["-created"],
     }
 

--- a/core/observables/tag.py
+++ b/core/observables/tag.py
@@ -20,7 +20,8 @@ class Tag(Node):
     default_expiration = TimeDeltaField(default=timedelta(days=90))
 
     meta = {
-        'ordering': ['name']
+        'ordering': ['name'],
+        'indexes': ['name', 'replaces']
     }
 
     def __unicode__(self):

--- a/plugins/feeds/public/misp.py
+++ b/plugins/feeds/public/misp.py
@@ -1,0 +1,156 @@
+import logging
+import requests
+from lxml import etree
+from urlparse import urljoin
+from mongoengine import DictField
+from datetime import date, datetime, timedelta
+
+from core.feed import Feed
+from core.observables import Observable
+from core.errors import ObservableValidationError
+from core.config.config import yeti_config
+
+
+class MispFeed(Feed):
+
+    last_runs = DictField()
+
+    default_values = {
+        "frequency": timedelta(hours=1),
+        "name": "MispFeed",
+        "description": "Parses events from a given MISP instance",
+        "source": "MISP"
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(MispFeed, self).__init__(*args, **kwargs)
+        self.get_instances()
+
+    def get_instances(self):
+        self.instances = {}
+
+        for instance in yeti_config.get('misp', 'instances', '').split(','):
+            config = {
+                'url': yeti_config.get(instance, 'url'),
+                'key': yeti_config.get(instance, 'key'),
+                'name': yeti_config.get(instance, 'name') or instance,
+                'organisations': {}
+            }
+
+            if config['url'] and config['key']:
+                self.instances[instance] = config
+
+    def last_run_for(self, instance):
+        last_run = [int(part) for part in self.last_runs[instance].split('-')]
+
+        return date(*last_run)
+
+    def get_organisations(self, instance):
+        url = urljoin(self.instances[instance]['url'], '/organisations/index/scope:all')
+        headers = {
+            'Authorization': self.instances[instance]['key'],
+            'Content-type': 'application/json',
+            'Accept': 'application/json'
+        }
+
+        orgs = requests.get(url, headers=headers).json()
+
+        for org in orgs:
+            org_id = org['Organisation']['id']
+            org_name = org['Organisation']['name']
+            self.instances[instance]['organisations'][org_id] = org_name
+
+    def week_events(self, instance):
+        one_week = timedelta(days=7)
+        url = urljoin(self.instances[instance]['url'], '/events/xml/download.json')
+        headers = {'Authorization': self.instances[instance]['key']}
+        to = date.today()
+        fromdate = to - timedelta(days=6)
+        time_filter = {'request': {}}
+
+        while True:
+            imported = 0
+
+            time_filter['request']['to'] = to.isoformat()
+            time_filter['request']['from'] = fromdate.isoformat()
+            r = requests.post(url, headers=headers, json=time_filter)
+
+            try:
+                msg = r.json()
+                raise AttributeError(msg['message'])
+            except ValueError:
+                tree = etree.fromstring(r.content)
+
+                for event in tree.findall(".//Event"):
+                    self.analyze(event, instance)
+                    imported += 1
+
+                yield fromdate, to, imported
+                to = to - one_week
+                fromdate = fromdate - one_week
+
+    def get_last_events(self, instance):
+        print "Getting last events for {}".format(instance)
+        last_run = self.last_run_for(instance)
+        seen_last_run = False
+
+        for date_from, date_to, imported in self.week_events(instance):
+            print date_from, date_to
+
+            if seen_last_run:
+                break
+
+            if date_from <= last_run <= date_to:
+                seen_last_run = True
+
+    def get_all_events(self, instance):
+        print "Getting all events for {}".format(instance)
+        had_results = True
+
+        for date_from, date_to, imported in self.week_events(instance):
+            print date_from, date_to
+
+            if imported == 0:
+                if had_results:
+                    had_results = False
+                else:
+                    break
+            else:
+                had_results = True
+
+    def update(self):
+        for instance in self.instances:
+            print "Processing instance {}".format(instance)
+            self.get_organisations(instance)
+            if instance in self.last_runs:
+                self.get_last_events(instance)
+            else:
+                self.get_all_events(instance)
+
+            self.modify(**{"set__last_runs__{}".format(instance): date.today().isoformat()})
+
+    def analyze(self, event, instance):
+        context = {}
+        org = self.instances[instance]['organisations'][event.findtext('orgc_id')]
+        context['org'] = org
+        context['uuid'] = event.findtext('uuid')
+        context['id'] = int(event.findtext('id'))
+        context['link'] = urljoin(self.instances[instance]['url'], "/events/{}".format(context['id']))
+        context['timestamp'] = datetime.fromtimestamp(float(event.findtext('timestamp')))
+        context['source'] = self.instances[instance]['name']
+        context['description'] = event.findtext('info')
+
+        for attr in event.findall('Attribute'):
+            type = attr.findtext('type')
+            category = attr.findtext('category').replace(' ', '_')
+            value = attr.findtext('value')
+            context['comment'] = attr.findtext('comment') or "N/A"
+
+            if type in ['domain', 'ip-dst', 'ip-src', 'url', 'hostname']:
+                try:
+                    obs = Observable.add_text(value)
+                    if obs:
+                        obs.tag(category)
+                        obs.add_context(context)
+                except ObservableValidationError:
+                    logging.error("{}: error adding {}".format(self.__class__.name, value))

--- a/testfeeds.py
+++ b/testfeeds.py
@@ -1,11 +1,14 @@
 import sys
+import logging
 
 from core.feed import Feed, update_feed
 from core.scheduling import Scheduler
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+
     Scheduler()
-    # feeds = {f.name: f for f in }
+
     if len(sys.argv) == 1:
         print "Re-run using a feed name as argument"
         for f in Feed.objects():

--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -1,0 +1,45 @@
+[mongodb]
+
+##
+## Use these settings to configure how to connect to your MongoDB database.
+## All settings are optional, with default values being the one in the comment.
+## If you do not specify a username and password, there will be no authentication.
+##
+
+# host = 127.0.0.1
+# port = 27017
+# database = yeti
+# username = yeti
+# password = STRONG_PASSWORD
+
+[redis]
+
+##
+## Use these settings to configure how to connect to your redis server.
+## All settings are optional, with default values being the one in the comment.
+##
+
+# host = 127.0.0.1
+# port = 6379
+# database = 0
+
+[misp]
+
+##
+## Use this setting in order to specify a comma-separated list of MISP instances
+## that should be taken into account by the MISP feed.
+##
+
+# instances = misp_1
+
+[misp_1]
+
+##
+## For each instance in the 'misp.instances' setting, you should specify a
+## configuration block with this format, in order to specify at least the URL
+## and the auth key.
+##
+
+# name = MISP_1
+# url = MISP_URL
+# key = MISP_AUTH_KEY


### PR DESCRIPTION
This PR brings two new features:

- An optional configuration file in which you can change the default settings for connections to MongoDB and Redis. MongoDB authentication is now supported ! This fixes #107.
- A MISP feed that you can configure (in the previously mentioned configuration file) in order to get all events from any number of MISP instances.