### PR TITLE
Create packettotal.py

### DIFF
--- a/plugins/analytics/public/packettotal.py
+++ b/plugins/analytics/public/packettotal.py
@@ -105,54 +105,54 @@ class PacketTotalQuery(PacketTotalAPI, OneShotAnalytics):
                     analysis_url, 'analysis_link', 'packettotal_query')
                 )
 
-                analysis = pcap_analysis.get('analysis_summary', {})
+            analysis = pcap_analysis.get('analysis_summary', {})
 
-                for signature in analysis.get('signatures', []):
-                    o_sig = Text.get_or_create(value=signature)
+            for signature in analysis.get('signatures', []):
+                o_sig = Text.get_or_create(value=signature)
+                links.update(
+                    analysis_url.active_link_to(
+                        o_sig,
+                        'triggered_ids_signature',
+                        'packettotal_query'
+                    )
+                )
+
+            destination_addresses = analysis.get(
+                'top_talkers', {}).get('destination_ips', {})
+
+            for dst_addr, percentage in destination_addresses.items():
+                try:
+                    o_ip = Ip.get_or_create(value=dst_addr)
                     links.update(
                         analysis_url.active_link_to(
-                            o_sig,
-                            'triggered_ids_signature',
+                            o_ip,
+                            'potentially_related_ip',
                             'packettotal_query'
                         )
                     )
+                except Exception as e:
+                    logging.error(
+                        'Error attempting to create IP {}'
+                        .format(e.message))
 
-                destination_addresses = analysis.get(
-                    'top_talkers', {}).get('destination_ips', {})
+            dns_queries = analysis.get(
+                'dns_statistics', {}).get('queries', {})
 
-                for dst_addr, percentage in destination_addresses.items():
-                    try:
-                        o_ip = Ip.get_or_create(value=dst_addr)
-                        links.update(
-                            analysis_url.active_link_to(
-                                o_ip,
-                                'potentially_related_ip',
-                                'packettotal_query'
-                            )
+            for dns_query, percentage in dns_queries.items():
+                try:
+                    o_hostname = Hostname.get_or_create(
+                        value=dns_query)
+                    links.update(
+                        analysis_url.active_link_to(
+                            o_hostname,
+                            'potentially_related_hostname',
+                            'packettotal_query'
                         )
-                    except Exception as e:
-                        logging.error(
-                            'Error attempting to create IP {}'
-                            .format(e.message))
-
-                dns_queries = analysis.get(
-                    'dns_statistics', {}).get('queries', {})
-
-                for dns_query, percentage in dns_queries.items():
-                    try:
-                        o_hostname = Hostname.get_or_create(
-                            value=dns_query)
-                        links.update(
-                            analysis_url.active_link_to(
-                                o_hostname,
-                                'potentially_related_hostname',
-                                'packettotal_query'
-                            )
-                        )
-                    except Exception as e:
-                        logging.error(
-                            'Error attempting to create hostname {}'
-                            .format(e.message))
+                    )
+                except Exception as e:
+                    logging.error(
+                        'Error attempting to create hostname {}'
+                        .format(e.message))
 
         result['source'] = 'packettotal_query'
         observable.add_context(result)

--- a/plugins/analytics/public/packettotal.py
+++ b/plugins/analytics/public/packettotal.py
@@ -82,13 +82,14 @@ class PacketTotalQuery(PacketTotalAPI, OneShotAnalytics):
         links = set()
         pcap_hits = PacketTotalAPI.search(
             observable, results.settings['packettotal_api_key'])
+
         result = {}
 
         if pcap_hits:
-            for result in pcap_hits.get('results', []):
-                pcap_id = result.get('id', '')
+            for hit in pcap_hits.get('results', []):
+                pcap_id = hit.get('id', '')
                 pcap_analysis = PacketTotalAPI.fetch_analysis(
-                    pcap_id,  results.settings['packettotal_api_key']
+                    pcap_id, results.settings['packettotal_api_key']
                 )
 
                 if pcap_analysis:
@@ -103,9 +104,8 @@ class PacketTotalQuery(PacketTotalAPI, OneShotAnalytics):
                     )
 
                     analysis = pcap_analysis.get('analysis_summary', {})
