### PR TITLE
Fix investigations if no user input

### DIFF
--- a/core/web/frontend/investigations.py
+++ b/core/web/frontend/investigations.py
@@ -79,11 +79,14 @@ class InvestigationView(GenericView):
                     if url:
                         import_method = ImportMethod.objects.get(acts_on="url")
                         results = import_method.run(url)
-                    else:
+                    elif "file" in request.files:
                         target = AttachedFile.from_upload(request.files['file'])
                         import_method = ImportMethod.objects.get(
                             acts_on=target.content_type)
                         results = import_method.run(target)
+                    else:
+                        flash("You need to provide an input", "danger")
+                        return redirect(request.referrer)
 
                     return redirect(
                         url_for(


### PR DESCRIPTION
if user press import, but not provided any input by default app throw an error, this forward back and flash msg about input required


no debug
```
Bad Request
The browser (or proxy) sent a request that this server could not understand.
```

```
BadRequestKeyError: 400 Bad Request: KeyError: 'file'
```