### PR TITLE
.info() methods survive missing Flask context

### DIFF
--- a/core/entities/entity.py
+++ b/core/entities/entity.py
@@ -80,12 +80,22 @@ class Entity(Node):
         return []
 
     def info(self):
+        """Object info.
+        
+        When there is no Flask context, url and human_url are not returned and the
+        object id is returned instead.
+        """
         i = {
             "name": self.name,
             "description": self.description,
             "tags": self.tags
         }
-        i['url'] = url_for("api.Entity:post", id=str(self.id), _external=True)
-        i['human_url'] = url_for(
-            "frontend.EntityView:get", id=str(self.id), _external=True)
+        try:
+            i['url'] = url_for("api.Entity:post", id=str(self.id), _external=True)
+            i['human_url'] = url_for(
+                "frontend.EntityView:get", id=str(self.id), _external=True)
+        except RuntimeError:
+            i['id'] = str(self.id)
+
+
         return i

--- a/core/indicators/indicator.py
+++ b/core/indicators/indicator.py
@@ -63,9 +63,12 @@ class Indicator(Node):
             if k in ['name', 'pattern', 'diamond', 'description', 'location']
         }
         i['id'] = str(self.id)
-        i['url'] = url_for(
-            "api.Indicator:post", id=str(self.id), _external=True)
-        i['human_url'] = url_for(
-            "frontend.IndicatorView:get", id=str(self.id), _external=True)
         i['type'] = self.type
+        try:
+            i['url'] = url_for(
+                "api.Indicator:post", id=str(self.id), _external=True)
+            i['human_url'] = url_for(
+                "frontend.IndicatorView:get", id=str(self.id), _external=True)
+        except RuntimeError:
+            pass
         return i

--- a/core/observables/observable.py
+++ b/core/observables/observable.py
@@ -433,8 +433,11 @@ class Observable(Node):
         if self.id:
             i['id'] = str(self.id)
         i['type'] = self.__class__.__name__
-        i['url'] = url_for(
-            "api.Observable:post", id=str(self.id), _external=True)
-        i['human_url'] = url_for(
-            "frontend.ObservableView:get", id=str(self.id), _external=True)
+        try:
+            i['url'] = url_for(
+                "api.Observable:post", id=str(self.id), _external=True)
+            i['human_url'] = url_for(
+                "frontend.ObservableView:get", id=str(self.id), _external=True)
+        except RuntimeError:
+            pass
         return i

--- a/tests/interface/README.md
+++ b/tests/interface/README.md
@@ -1,0 +1,11 @@
+# Testing at "Interface Value"
+
+Tests in this directory run against the web interface in clever ways in order to tickle specific 
+functionality. (Like SQL injection but for Good!)
+
+If `core.config.config.yeti_config.yeti` exists it should define `host` and `port`; if it doesn't
+exist, `host='localhost'` and `port=5000` are assumed.
+
+In general you can just run these with Python.
+
+(With apologies to _Sherry Turkle_ for using the term "interface value".)

--- a/tests/interface/info_method.py
+++ b/tests/interface/info_method.py
@@ -10,35 +10,38 @@ from os import path
 import unittest
 import requests
 
-YETI_ROOT = path.normpath(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
+YETI_ROOT = path.normpath(
+    path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
 sys.path.append(YETI_ROOT)
 
 from core.config.config import yeti_config, Dictionary
-YETI_SERVICE = getattr(yeti_config,'yeti',Dictionary(host='localhost',port=5000))
+YETI_SERVICE = getattr(
+    yeti_config, 'yeti', Dictionary(host='localhost', port=5000))
 
 SAMPLE_DOMAIN = 'example.com'
 SAMPLE_SOURCE = 'Yeti_Test'
 
 SAMPLE_OBSERVABLE = {
-        'value':        'http://{}/yeti-test'.format(SAMPLE_DOMAIN),
-        'tags':         [SAMPLE_SOURCE],
-        'source':       SAMPLE_SOURCE,
-        'context':      {}
-    }
+    'value': 'http://{}/yeti-test'.format(SAMPLE_DOMAIN),
+    'tags': [SAMPLE_SOURCE],
+    'source': SAMPLE_SOURCE,
+    'context': {}
+}
 SAMPLE_ACTOR = {
-        'type':         'Actor',
-        'name':         "Joe's Garage",
-        'description':  "Joe's is the place",
-        'tags':         [SAMPLE_SOURCE]
-    }
+    'type': 'Actor',
+    'name': "Joe's Garage",
+    'description': "Joe's is the place",
+    'tags': [SAMPLE_SOURCE]
+}
 SAMPLE_INDICATOR = {
-        'diamond':      'capability',
-        'name':         'Joe scanner',
-        'pattern':      '[Jj]oe',
-        'location':     'network',
-        'type':         'Regex',
-        'description':  SAMPLE_SOURCE
-    }
+    'diamond': 'capability',
+    'name': 'Joe scanner',
+    'pattern': '[Jj]oe',
+    'location': 'network',
+    'type': 'Regex',
+    'description': SAMPLE_SOURCE
+}
+
 
 class ObservableInfo(unittest.TestCase):
     """Calls core.observables.observable.Observable.info()"""
