### PR TITLE
Fix linking error in VT analytics plugin

### DIFF
--- a/plugins/analytics/public/virustotal_api.py
+++ b/plugins/analytics/public/virustotal_api.py
@@ -105,9 +105,10 @@ class VirusTotalQuery(OneShotAnalytics, VirustotalApi):
                 result['detected_urls'] = json_result['detected_urls']
                 for detected_url in json_result['detected_urls']:
                     o_url = Url.get_or_create(value=detected_url['url'])
+                    scan_date = detected_url.get("scan_date")
                     links.update(
-                        o_url.active_link_to(
-                            o_url, 'hostname', 'virustotal_query'))
+                        observable.link_to(
+                            o_url, 'url', 'virustotal_query', scan_date, scan_date))
 
             if json_result.get('permalink'):
                 result['permalink'] = json_result['permalink']

--- a/plugins/analytics/public/virustotal_api.py
+++ b/plugins/analytics/public/virustotal_api.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-
+from dateutil import parser
 import json
 
 import requests
@@ -105,7 +105,7 @@ class VirusTotalQuery(OneShotAnalytics, VirustotalApi):
                 result['detected_urls'] = json_result['detected_urls']
                 for detected_url in json_result['detected_urls']:
                     o_url = Url.get_or_create(value=detected_url['url'])
-                    scan_date = detected_url.get("scan_date")
+                    scan_date = parser.parse(detected_url.get("scan_date"))
                     links.update(
                         observable.link_to(
                             o_url, 'url', 'virustotal_query', scan_date, scan_date))


### PR DESCRIPTION
VT analytics plugin has a linking error.

```python
            if json_result.get('detected_urls'):
                result['detected_urls'] = json_result['detected_urls']
                for detected_url in json_result['detected_urls']:
                    o_url = Url.get_or_create(value=detected_url['url'])
                    links.update(
                        o_url.active_link_to(
                            o_url, 'hostname', 'virustotal_query'))
```
It creates a link to itself(`o_url`). It should create a link to the observable.