### PR TITLE
Upgrade of node.js

### DIFF
--- a/extras/debian_bootstrap.sh
+++ b/extras/debian_bootstrap.sh
@@ -10,6 +10,9 @@ fi
 $APT update -y
 $APT install apt-transport-https dirmngr
 
+curl -sL https://deb.nodesource.com/setup_10.x | bash -
+$APT install nodejs -y
+
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 


### PR DESCRIPTION
Without it, the yarn install fail on debian