@@ -48,102 +51,111 @@ class ObservableInfo(unittest.TestCase):
         self.url = None
         self.ok_to_delete = False
         return
-    
+
     def tearDown(self):
         if self.ok_to_delete:
-            resp = requests.delete(self.url,headers={'Accept':'application/json'})
+            resp = requests.delete(
+                self.url, headers={'Accept': 'application/json'})
         return
-    
+
     def test_info(self):
         resp = requests.post(
-                'http://{}:{}/api/observable/'.format(YETI_SERVICE.host,YETI_SERVICE.port),
-                json=SAMPLE_OBSERVABLE,
-                headers={'Accept':'application/json'}
-            )
-        self.assertEqual(   resp.status_code,200,
-                            "Expected 200 status")
+            'http://{}:{}/api/observable/'.format(
+                YETI_SERVICE.host, YETI_SERVICE.port),
+            json=SAMPLE_OBSERVABLE,
+            headers={'Accept': 'application/json'})
+        self.assertEqual(resp.status_code, 200, "Expected 200 status")
 
-        self.assertTrue(    'id' in resp.json(),
-                            "Expected 'id' in response")
+        self.assertTrue('id' in resp.json(), "Expected 'id' in response")
 
         self.id = resp.json()['id']
-        self.assertTrue(    'url' in resp.json(),
-                            "Expected 'url' in response")
+        self.assertTrue('url' in resp.json(), "Expected 'url' in response")
 
         self.url = resp.json()['url']
-        self.assertEqual(   resp.json()['value'],SAMPLE_OBSERVABLE['value'],
-                            "Expected to see {} as value".format(SAMPLE_OBSERVABLE['value']))
+        self.assertEqual(
+            resp.json()['value'], SAMPLE_OBSERVABLE['value'],
+            "Expected to see {} as value".format(SAMPLE_OBSERVABLE['value']))
 
-        self.assertTrue(    self.id in self.url,
-                            "url should contain id")
+        self.assertTrue(self.id in self.url, "url should contain id")
         self.ok_to_delete = True
         return
+
 
 class EntityInfo(unittest.TestCase):
     """Calls core.entities.entity.Entity.info()"""
-    
-    BASE_URL = 'http://{}:{}/api/entity/'.format(YETI_SERVICE.host,YETI_SERVICE.port)
+
+    BASE_URL = 'http://{}:{}/api/entity/'.format(
+        YETI_SERVICE.host, YETI_SERVICE.port)
 
     def setUp(self):
         self.url = None
         self.ok_to_delete = False
         return
-    
+
     def tearDown(self):
         if self.ok_to_delete:
-            resp = requests.delete(self.url,headers={'Accept':'application/json'})
+            resp = requests.delete(
+                self.url, headers={'Accept': 'application/json'})
         return
-    
+
     def test_info(self):
-        resp = requests.post( EntityInfo.BASE_URL, json=SAMPLE_ACTOR, headers={'Accept':'application/json'} )
+        resp = requests.post(
+            EntityInfo.BASE_URL,
+            json=SAMPLE_ACTOR,
+            headers={'Accept': 'application/json'})
 
-        self.assertEqual(   resp.status_code,200,
-                            "Expected 200 status")
+        self.assertEqual(resp.status_code, 200, "Expected 200 status")
 
-        self.assertTrue(    'url' in resp.json(),
-                            "Expected 'url' in response")
+        self.assertTrue('url' in resp.json(), "Expected 'url' in response")
 
         self.url = resp.json()['url']
-        self.assertEqual(   resp.json()['name'],SAMPLE_ACTOR['name'],
-                            "Expected to see {} as name".format(SAMPLE_ACTOR['name']))
+        self.assertEqual(
+            resp.json()['name'], SAMPLE_ACTOR['name'],
+            "Expected to see {} as name".format(SAMPLE_ACTOR['name']))
 
-        self.assertTrue(    EntityInfo.BASE_URL in self.url,
-                            "url should contain BASE_URL")
+        self.assertTrue(
+            EntityInfo.BASE_URL in self.url, "url should contain BASE_URL")
         self.ok_to_delete = True
         return
