### PR TITLE
macaddress.io one-shot analytics added

### DIFF
--- a/core/observables/__init__.py
+++ b/core/observables/__init__.py
@@ -11,3 +11,4 @@ from core.observables.email import Email
 from core.observables.text import Text
 from core.observables.bitcoin import Bitcoin
 from core.observables.path import Path
+from core.observables.mac_address import MacAddress

--- a/core/observables/mac_address.py
+++ b/core/observables/mac_address.py
@@ -1,0 +1,24 @@
+from __future__ import unicode_literals
+
+import re
+
+from core.observables import Observable
+
+
+class MacAddress(Observable):
+    regex = r'(?P<search>(([0-9A-Fa-f]{1,2}[.:-]?){5,7}([0-9A-Fa-f]{1,2})))'
+
+    exclude_fields = Observable.exclude_fields
+
+    DISPLAY_FIELDS = Observable.DISPLAY_FIELDS
+
+    @classmethod
+    def is_valid(cls, match):
+        value = match.group('search')
+        return len(value) > 0
+
+    def normalize(self):
+        self.value = re.sub(r'[.:\-]', '', self.value)
+        self.value = self.value.upper()
+        self.value = \
+            ':'.join([self.value[i:i + 2] for i in range(0, len(self.value), 2)])

--- a/core/observables/observable.py
+++ b/core/observables/observable.py
@@ -98,9 +98,9 @@ class Observable(Node):
         Raises:
             ObservableValidationError if no type could be guessed.
         """
-        from core.observables import Url, Ip, Email, Path, Hostname, Hash, Bitcoin
+        from core.observables import Url, Ip, Email, Path, Hostname, Hash, Bitcoin, MacAddress
         if string and string.strip() != '':
-            for t in [Url, Ip, Email, Path, Hostname, Hash, Bitcoin]:
+            for t in [Url, Ip, Email, Path, Hostname, Hash, Bitcoin, MacAddress]:
                 if t.check_type(string):
                     return t
 
@@ -109,10 +109,10 @@ class Observable(Node):
 
     @staticmethod
     def from_string(string):
-        from core.observables import Url, Ip, Hostname, Email, Hash
+        from core.observables import Url, Ip, Hostname, Email, Hash, MacAddress
 
         results = dict()
-        for t in [Url, Ip, Email, Hostname, Hash]:
+        for t in [Url, Ip, Email, Hostname, Hash, MacAddress]:
             results[t.__name__] = t.extract(string)
 
         return results

--- a/core/web/frontend/staticfiles/yeti/js/graph.js
+++ b/core/web/frontend/staticfiles/yeti/js/graph.js
@@ -25,6 +25,7 @@ var analyticsResultsTemplate = Handlebars.compile($('#graph-sidebar-analytics-re
 // Define default icons
 var icons = {
   'Observable.Ip': flaticon('\ue005'),
+  'Observable.MacAddress': flaticon('\ue005'),
   'Observable.Hostname': flaticon('\ue01E'),
   'Observable.Url': flaticon('\ue013'),
   'Observable.Email': flaticon('\ue01A'),
@@ -32,6 +33,7 @@ var icons = {
   'Observable.File': flaticon('\ue021'),
   'Observable.Hash': flaticon('\ue00e'),
   'Observable.Path': flaticon('\ue00a'),
+
   'Entity.Malware': flaticon('\ue001'),
   'Entity.TTP': flaticon('\ue019'),
   'Entity.Company': flaticon('\ue002'),
@@ -42,6 +44,7 @@ var icons = {
 
 var cssicons = {
   'Observable.Ip': 'flaticon-computer189',
+  'Observable.MacAddress': 'flaticon-computer189',
   'Observable.Hostname': 'flaticon-server20',
   'Observable.Url': 'flaticon-links11',
   'Observable.Email': 'flaticon-message99',

--- a/plugins/analytics/public/macaddress_io.py
+++ b/plugins/analytics/public/macaddress_io.py
@@ -1,0 +1,154 @@
+from __future__ import unicode_literals
+
+import json
+from datetime import datetime
+
+from maclookup import ApiClient, exceptions
+
+from core.analytics import OneShotAnalytics
+from core.entities import Company
+
+
+class MacAddressIoApi(object):
+    __MODULE_GROUP__ = "MacAddress.io"
+
+    settings = {
+        "macaddress_io_api_key": {
+            "name": "macaddress.io API Key",
+            "description": "API Key provided by macaddress.io"
+        }
+    }
+
+    @staticmethod
+    def get(mac_address, settings):
+        api_client = ApiClient(settings["macaddress_io_api_key"])
+
+        try:
+            response = api_client.get_raw_data(mac_address, 'json')
+            return json.loads(response)
+
+        except exceptions.EmptyResponseException:
+            raise LookupError('Empty response')
+
+        except exceptions.UnparsableResponseException:
+            raise LookupError('Unparsable response')
+
+        except exceptions.ServerErrorException:
+            raise LookupError('Internal server error')
+
+        except exceptions.UnknownOutputFormatException:
+            raise LookupError('Unknown output')
+
+        except exceptions.AuthorizationRequiredException:
+            raise LookupError('Authorization required')
+
+        except exceptions.AccessDeniedException:
+            raise LookupError('Access denied')
+
+        except exceptions.InvalidMacOrOuiException:
+            raise LookupError('Invalid MAC or OUI')
+
+        except exceptions.NotEnoughCreditsException:
+            raise LookupError('Not enough credits')
+
+        except Exception:
+            raise LookupError('Unknown error')
+
+
+class MacAddressIo(OneShotAnalytics, MacAddressIoApi):
+    default_values = {
+        "group": MacAddressIoApi.__MODULE_GROUP__,
+        "name": "MacAddress Vendor lookup (macaddress.io)",
+        "description":
+            "Retrieve vendor details and other information regarding a given MAC address or an OUI from macaddress.io."
+    }
+
+    ACTS_ON = ["MacAddress"]
+
+    @staticmethod
+    def analyze(observable, results):
+        links = set()
+
+        lookup_results = MacAddressIoApi.get(observable.value, results.settings)
+
+        results.update(raw=json.dumps(lookup_results, indent=2))
+
+        if lookup_results["blockDetails"]["dateCreated"]:
+            date_created = \
+                datetime.strptime(lookup_results["blockDetails"]["dateCreated"], "%Y-%m-%d")
+        else:
+            date_created = None
+
+        if lookup_results["blockDetails"]["dateUpdated"]:
+            date_updated = \
+                datetime.strptime(lookup_results["blockDetails"]["dateUpdated"], "%Y-%m-%d")
+        else:
+            date_updated = None
+
+        try:
+            if lookup_results["vendorDetails"]["companyName"] != "":
+                vendor = \
+                    Company.get_or_create(name=lookup_results["vendorDetails"]["companyName"])
+
+                links.update(
+                    observable.link_to(
+                        vendor,
+                        'Vendor',
+                        MacAddressIoApi.__MODULE_GROUP__,
+                        date_created,
+                        date_updated))
+        except KeyError:
+            pass
+
+        MacAddressIo.add_context_to_observable(observable, lookup_results)
+
+        return list(links)
+
+    @staticmethod
+    def add_context_to_observable(observable, lookup_results):
+        context = dict([
+            ('raw', json.dumps(lookup_results, indent=2)),
+
+            ('source', 'MAC address vendor lookup (macaddress.io)'),
+
+            # Mac address details
+            ('Valid MAC address', lookup_results["macAddressDetails"]["isValid"]),
+
+            ('Transmission type', lookup_results["macAddressDetails"]["transmissionType"]),
+
+            ('Administration type', lookup_results["macAddressDetails"]["administrationType"]),
+
+            # Vendor details
+            ('OUI', lookup_results["vendorDetails"]["oui"]),
+
+            ('Vendor details are hidden', lookup_results["vendorDetails"]["isPrivate"]),
+
+            ('Company name', lookup_results["vendorDetails"]["companyName"]),
+
+            ('Company\'s address', lookup_results["vendorDetails"]["companyAddress"]),
+
+            ('Country code', lookup_results["vendorDetails"]["countryCode"]),
+
+            # Block details
+            ('Block found', lookup_results["blockDetails"]["blockFound"]),
+
+            ('The left border of the range', lookup_results["blockDetails"]["borderLeft"]),
+
+            ('The right border of the range', lookup_results["blockDetails"]["borderRight"]),
+
+            ('The total number of MAC addresses in this range', lookup_results["blockDetails"]["blockSize"]),
+
+            ('Assignment block size', lookup_results["blockDetails"]["assignmentBlockSize"]),
+        ])
+
+        if lookup_results["blockDetails"]["dateCreated"]:
+            context['Date when the range was allocated'] = datetime.strptime(
+                lookup_results["blockDetails"]["dateCreated"], '%Y-%m-%d').strftime('%d %B %Y')
+
+        if lookup_results["blockDetails"]["dateUpdated"]:
+            context['Date when the range was last updated'] = datetime.strptime(
+                lookup_results["blockDetails"]["dateUpdated"], '%Y-%m-%d').strftime('%d %B %Y')
+
+        context = {k: v for k, v in context.iteritems() if v}
+
+        observable.add_context(context, replace_source=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ readability-lxml
 beautifulsoup4
 requests[socks]
 python-dateutil
+maclookup


### PR DESCRIPTION
- New MacAddress observable added
- New macaddress.io one-shot analytics plugin added

The plugin allows retrieving vendor details and other information regarding a given MAC address or an OUI. 
It is based on the macaddress.io API. (https://macaddress.io)

How to use: 
- https://macaddress.io/integrations/YETI-module