-                    pcap_analysis.get('analysis_summary', {})
-                    ids_signatures = analysis.get("signatures", [])
-                    for signature in ids_signatures:
+
+                    for signature in analysis.get('signatures', []):
                         o_sig = Text.get_or_create(value=signature)
                         links.update(
                             analysis_url.active_link_to(
@@ -133,7 +133,7 @@ class PacketTotalQuery(PacketTotalAPI, OneShotAnalytics):
                                 'Error attempting to create IP {}'
                                 .format(e.message))
 
-                    dns_queries = analysis.get('analysis_summary', {}).get(
+                    dns_queries = analysis.get(
                         'dns_statistics', {}).get('queries', {})
 
                     for dns_query, percentage in dns_queries.items():

--- a/plugins/analytics/public/packettotal.py
+++ b/plugins/analytics/public/packettotal.py
@@ -30,23 +30,18 @@ class PacketTotalAPI(object):
         params = {'query': observable.value}
 
         try:
-            res = requests.get(
+            res=requests.get(
                 '{}search'.format(PacketTotalAPI.API),
                 headers={'x-api-key': api_key},
                 params=params,
-                verify=False,
                 proxies=yeti_config.proxy
             )
 
             if res.ok:
                 return res.json()
-            else:
-                return None
-
+            
         except Exception as e:
             logging.error('Exception while getting packettotal report {}'.format(e.message))
-            return None
-
 
     @staticmethod
     def fetch_analysis(pcap_id, api_key):
@@ -66,13 +61,9 @@ class PacketTotalAPI(object):
 
             if res.ok:
                 return res.json()
-            else:
-                return None
 
         except Exception as e:
             logging.error('Exception while getting packettotal report {}'.format(e.message))
-            return None
-
 
 class PacketTotalQuery(PacketTotalAPI, OneShotAnalytics):
     default_values = {
@@ -94,16 +85,17 @@ class PacketTotalQuery(PacketTotalAPI, OneShotAnalytics):
                 pcap_analysis = PacketTotalAPI.fetch_analysis(pcap_id,  results.settings['packettotal_api_key'])
                 if pcap_analysis:
                     analysis_url = Text.get_or_create(
-                        value = 'https://packettotal.com/app/analysis?id={pcap_id}'.format(pcap_id=pcap_id)
+                        value='https://packettotal.com/app/analysis?id={pcap_id}'.format(pcap_id=pcap_id)
                     )
                     links.update(
                         observable.active_link_to(analysis_url, 'analysis_link', 'packettotal_query')
                     )
 
-                    analysis = pcap_analysis.get('analysis_summary', {})
+                    analysis 
+                    pcap_analysis.get('analysis_summary', {})
                     ids_signatures = analysis.get("signatures", [])
                     for signature in ids_signatures:
-                        o_sig = Text.get_or_create(value = signature)
+                        o_sig = Text.get_or_create(value=signature)
                         links.update(
                             analysis_url.active_link_to(
                                 o_sig,
@@ -116,7 +108,7 @@ class PacketTotalQuery(PacketTotalAPI, OneShotAnalytics):
                     destination_addresses = analysis.get('top_talkers', {}).get('destination_ips', {})
                     for dst_addr, percentage in destination_addresses.items():
                         try:
-                            o_ip = Ip.get_or_create(value = dst_addr)
+                            o_ip = Ip.get_or_create(value=dst_addr)
                             links.update(
                                 analysis_url.active_link_to(
                                     o_ip,
@@ -130,7 +122,7 @@ class PacketTotalQuery(PacketTotalAPI, OneShotAnalytics):
                     dns_queries = analysis.get('analysis_summary', {}).get('dns_statistics', {}).get('queries', {})
                     for dns_query, percentage in dns_queries.items():
                         try:
-                            o_hostname = Hostname.get_or_create(value = dns_query)
+                            o_hostname = Hostname.get_or_create(value=dns_query)
                             links.update(
                                 analysis_url.active_link_to(
                                     o_hostname, 

--- a/plugins/analytics/public/packettotal.py
+++ b/plugins/analytics/public/packettotal.py
@@ -1,0 +1,147 @@
+import json
+import logging
+
+import requests
+
+from core.analytics import OneShotAnalytics
+from core.errors import ObservableValidationError
+from core.observables import Hostname, Ip, Hash, Url, Text
+from core.config.config import yeti_config
+
+class PacketTotalAPI(object):
+    """Base class for querying the PacketTotal API."""
+    settings = {
+        'packettotal_api_key': {
+            'name': 'PacketTotal API Key',
+            'description': 'API Key provided by packettotal.com'
+        }
+    }
+
+    API = 'https://api.packettotal.com/v1/'
+
+    @staticmethod
+    def search(observable, api_key):
+        #"""
+        #:param observable: The extended observable class
+        #:param api_key: The api key obtained from PacketTotal
+        #:return:  packettotal json response or None if error
+        #"""
+
+        params = {'query': observable.value}
+
+        try:
+            res = requests.get(
+                '{}search'.format(PacketTotalAPI.API),
+                headers={'x-api-key': api_key},
+                params=params,
+                verify=False,
+                proxies=yeti_config.proxy
+            )
+
+            if res.ok:
+                return res.json()
+            else:
+                return None
+
+        except Exception as e:
+            logging.error('Exception while getting packettotal report {}'.format(e.message))
+            return None
+
+
+    @staticmethod
+    def fetch_analysis(pcap_id, api_key):
+        #"""
+        #:param observable: The extended observable class
+        #:param api_key: The api key obtained from PacketTotal
+        #:return:  packettotal json response or None if error
+        #"""
+
+        try:
+            res = requests.get(
+                '{}pcaps/{}/analysis'.format(PacketTotalAPI.API, pcap_id),
+                headers={'x-api-key': api_key},
+                verify=False,
+                proxies=yeti_config.proxy
+            )
+
+            if res.ok:
+                return res.json()
+            else:
+                return None
+
+        except Exception as e:
+            logging.error('Exception while getting packettotal report {}'.format(e.message))
+            return None
+
+
+class PacketTotalQuery(PacketTotalAPI, OneShotAnalytics):
+    default_values = {
+        'name': 'PacketTotal',
+        'description': 'Perform a PacketTotal query.',
+    }
+
+    ACTS_ON = ['Ip', 'Hostname', 'Hash', 'Url']
+
+    @staticmethod
+    def analyze(observable, results):
+        links = set()
+        pcap_hits = PacketTotalAPI.search(observable, results.settings['packettotal_api_key'])
+        result = {}
+
+        if pcap_hits:
+            for result in pcap_hits.get('results', []):
+                pcap_id = result.get('id','')
+                pcap_analysis = PacketTotalAPI.fetch_analysis(pcap_id,  results.settings['packettotal_api_key'])
+                if pcap_analysis:
+                    analysis_url = Text.get_or_create(
+                        value = 'https://packettotal.com/app/analysis?id={pcap_id}'.format(pcap_id=pcap_id)
+                    )
+                    links.update(
+                        observable.active_link_to(analysis_url, 'analysis_link', 'packettotal_query')
+                    )
+
+                    analysis = pcap_analysis.get('analysis_summary', {})
+                    ids_signatures = analysis.get("signatures", [])
+                    for signature in ids_signatures:
+                        o_sig = Text.get_or_create(value = signature)
+                        links.update(
+                            analysis_url.active_link_to(
+                                o_sig,
+                                'triggered_ids_signature',
+                                'packettotal_query'
+                            )
+                        )
+
+
+                    destination_addresses = analysis.get('top_talkers', {}).get('destination_ips', {})
+                    for dst_addr, percentage in destination_addresses.items():
+                        try:
+                            o_ip = Ip.get_or_create(value = dst_addr)
+                            links.update(
+                                analysis_url.active_link_to(
+                                    o_ip,
+                                    'potentially_related_ip',
+                                    'packettotal_query'
+                                )
+                            )
+                        except Exception as e:
+                            logging.error('hit an error when trying to create a new ip {}'.format(e.message))
+
+                    dns_queries = analysis.get('analysis_summary', {}).get('dns_statistics', {}).get('queries', {})
+                    for dns_query, percentage in dns_queries.items():
+                        try:
+                            o_hostname = Hostname.get_or_create(value = dns_query)
+                            links.update(
+                                analysis_url.active_link_to(
+                                    o_hostname, 
+                                    'potentially_related_hostname',
+                                    'packettotal_query'
+                                )
+                            )
+                        except Exception as e:
+                            logging.error('hit an error when trying to create a new ip {}'.format(e.message))
+
+        result['source'] = 'packettotal_query'
+        observable.add_context(result)
+
+        return list(links)


### PR DESCRIPTION
A simple plugin to query packettotal.com for pcap files related to an indicator of interest. It will return a text node that has links to related iocs from the pcap analysis report.