+
 
 class IndicatorInfo(unittest.TestCase):
     """Calls core.indicators.indicator.Indicator.info()"""
-    
-    BASE_URL = 'http://{}:{}/api/indicator/'.format(YETI_SERVICE.host,YETI_SERVICE.port)
+
+    BASE_URL = 'http://{}:{}/api/indicator/'.format(
+        YETI_SERVICE.host, YETI_SERVICE.port)
 
     def setUp(self):
         self.url = None
         self.ok_to_delete = False
         return
-    
+
     def tearDown(self):
         if self.ok_to_delete:
-            resp = requests.delete(self.url,headers={'Accept':'application/json'})
+            resp = requests.delete(
+                self.url, headers={'Accept': 'application/json'})
         return
-    
+
     def test_info(self):
-        resp = requests.post( IndicatorInfo.BASE_URL, json=SAMPLE_INDICATOR, headers={'Accept':'application/json'} )
+        resp = requests.post(
+            IndicatorInfo.BASE_URL,
+            json=SAMPLE_INDICATOR,
+            headers={'Accept': 'application/json'})
 
-        self.assertEqual(   resp.status_code,200,
-                            "Expected 200 status")
+        self.assertEqual(resp.status_code, 200, "Expected 200 status")
 
-        self.assertTrue(    'url' in resp.json(),
-                            "Expected 'url' in response")
+        self.assertTrue('url' in resp.json(), "Expected 'url' in response")
 
         self.url = resp.json()['url']
-        self.assertEqual(   resp.json()['name'],SAMPLE_INDICATOR['name'],
-                            "Expected to see {} as name".format(SAMPLE_INDICATOR['name']))
+        self.assertEqual(
+            resp.json()['name'], SAMPLE_INDICATOR['name'],
+            "Expected to see {} as name".format(SAMPLE_INDICATOR['name']))
 
