### PR TITLE
Add an api and frontend view for listing related investigations in graph

### DIFF
--- a/core/web/api/investigation.py
+++ b/core/web/api/investigation.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from flask import request
 from flask_classy import route
 from bson.json_util import loads
+from bson.objectid import ObjectId
 
 from core.helpers import iterify
 from core import investigation
@@ -12,7 +13,7 @@ from core.web.api.crud import CrudApi, CrudSearchApi
 from core.observables import *
 from core.investigation import ImportResults
 from core.entities import Entity
-from core.web.api.api import render
+from core.web.api.api import render, render_json
 from core.web.helpers import get_object_or_404
 from core.web.helpers import requires_permissions
 
@@ -98,4 +99,51 @@ class Investigation(CrudApi):
         except Exception, e:
             response = {'status': 'error', 'message': str(e)}
 
+        return render(response)
+
+    @route('/search_existence', methods=["POST"])
+    @requires_permissions('read')
+    def search_existence(self):
+        """Query investigation based on given observable, incident or entity
+
+            Query[ref]: class of the given node, which should be observable or entity
+            Query[id]: the id of the given node.
+
+        """
+        REF_CLASS = ('observable', 'entity')
+
+        data = loads(request.data)
+
+        if 'id' not in data or 'ref' not in data:
+            response = { 
+                'status': 'error',
+                'message': 'missing argument.' 
+            }
+        
+        elif not ObjectId.is_valid(data['id']):
+            response = { 
+                'status': 'error',
+                'message': 'given id is not valid.'
+            }
+        
+        elif data['ref'] not in REF_CLASS:
+            response = { 
+                'status': 'error',
+                'message': 'reference class is not valid.' 
+            }
+
+        else:
+            query = {
+                'nodes': {
+                    '$elemMatch': {
+                        '$id': ObjectId(data['id']),
+                        '$ref': data['ref']
+                    }
+                }
+            }
+            response = self.objectmanager.objects(__raw__=query)
+            for inv in response:
+                if not inv.name:
+                    inv['name'] = 'unnamed investigation'
+                    
         return render(response)

--- a/core/web/frontend/staticfiles/handlebars/helpers.js
+++ b/core/web/frontend/staticfiles/handlebars/helpers.js
@@ -73,3 +73,21 @@ Handlebars.registerHelper('join', function(val, delimiter) {
     delimiter = ( typeof delimiter == "string" ? delimiter : ',' );
     return arry.join(delimiter);
 });
+
+Handlebars.registerHelper("listinv", function (investigations) {
+  const [currentId] = window.location.href.split('/').splice(-1, 1);
+  const filteredInvestigations = investigations.filter((inv) => (inv._id != currentId));
+  if (filteredInvestigations.length === 0) {
+    return "No results.";
+  }
+  let htmlContent = '';
+  filteredInvestigations.forEach((inv) => {
+    let template = `<h4>${inv.name}</h4>
+      <a class="btn btn-primary" href="${'/investigation/' + inv._id}" target="_blank">link</a>
+      <a class="btn btn-default" href="${'/investigation/graph/' + inv._id}" target="_blank">graph</a>
+      <div class="related-investigation-bottom"></div>
+    `;
+    htmlContent += template;
+  });
+  return htmlContent;
+});

--- a/core/web/frontend/templates/investigation/graph_templates.html
+++ b/core/web/frontend/templates/investigation/graph_templates.html
@@ -232,8 +232,9 @@
                     No context to display.
                 {{/each}}
             </div>
+            <div id="graph-sidebar-related-investigation" data-id="{{id}}">
+            </div>
         </div>
-
         <div id="graph-sidebar-links" class="tab-pane active">
             <div id="graph-sidebar-links-to-{{id}}">Links loading ...</div>
             <div id="graph-sidebar-links-from-{{id}}"></div>
@@ -289,5 +290,23 @@
             {{> analyticsPanel}}
         </div>
     </div>
+</script>
+
+<script id="graph-sidebar-related-investigation-template" type="text/x-handlebars-template">
+    <h1 id="graph-sidebar-related-investigation-title" >Related Investigations</h1>
+    <style>
+    #graph-sidebar-related-investigation-title {
+        border-bottom: 1px solid #888888;
+        font-size: 1.2em;
+        color: white;
+        padding-bottom: 5px;
+    }
+    .related-investigation-bottom {
+        margin-top:5px;
+        border-bottom: 1px dashed #888888;
+    }
+    </style>
+    {{#listinv investigations }}
+    {{/listinv }}
 </script>
 {% endraw %}


### PR DESCRIPTION
Hi, I add a small feature. The feature list all related investigation when you click on an node in graph mode.
The use case is below.
1. Assume user already has some existing investigations. Then create a new one and add an entity.
<img width="1440" alt="default" src="https://user-images.githubusercontent.com/20921230/48828740-8157b700-edab-11e8-8f43-0d71b4f703ff.png">
2. User clicks the node on the graph. Then click option info in the left panel. There is a section below which lists all investigations except current one that the clicked node have already been added into. 
<img width="1440" alt="default" src="https://user-images.githubusercontent.com/20921230/48828795-a51afd00-edab-11e8-8d3b-aecb794259b7.png">
<img width="286" alt="default" src="https://user-images.githubusercontent.com/20921230/48828954-09d65780-edac-11e8-8e5c-64f62502bc57.png">
3. Clicking the link button will lead user to the investigation page.
<img width="1440" alt="default" src="https://user-images.githubusercontent.com/20921230/48828968-0f33a200-edac-11e8-934c-d86070ca1499.png">
4. Clicking the graph button will lead user to the investigation graph.
<img width="1440" alt="default" src="https://user-images.githubusercontent.com/20921230/48829009-283c5300-edac-11e8-90ca-f90caadbed4a.png">
I added this because of my work before. I think this should contribute back to you.