### PR TITLE
fix problem on verification of urls with space

### DIFF
--- a/core/observables/observable.py
+++ b/core/observables/observable.py
@@ -181,6 +181,10 @@ class Observable(Node):
         pass
 
     def clean(self):
+        
+        if self.__class__.__name__ == "Url" and " " in self.value:
+            self.value = self.value.replace(" ", "%20")
+            
         if self.check_type(self.value):
             self.normalize()
         else:


### PR DESCRIPTION
getting fumik0 feed i found a urls with space
```
ERROR:root:'http://84.38.129.57/blog/Perdo/hawk 2nd (1).exe' is not a valid 'Url'
ERROR:root:'http://84.38.129.57/blog/OGB/OLGA HKFILE.exe' is not a valid 'Url'
```

checking your regex and other validation tools like

```
>>> import validators
>>> validators.url("http://84.38.129.57/blog/OGB/OLGA HKFILE.exe")
ValidationFailure(func=url, args={'public': False, 'value': 'http://84.38.129.57/blog/OGB/OLGA HKFILE.exe'})

validators.url("http://84.38.129.57/blog/OGB/OLGA HKFILE.exe".replace(" ", "%20"))
True
```

i saw you already do replace of space with %20, but inside of the self.normalize() which is just after, so i think this should solve this issue