### PR TITLE
Apache authentication

### DIFF
--- a/core/auth/apache/__init__.py
+++ b/core/auth/apache/__init__.py
@@ -1,0 +1,3 @@
+from core.auth.apache.views import auth
+from core.auth.apache.user_management import get_default_user
+

--- a/core/auth/apache/user_management.py
+++ b/core/auth/apache/user_management.py
@@ -1,0 +1,35 @@
+from os import urandom
+
+from flask import request
+from flask_login.mixins import AnonymousUserMixin
+from mongoengine.errors import DoesNotExist
+
+from core.config.config import yeti_config
+from core.auth.local.user_management import DEFAULT_PERMISSIONS, \
+    generate_session_token
+from core.user import User
+
+def create_user(username):
+    user = User(username=username, permissions=DEFAULT_PERMISSIONS)
+    user.api_key = User.generate_api_key()
+    user.password = urandom(24).encode('hex')
+    user.session_token = generate_session_token(user)
+    user.enabled = True
+    user.save()
+    return user
+
+def authenticate():
+    username = request.environ.get(yeti_config.auth.apache_variable)
+    if username is None:
+        return False
+    try:
+        return User.objects.get(username=username)
+    except DoesNotExist:
+        return create_user(username)
+
+
+def get_default_user():
+    user = authenticate()
+    if not user:
+        return AnonymousUserMixin()
+    return user

--- a/core/auth/apache/views.py
+++ b/core/auth/apache/views.py
@@ -1,0 +1,25 @@
+from flask import Blueprint, request, redirect, flash, abort
+from flask_login import current_user, login_user, logout_user
+
+from core.auth.apache.user_management import authenticate
+from core.user import User
+
+auth = Blueprint('auth', __name__, template_folder='templates')
+
+@auth.route('/login')
+def login():
+    if current_user.is_authenticated:
+        return redirect("/observable/")
+    user = authenticate()
+    if user:
+        login_user(user)
+        print "User logged in (web):", user
+        return redirect(request.args.get('next', '/'))
+    flash("Invalid credentials", "danger")
+    abort(401)
+
+@auth.route('/logout')
+def logout():
+    logout_user()
+    flash("Logged out", "info")
+    return redirect('/login')

--- a/core/config/config.py
+++ b/core/config/config.py
@@ -50,6 +50,7 @@ class Config:
 
 
 yeti_config = Config()
+yeti_config.set_default_value('auth', 'module', 'local')
 yeti_config.set_default_value('mongodb', 'host', '127.0.0.1')
 yeti_config.set_default_value('mongodb', 'port', 27017)
 yeti_config.set_default_value('mongodb', 'database', 'yeti')

--- a/core/config/config.py
+++ b/core/config/config.py
@@ -51,6 +51,7 @@ class Config:
 
 yeti_config = Config()
 yeti_config.set_default_value('auth', 'module', 'local')
+yeti_config.set_default_value('auth', 'apache_variable', 'REMOTE_USER')
 yeti_config.set_default_value('mongodb', 'host', '127.0.0.1')
 yeti_config.set_default_value('mongodb', 'port', 27017)
 yeti_config.set_default_value('mongodb', 'database', 'yeti')

--- a/core/web/webapp.py
+++ b/core/web/webapp.py
@@ -27,7 +27,7 @@ login_manager = LoginManager()
 login_manager.init_app(webapp)
 login_manager.login_view = '/login'
 
-auth_module = import_module('core.auth.local')
+auth_module = import_module('core.auth.%s' % yeti_config.auth.module)
 webapp.register_blueprint(auth_module.auth)
 
 connect(

--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -6,6 +6,14 @@
 
 # module = local
 
+##
+## If you specify module = apache, you can set the environment
+## variable from which the username can be retrieved (defaults to
+## REMOTE_USER).
+##
+
+# apache_variable = REMOTE_USER
+
 [mongodb]
 
 ##

--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -1,3 +1,11 @@
+[auth]
+
+##
+## Use these settings to configure Yeti authentication.
+##
+
+# module = local
+
 [mongodb]
 
 ##


### PR DESCRIPTION
This PR adds an authentication module to use Apache (or any Web server that can set an environment variable to the logged in user) built-in authentication.

This is useful if you already have an authentication used for other Web applications, or if you want to rely on Windows AD (or Unix Kerberos) SSO.