### PR TITLE
improve domain recon + update related scripts where used

### DIFF
--- a/core/common/utils.py
+++ b/core/common/utils.py
@@ -1,0 +1,24 @@
+import logging
+from core.config.config import yeti_config
+from tldextract import TLDExtract
+
+
+tld_extract_dict = {
+    'extra_suffixes': list(),
+    'suffix_list_urls': None
+}
+
+if yeti_config.tldextract.extra_suffixes:
+    tld_extract_dict['extra_suffixes'] = yeti_config.tldextract.extra_suffixes.split(',')
+if yeti_config.tldextract.suffix_list_urls:
+    tld_extract_dict['suffix_list_urls'] = yeti_config.tldextract.suffix_list_urls
+
+def tldextract_parser(url):
+    parts = None
+
+    try:
+        parts = TLDExtract(**tld_extract_dict)(url)
+    except Exception as e:
+        logging.error(e)
+
+    return parts

--- a/core/common/utils.py
+++ b/core/common/utils.py
@@ -8,10 +8,11 @@ tld_extract_dict = {
     'suffix_list_urls': None
 }
 
-if yeti_config.tldextract.extra_suffixes:
-    tld_extract_dict['extra_suffixes'] = yeti_config.tldextract.extra_suffixes.split(',')
-if yeti_config.tldextract.suffix_list_urls:
-    tld_extract_dict['suffix_list_urls'] = yeti_config.tldextract.suffix_list_urls
+if hasattr(yeti_config, "tldextract"):
+    if yeti_config.tldextract.extra_suffixes:
+        tld_extract_dict['extra_suffixes'] = yeti_config.tldextract.extra_suffixes.split(',')
+    if yeti_config.tldextract.suffix_list_urls:
+        tld_extract_dict['suffix_list_urls'] = yeti_config.tldextract.suffix_list_urls
 
 def tldextract_parser(url):
     parts = None

--- a/core/observables/hostname.py
+++ b/core/observables/hostname.py
@@ -2,12 +2,11 @@ from __future__ import unicode_literals
 
 import idna
 from mongoengine import BooleanField, StringField
-from tldextract import extract
+from core.common.utils import tldextract_parser
 
 from core.errors import ObservableValidationError
 from core.observables import Observable
 from core.helpers import refang
-
 
 class Hostname(Observable):
 
@@ -29,7 +28,7 @@ class Hostname(Observable):
             value = refang(match.group('search'))
 
             if len(value) <= 255:
-                parts = extract(value)
+                parts = tldextract_parser(value)
                 if parts.suffix and parts.domain:
                     return True
 

--- a/plugins/analytics/public/domain_tools.py
+++ b/plugins/analytics/public/domain_tools.py
@@ -6,7 +6,7 @@ import requests
 from pythonwhois.parse import parse_raw_whois
 from mongoengine import FieldDoesNotExist
 from datetime import datetime
-from tldextract import extract
+from core.common.utils import tldextract_parser
 
 from core.helpers import iterify, get_value_at
 from core.analytics import OneShotAnalytics
@@ -156,7 +156,7 @@ class DTWhoisHistory(OneShotAnalytics, DomainToolsApi):
     @staticmethod
     def analyze(observable, results):
         links = set()
-        parts = extract(observable.value)
+        parts = tldextract_parser(observable.value)
 
         if parts.subdomain == '':
             data = DomainToolsApi.get(
@@ -259,7 +259,7 @@ class DTWhois(OneShotAnalytics, DomainToolsApi):
     @staticmethod
     def analyze(observable, results):
         links = []
-        parts = extract(observable.value)
+        parts = tldextract_parser(observable.value)
 
         if parts.subdomain == '':
             should_add_context = False

--- a/plugins/analytics/public/process_hostnames.py
+++ b/plugins/analytics/public/process_hostnames.py
@@ -1,4 +1,4 @@
-from tldextract import extract
+from core.common.utils import tldextract_parser
 from core.analytics import InlineAnalytics
 from core.observables import Hostname
 
@@ -18,12 +18,12 @@ class ProcessHostnames(InlineAnalytics):
 
     @staticmethod
     def analyze_string(hostname_string):
-        parts = extract(hostname_string)
+        parts = tldextract_parser(hostname_string)
         return [parts.registered_domain]
 
     @staticmethod
     def each(hostname):
-        parts = extract(hostname.value)
+        parts = tldextract_parser(hostname.value)
 
         if parts.suffix in SUSPICIOUS_TLDS:
             hostname.tag('suspicious_tld')

--- a/plugins/analytics/public/whois.py
+++ b/plugins/analytics/public/whois.py
@@ -1,6 +1,6 @@
 from pythonwhois.net import get_whois_raw
 from pythonwhois.parse import parse_raw_whois
-from tldextract import extract
+from core.common.utils import tldextract_parser
 
 from core.analytics import OneShotAnalytics
 from core.observables import Email, Text
@@ -34,7 +34,7 @@ class Whois(OneShotAnalytics):
     def analyze(hostname, results):
         links = set()
 
-        parts = extract(hostname.value)
+        parts = tldextract_parser(hostname.value)
 
         if parts.subdomain == '':
             should_add_context = False

--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -68,3 +68,8 @@
 [maxmind]
 
 # path = /full/path/to/GeoLite2-City.mmdb
+
+[tldextract]
+# comma separated list of tlds, WITHOUT dots, example: bit,tor2web,pw
+# extra_suffixes =
+# suffix_list_urls =


### PR DESCRIPTION
this will allow to users set their extended/custom tld(s) lists and mute/point to extended tld lists to retrieve, or not leak server ip to tldextract each time and they can update tld list from tldextract by cron

right now it not support for example urls wtih .bit tld, so this fixes it :)

```
core.errors.ObservableValidationError: http://X.bit/X/X.php was not recognized as a viable datatype
```