### PR TITLE
Added functionality to dedup contexts when adding and updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,10 @@ develop-eggs
 lib
 lib64
 __pycache__
+/local
+/include
+/share
+pip-selfcheck.json
 
 # Installer logs
 pip-log.txt

--- a/core/observables/observable.py
+++ b/core/observables/observable.py
@@ -144,9 +144,8 @@ class Observable(Node):
             replace_source: If defined, contexts having a ``source`` attribute
                             set to ``replace_source`` will be deleted before insert
             dedup_list: takes a list of fields to ignore during dedup comparison.
-                         i.e. date/count type fields. Empty list will
-                         skip dedup the partial dedup as dedup for the exact same context
-                         is already builtin.
+                         i.e. date/count type fields. Empty list will skip the partial
+                         dedup as dedup for the exact same context is already builtin.
         Returns:
             A fresh instance of the Observable as it exists in the database.
 

--- a/core/observables/observable.py
+++ b/core/observables/observable.py
@@ -129,7 +129,7 @@ class Observable(Node):
             for old_tag in old_tags:
                 o.change_tag(old_tag, new_tag)
 
-    def add_context(self, context, replace_source=None, dedup=False, ignore_list=[]):
+    def add_context(self, context, replace_source=None, dedup_list=[]):
         """Adds context to an Observable.
 
         "Context" is represented by a JSON object (or Python ``dict()``) that will
@@ -143,8 +143,7 @@ class Observable(Node):
             context: a JSON object representing the context to be added.
             replace_source: If defined, contexts having a ``source`` attribute
                             set to ``replace_source`` will be deleted before insert
-            dedup: Boolean indicating if we should dedup contexts when adding
-            ignore-list: takes a list of fields to ignore during dedup comparison..
+            dedup_list: takes a list of fields to ignore during dedup comparison..
                          i.e. date/count type fields. Empty list will compare all, 'None' will
                          skip dedup.
         Returns:
@@ -157,11 +156,11 @@ class Observable(Node):
             # This does not work : cannot traverse and set context atomically
             # self.modify({"context__source": c}, set__context__S=context)
             self.modify(pull__context__source=replace_source)
-        if dedup:
+        if dedup_list:
             for c in self.context:
                 remove = True
                 for key in c:
-                    if key in ignore_list:
+                    if key in dedup_list:
                         continue
                     if c[key] != context.get(key, ''):
                         remove = False

--- a/core/observables/observable.py
+++ b/core/observables/observable.py
@@ -143,9 +143,10 @@ class Observable(Node):
             context: a JSON object representing the context to be added.
             replace_source: If defined, contexts having a ``source`` attribute
                             set to ``replace_source`` will be deleted before insert
-            dedup_list: takes a list of fields to ignore during dedup comparison..
-                         i.e. date/count type fields. Empty list will compare all, 'None' will
-                         skip dedup.
+            dedup_list: takes a list of fields to ignore during dedup comparison.
+                         i.e. date/count type fields. Empty list will
+                         skip dedup the partial dedup as dedup for the exact same context
+                         is already builtin.
         Returns:
             A fresh instance of the Observable as it exists in the database.
 

--- a/core/observables/observable.py
+++ b/core/observables/observable.py
@@ -129,7 +129,7 @@ class Observable(Node):
             for old_tag in old_tags:
                 o.change_tag(old_tag, new_tag)
 
-    def add_context(self, context, replace_source=None):
+    def add_context(self, context, replace_source=None, dedup=False, ignore_list=[]):
         """Adds context to an Observable.
 
         "Context" is represented by a JSON object (or Python ``dict()``) that will
@@ -143,7 +143,10 @@ class Observable(Node):
             context: a JSON object representing the context to be added.
             replace_source: If defined, contexts having a ``source`` attribute
                             set to ``replace_source`` will be deleted before insert
-
+            dedup: Boolean indicating if we should dedup contexts when adding
+            ignore-list: takes a list of fields to ignore during dedup comparison..
+                         i.e. date/count type fields. Empty list will compare all, 'None' will
+                         skip dedup.
         Returns:
             A fresh instance of the Observable as it exists in the database.
 
@@ -154,6 +157,17 @@ class Observable(Node):
             # This does not work : cannot traverse and set context atomically
             # self.modify({"context__source": c}, set__context__S=context)
             self.modify(pull__context__source=replace_source)
+        if dedup:
+            for c in self.context:
+                remove = True
+                for key in c:
+                    if key in ignore_list:
+                        continue
+                    if c[key] != context.get(key, ''):
+                        remove = False
+                        break
+                if remove:
+                    self.modify(pull__context=c)
         self.modify(add_to_set__context=context)
 
         return self.reload()


### PR DESCRIPTION
This pull adds come code and parameters into add_context in observable.py to compare the context being added against the fields of the existing context entries for the observable and remove similar contexts when adding. The ignore_list parameter allows you to provide a list of keys that should be ignored like dates or hit counts or whatever. 

It gives you the ability to only have new contexts when the context of the observable actually changes and not a new one for each pull. 

Additionally added some venv folders to gitignore. 