### PR TITLE
Make some investigation fields editable. Closes #98

### DIFF
--- a/core/web/frontend/generic.py
+++ b/core/web/frontend/generic.py
@@ -4,8 +4,8 @@ from flask_classy import FlaskView, route
 from flask import render_template, request, redirect, url_for, abort
 from mongoengine import NotUniqueError
 
-from core.errors import GenericValidationError
 from core.entities import Malware, Company, TTP, Actor
+from core.errors import  GenericValidationError
 from core.indicators import Regex
 from core.database import AttachedFile
 from core.web.helpers import get_object_or_404
@@ -80,7 +80,7 @@ class GenericView(FlaskView):
     def post_save(self, obj, request):
         pass
 
-    def handle_form(self, id=None, klass=None):
+    def handle_form(self, id=None, klass=None, skip_validation=False):
         if klass:  # create
             obj = klass()
             form = klass.get_form()(request.form)
@@ -93,7 +93,7 @@ class GenericView(FlaskView):
             form.populate_obj(obj)
             try:
                 self.pre_validate(obj, request)
-                obj = obj.save()
+                obj = obj.save(validate=not skip_validation)
                 self.post_save(obj, request)
             except GenericValidationError as e:
                 # failure - redirect to edit page

--- a/core/web/frontend/investigations.py
+++ b/core/web/frontend/investigations.py
@@ -84,3 +84,7 @@ class InvestigationView(GenericView):
         observables = Observable.from_string(investigation.import_text)
 
         return render_template("{}/import_from.html".format(self.klass.__name__.lower()), investigation=investigation, observables=bson_renderer(observables))
+
+    def handle_form(self, *args, **kwargs):
+        kwargs['skip_validation'] = True
+        return super(InvestigationView, self).handle_form(*args, **kwargs)

--- a/core/web/frontend/templates/investigation/edit.html
+++ b/core/web/frontend/templates/investigation/edit.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% import "macros/generic.html" as macros %}
+
+{% block title %}
+{% if not obj %}New {{obj_type}}{% else %}Editing {{obj.name}}{%endif%}
+{% endblock %}
+
+{% block breadcrumb %}
+<ol class="breadcrumb">
+	<li>YETI</li>
+  <li><a href="{{url_for('frontend.InvestigationView:index')}}">Investigations</a></li>
+	<li class="active">Edit</li>
+</ol>
+{% endblock %}
+
+{% block custom_head %}
+<script type="text/javascript" src="{{ url_for("frontend.static", filename="yeti/js/tagfields.js") }}" charset="utf-8"></script>
+<script type="text/javascript" src="{{ url_for("frontend.static", filename="yeti/js/forms.js") }}" charset="utf-8"></script>
+<script type="text/javascript" src="{{ url_for("static", filename="bootstrap-tokenfield/dist/bootstrap-tokenfield.min.js") }}" charset="utf-8"></script>
+<script type="text/javascript" src="{{ url_for("static", filename="jquery-ui-dist/jquery-ui.min.js") }}" charset="utf-8"></script>
+
+<link rel=stylesheet type=text/css href="{{ url_for("static", filename="jquery-ui-dist/jquery-ui.min.css") }}">
+<link rel=stylesheet type=text/css href="{{ url_for("static", filename="bootstrap-tokenfield/dist/css/tokenfield-typeahead.min.css") }}">
+<link rel=stylesheet type=text/css href="{{ url_for("static", filename="bootstrap-tokenfield/dist/css/bootstrap-tokenfield.min.css") }}">
+{% endblock %}
+
+{% block main %}
+
+  <div class="cold-md-12">
+    <form action="{{request.path}}" method="POST" class="yeti-form yeti-add-node">
+    <div class="row">
+      <div class="col-md-10 col-md-offset-1">
+        <h1>Editing {{obj.name or "Unnamed investigation"}}</h1>
+      </div>
+      <div class="form-content">
+          <div class="row">
+              <div class="col-md-10 col-md-offset-1">
+                  {{ macros.render_generic_errors(form)}}
+              </div>
+              <div class="col-md-3 col-md-offset-1">
+                {% for field in form if field.name not in ['description', 'import_document', 'import_md', 'import_url', 'import_text']%}
+                  {{ macros.render_field(field) }}
+                {% endfor %}
+              </div>
+              <div class="col-md-7">
+                {{ macros.render_field(form.description, rows=12, class="form-control markdown") }}
+              </div>
+          </div>
+      </div>
+    </div>
+    <div class="row">
+        <div class="col-md-3 col-md-offset-1">
+            <input type="submit" class="btn btn-primary" value="Save">
+        </div>
+    </div>
+    </form>
+  </div>
+
+{% endblock %}

--- a/core/web/frontend/templates/investigation/single.html
+++ b/core/web/frontend/templates/investigation/single.html
@@ -24,6 +24,7 @@
           <div class="panel-heading">
             <h3 class="panel-title">
                 {{investigation.name}}
+                <a href="{{url_for('frontend.InvestigationView:edit', id=investigation.id)}}" class="btn btn-default btn-xs pull-right"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit</a>
                 <a href="{{url_for('frontend.InvestigationView:delete', id=investigation.id)}}" class="btn btn-danger btn-xs pull-right object-delete" onclick="return confirm('Are you sure?')"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Delete</a>
                 <a href="{{url_for('frontend.InvestigationView:graph', id=investigation.id)}}" class="btn btn-default btn-xs pull-right"><i class="flaticon-network38"></i> Go To Graph</a>
                 {% if investigation.import_text %}


### PR DESCRIPTION
Some werid things with validation are done because of one or more bugs in mongoengine, namely a blatant [format string](https://github.com/MongoEngine/mongoengine/issues/1619) error and what I suspect to be a validation error involving DBRefs to fields referencing abstract objects (in this case, `Node`).

To reproduce, create an investigation with at least one node, then:

```
from core.investigations import Investigation
i = Investigation.objects.all()[0]
i.save()
```
If you fix the format string issues in mongoengine/blob/master/mongoengine/fields.py#L1100 you'll see that it tries to compare a non-resolved Observable object to it's corresponding DBRef. The types not being the same, and exception is raised.