-        self.assertTrue(    IndicatorInfo.BASE_URL in self.url,
-                            "url should contain BASE_URL")
+        self.assertTrue(
+            IndicatorInfo.BASE_URL in self.url, "url should contain BASE_URL")
         self.ok_to_delete = True
         return
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests/interface/info_method.py
+++ b/tests/interface/info_method.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python
+"""Tests for the .info() method
+
+Hits the HTTP interface in ways which call the various .info() methods.
+"""
+
+import sys
+from os import path
+
+import unittest
+import requests
+
+YETI_ROOT = path.normpath(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
+sys.path.append(YETI_ROOT)
+
+from core.config.config import yeti_config, Dictionary
+YETI_SERVICE = getattr(yeti_config,'yeti',Dictionary(host='localhost',port=5000))
+
+SAMPLE_DOMAIN = 'example.com'
+SAMPLE_SOURCE = 'Yeti_Test'
+
+SAMPLE_OBSERVABLE = {
+        'value':        'http://{}/yeti-test'.format(SAMPLE_DOMAIN),
+        'tags':         [SAMPLE_SOURCE],
+        'source':       SAMPLE_SOURCE,
+        'context':      {}
+    }
+SAMPLE_ACTOR = {
+        'type':         'Actor',
+        'name':         "Joe's Garage",
+        'description':  "Joe's is the place",
+        'tags':         [SAMPLE_SOURCE]
+    }
+SAMPLE_INDICATOR = {
+        'diamond':      'capability',
+        'name':         'Joe scanner',
+        'pattern':      '[Jj]oe',
+        'location':     'network',
+        'type':         'Regex',
+        'description':  SAMPLE_SOURCE
+    }
+
+class ObservableInfo(unittest.TestCase):
+    """Calls core.observables.observable.Observable.info()"""
+
+    def setUp(self):
+        self.id = None
+        self.url = None
+        self.ok_to_delete = False
+        return
+    
+    def tearDown(self):
+        if self.ok_to_delete:
+            resp = requests.delete(self.url,headers={'Accept':'application/json'})
+        return
+    
+    def test_info(self):
+        resp = requests.post(
+                'http://{}:{}/api/observable/'.format(YETI_SERVICE.host,YETI_SERVICE.port),
+                json=SAMPLE_OBSERVABLE,
+                headers={'Accept':'application/json'}
+            )
+        self.assertEqual(   resp.status_code,200,
+                            "Expected 200 status")
+
+        self.assertTrue(    'id' in resp.json(),
+                            "Expected 'id' in response")
+
+        self.id = resp.json()['id']
+        self.assertTrue(    'url' in resp.json(),
+                            "Expected 'url' in response")
+
+        self.url = resp.json()['url']
+        self.assertEqual(   resp.json()['value'],SAMPLE_OBSERVABLE['value'],
+                            "Expected to see {} as value".format(SAMPLE_OBSERVABLE['value']))
+
+        self.assertTrue(    self.id in self.url,
+                            "url should contain id")
+        self.ok_to_delete = True
+        return
+
+class EntityInfo(unittest.TestCase):
+    """Calls core.entities.entity.Entity.info()"""
+    
+    BASE_URL = 'http://{}:{}/api/entity/'.format(YETI_SERVICE.host,YETI_SERVICE.port)
+
+    def setUp(self):
+        self.url = None
+        self.ok_to_delete = False
+        return
+    
+    def tearDown(self):
+        if self.ok_to_delete:
+            resp = requests.delete(self.url,headers={'Accept':'application/json'})
+        return
+    
+    def test_info(self):
+        resp = requests.post( EntityInfo.BASE_URL, json=SAMPLE_ACTOR, headers={'Accept':'application/json'} )
+
+        self.assertEqual(   resp.status_code,200,
+                            "Expected 200 status")
+
+        self.assertTrue(    'url' in resp.json(),
+                            "Expected 'url' in response")
+
+        self.url = resp.json()['url']
+        self.assertEqual(   resp.json()['name'],SAMPLE_ACTOR['name'],
+                            "Expected to see {} as name".format(SAMPLE_ACTOR['name']))
+
+        self.assertTrue(    EntityInfo.BASE_URL in self.url,
+                            "url should contain BASE_URL")
+        self.ok_to_delete = True
+        return
+
+class IndicatorInfo(unittest.TestCase):
+    """Calls core.indicators.indicator.Indicator.info()"""
+    
+    BASE_URL = 'http://{}:{}/api/indicator/'.format(YETI_SERVICE.host,YETI_SERVICE.port)
+
+    def setUp(self):
+        self.url = None
+        self.ok_to_delete = False
+        return
+    
+    def tearDown(self):
+        if self.ok_to_delete:
+            resp = requests.delete(self.url,headers={'Accept':'application/json'})
+        return
+    
+    def test_info(self):
+        resp = requests.post( IndicatorInfo.BASE_URL, json=SAMPLE_INDICATOR, headers={'Accept':'application/json'} )
+
+        self.assertEqual(   resp.status_code,200,
+                            "Expected 200 status")
+
+        self.assertTrue(    'url' in resp.json(),
+                            "Expected 'url' in response")
+
+        self.url = resp.json()['url']
+        self.assertEqual(   resp.json()['name'],SAMPLE_INDICATOR['name'],
+                            "Expected to see {} as name".format(SAMPLE_INDICATOR['name']))
+
+        self.assertTrue(    IndicatorInfo.BASE_URL in self.url,
+                            "url should contain BASE_URL")
+        self.ok_to_delete = True
+        return
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/testrun.py
+++ b/tests/testrun.py
@@ -17,7 +17,7 @@ from core.observables import Tag
 from core.exports import Export, ExportTemplate
 
 ## Clean slate
-db = connect('yeti',host=yeti_config.mongodb.host)
+db = connect('yeti', host=yeti_config.mongodb.host)
 db.drop_database('yeti')
 
 ## Populate database with initial values

--- a/tests/testrun.py
+++ b/tests/testrun.py
@@ -6,6 +6,8 @@ from mongoengine import connect
 YETI_ROOT = path.normpath(path.dirname(path.dirname(path.abspath(__file__))))
 sys.path.append(YETI_ROOT)
 
+from core.config.config import yeti_config
+
 from core.entities.malware import MalwareFamily, Malware
 from core.indicators import Regex, Indicator
 from core.database import Link
@@ -15,7 +17,7 @@ from core.observables import Tag
 from core.exports import Export, ExportTemplate
 
 ## Clean slate
-db = connect('yeti')
+db = connect('yeti',host=yeti_config.mongodb.host)
 db.drop_database('yeti')
 
 ## Populate database with initial values


### PR DESCRIPTION
### Primary Purpose

This updates:

* `core.entities.entity.Entity.info()`
* `core.indicators.indicator.Indicator.info()`
* `core.observables.observable.Observable.info()`

so that they return gracefully (without `url` properties) when _Flask_ app context is missing.

### Tests!

`tests/interface/` contains the barest of beginnings of tests at "interface value", in this case the tests show that the `.info()` methods are not broken.

### `testrun.py` is Config Aware

`tests/testrun.py` now reads Mongo host configs from `core.config.config.yeti_config`.