### PR TITLE
Investigations: add tags and attached files

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -323,7 +323,7 @@ class AttachedFile(YetiDocument):
 
     def attach(self, obj):
         obj.attached_files.append(self)
-        obj.save()
+        obj.save(validate=False)
         self.update(inc__references=1)
 
     def detach(self, obj):

--- a/core/web/api/investigation.py
+++ b/core/web/api/investigation.py
@@ -14,12 +14,25 @@ from core.investigation import ImportResults
 from core.entities import Entity
 from core.web.api.api import render
 from core.web.helpers import get_object_or_404
-from core.web.helpers import requires_permissions
+from core.web.helpers import requires_permissions, get_queryset
 
 
 class InvestigationSearch(CrudSearchApi):
     template = 'investigation_api.html'
     objectmanager = investigation.Investigation
+
+    def search(self, query):
+        fltr = query.get('filter', {})
+        params = query.get('params', {})
+        regex = params.pop('regex', False)
+        ignorecase = params.pop('ignorecase', False)
+        page = params.pop('page', 1) - 1
+        rng = params.pop('range', 50)
+
+        return list(
+            get_queryset(
+                self.objectmanager, fltr, regex, ignorecase,
+                replace=False)[page * rng:(page + 1) * rng])
 
 
 class Investigation(CrudApi):

--- a/core/web/api/templates/investigation_api.html
+++ b/core/web/api/templates/investigation_api.html
@@ -6,7 +6,7 @@
   <tr>
     <th><!-- graph icon column --></th>
     <th>Name</th>
-    <th>Created</th>
+    <th>Tags</th>
     <th>Updated</th>
     <th>Created By</th>
     <th>Nodes</th>
@@ -21,7 +21,7 @@
         {{obj['name'] or 'Unnamed'}}
       </a>
     </td>
-    <td>{{macros.display_datetime(obj.created)}}</td>
+    <td>{{macros.display_tags(obj.tags)}}</td>
     <td>{{macros.display_datetime(obj.updated)}}</td>
     <td>{{obj.created_by or ''}}</td>
     <td>{{obj.nodes|length}}</td>

--- a/core/web/frontend/staticfiles/yeti/css/yeti.css
+++ b/core/web/frontend/staticfiles/yeti/css/yeti.css
@@ -144,6 +144,7 @@ input.dropzone {
   margin: 0 1px 0 1px;
   font-size: 85%;
   cursor: default;
+  border: 1px solid grey;
 }
 
 .yeti-edit-elt:hover .yeti-tag,
@@ -176,6 +177,26 @@ input.dropzone {
 .tag-blocklist {
   color: white;
 	background-color: #e33;
+}
+
+.tag-tlp_red {
+    background-color: #e33;
+    color: white;
+}
+
+.tag-tlp_amber {
+    background-color: gold;
+    color: black;
+}
+
+.tag-tlp_green {
+    background-color: MediumSpringGreen;
+    color: black;
+}
+
+.tag-tlp_white {
+    background-color: white;
+    color: black;
 }
 
 .yeti-interact .yeti-tag  {

--- a/core/web/frontend/templates/investigation/single.html
+++ b/core/web/frontend/templates/investigation/single.html
@@ -24,8 +24,8 @@
           <div class="panel-heading">
             <h3 class="panel-title">
                 {{investigation.name or 'Unnamed Investigation'}}
-                <a href="{{url_for('frontend.InvestigationView:edit', id=investigation.id)}}" class="btn btn-default btn-xs pull-right"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit</a>
                 <a href="{{url_for('frontend.InvestigationView:delete', id=investigation.id)}}" class="btn btn-danger btn-xs pull-right object-delete" onclick="return confirm('Are you sure?')"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span> Delete</a>
+                <a href="{{url_for('frontend.InvestigationView:edit', id=investigation.id)}}" class="btn btn-default btn-xs pull-right"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit</a>
                 <a href="{{url_for('frontend.InvestigationView:graph', id=investigation.id)}}" class="btn btn-default btn-xs pull-right"><i class="flaticon-network38"></i> Go To Graph</a>
                 {% if investigation.import_text %}
                     <a id="show_import" href="#" class="btn btn-default btn-xs pull-right"><i class="glyphicon glyphicon-paperclip"></i> See Import Source</a>
@@ -65,13 +65,52 @@
       <div class="panel-body">
         <table class="table table-condensed main-table">
           {% for key, value in investigation.info().items() %}
-          {% if key not in ["_id", "links", "nodes", "events", "name", "import_document", "import_text", "import_md"] %}
-            <tr><th>{{key}}</th><td>{{macros.display_yeti(investigation, key)}}</td></tr>
-          {% endif %}
+            {% if key not in ["_id", "links", "nodes", "events", "name", "import_document", "import_text", "import_md", "attached_files"] %}
+              {% if value %}
+                <tr><th>{{key}}</th><td>{{macros.display_yeti(investigation, key)}}</td></tr>
+              {% endif %}
+            {% endif %}
           {% endfor %}
         </table>
       </div>
     </div>
+
+    <div class="panel panel-primary yeti-panel">
+      <div class="panel-heading">
+        <h3 class="panel-title">Files</h3>
+      </div>
+      <div class="panel-body">
+        <table class="table table-condensed">
+          {% for f in investigation.attached_files %}
+          <tr class="node-line">
+            <td class='icon-cell'>
+              <a href="{{url_for("api.Investigation:file_content", sha256=f.sha256)}}">
+                <i class="fa fa-download" aria-hidden="true"></i>
+              </a>
+            </td>
+
+            <td>{{f.filename}}</td>
+            <td class='icon-cell'>
+              <a onclick="return confirm('Are you sure?')" href="{{url_for("frontend.InvestigationView:detach_file", id=investigation.id, fileid=f.id)}}">
+                <i class="fa fa-trash-o" aria-hidden="true"></i>
+              </a>
+            </td>
+          </tr>
+          {% else %}
+          No files for now.
+          {% endfor %}
+        </table>
+        <form clas='form-inline' action="{{ url_for("frontend.InvestigationView:attach_file", id=investigation.id) }}" method="post" enctype=multipart/form-data>
+          <div class="form-group pull-right">
+            <input type="submit" value="Attach">
+          </div>
+          <div class="form-group">
+            <input type="file" name="file">
+          </div>
+        </form>
+      </div>
+    </div>
+
 
   </div> <!-- end second column -->
 


### PR DESCRIPTION
Several improvements to investigations:

* Added the possibility to tag an investigation (fixes #331)
* Added the possibility to attach files to an investigation (fixes #330)

Also introduced color conventions for tag values "tlp_red", "tlp_amber", "tlp_green" and "tlp_white".