### PR TITLE
Update proofpoint.py to handle Url where a hostname is returned from PP SIEM API

### DIFF
--- a/contrib/feeds/proofpoint/proofpoint.py
+++ b/contrib/feeds/proofpoint/proofpoint.py
@@ -313,9 +313,27 @@ class ThreatInsight(Feed):
         # if they do, do not parse the threat a second time ?
         threat_nodes = []
         if 'url' in threats:
-            threat_nodes.append(
-                Url.get_or_create(
-                    value=threats['url']['threat'], context=[context]))
+           #Proofpoint sometimes supplies a hostname marked as a Url.
+           #validation rejected such hostnames
+           #this trys a Url or a Hostname and appends it as the proper class/type
+           try:
+               appnd=Url.get_or_create(
+                     value=threats['url']['threat'], context=[context])
+           except ObservableValidationError:
+               try:
+                   appnd=Hostname.get_or_create(
+                         value=threats['url']['threat'], context=[context])
+               except ObservableValidationError as e:
+                   log.error(e)
+                   log.error(pprint.pformat(threat))
+                   log.error("URL specified by ProofPoint is neither a URL or a HostName")
+
+           threat_nodes.append(appnd)A
+#           original lines:
+#            threat_nodes.append(
+#                Url.get_or_create(
+#                    value=threats['url']['threat'], context=[context]))
+
         if 'attachment' in threats:
             threat_nodes.append(
                 Hash.get_or_create(

--- a/contrib/feeds/proofpoint/proofpoint.py
+++ b/contrib/feeds/proofpoint/proofpoint.py
@@ -328,7 +328,7 @@ class ThreatInsight(Feed):
                    log.error(pprint.pformat(threat))
                    log.error("URL specified by ProofPoint is neither a URL or a HostName")
 
-           threat_nodes.append(appnd)A
+           threat_nodes.append(appnd)
 #           original lines:
 #            threat_nodes.append(
 #                Url.get_or_create(

--- a/contrib/feeds/proofpoint/proofpoint.py
+++ b/contrib/feeds/proofpoint/proofpoint.py
@@ -314,8 +314,8 @@ class ThreatInsight(Feed):
         threat_nodes = []
         if 'url' in threats:
            #Proofpoint sometimes supplies a hostname marked as a Url.
-           #validation rejected such hostnames
-           #this trys a Url or a Hostname and appends it as the proper class/type
+           #validation rejected such hostnames in Url.is_valid due to lack of scheme or path.
+           #this trys a Url, then a Hostname and appends it as the proper class/type
            try:
                appnd=Url.get_or_create(
                      value=threats['url']['threat'], context=[context])


### PR DESCRIPTION
ProofPoint API has began returning Hostname only as a 'threat'. The Url.is_valid validation fails, as the hostname isn't a valid URL (lacks scheme, lacks path).

The below revisions tries to add the threat as a Url; and if that fails will attempt to add it as a Hostname.

This gets the threat to the right object type; and improves ingestion of ProofPoint threats of type Phish.

