### PR TITLE
returns list of plugins with their ids

### DIFF
--- a/core/web/api/analytics.py
+++ b/core/web/api/analytics.py
@@ -8,7 +8,7 @@ from core.observables import Observable
 from core.web.api.crud import CrudApi
 from core import analytics
 from core.analytics_tasks import schedule
-from core.web.api.api import render
+from core.web.api.api import render, render_json
 from core.web.helpers import get_object_or_404
 from core.web.helpers import requires_permissions
 
@@ -45,6 +45,19 @@ class ScheduledAnalytics(CrudApi):
 
         return render({"id": id, "status": a.enabled})
 
+    @route('/list', methods=["GET"])
+    @requires_permissions("read")
+    def list_ids(self):
+        """
+            Lists all plugins by name:id
+        """
+        data = dict()
+
+        for obj in self.objectmanager.objects.all():
+            data.setdefault(obj.name, obj.id)
+
+        return render_json(data)
+
 
 class InlineAnalytics(CrudApi):
     template = 'inline_analytics_api.html'
@@ -69,6 +82,19 @@ class InlineAnalytics(CrudApi):
 
         return render({"id": id, "status": a.enabled})
 
+    @route('/list', methods=["GET"])
+    @requires_permissions("read")
+    def list_ids(self):
+        """
+            Lists all plugins by name:id
+        """
+        data = dict()
+
+        for obj in self.objectmanager.objects.all():
+            data.setdefault(obj.name, obj.id)
+
+        return render_json(data)
+
 
 class OneShotAnalytics(CrudApi):
     template = "oneshot_analytics_api.html"
@@ -90,6 +116,19 @@ class OneShotAnalytics(CrudApi):
             data.append(info)
 
         return render(data, template=self.template)
+
+    @route('/list', methods=["GET"])
+    @requires_permissions("read")
+    def list_ids(self):
+        """
+            Lists all plugins by name:id
+        """
+        data = dict()
+
+        for obj in self.objectmanager.objects.all():
+            data.setdefault(obj.name, obj.id)
+
+        return render_json(data)
 
     @route("/<id>/toggle", methods=["POST"])
     @requires_permissions("toggle")
@@ -177,3 +216,4 @@ class OneShotAnalytics(CrudApi):
             return render(self._analytics_results(results[0]))
         except:
             return render(None)
+


### PR DESCRIPTION
This is useful to not inspect source code, or at least i didn't find another way to get plugin ids, without checking it in mongo.

`r = requests.get("http://yeti:5000/api/analytics/oneshot/list", headers={"X-Api-Key": APIKEY})`

```
>>> pp(r.json())
{u'Censys Lookup': u'5ce5737624977b5c1f84aa54',
 u'Circl.lu PDNS': u'5cdaca754ce774c961863922',
 u'CuckooSubmit': u'5cdaca754ce774c96186392b',
 u'DNSDB Passive DNS': u'5cdaca754ce774c961863934',
 u'DomainTools Reverse Whois': u'5cdaca754ce774c961863958',
 u'DomainTools Whois': u'5cdaca754ce774c961863961',
 u'DomainsBigData': u'5cdaca754ce774c961863973',
 u'DomanTools Reverse NS': u'5cdaca754ce774c96186394f',
 u'Get Malware': u'5cdaca754ce774c9618639ad',
 u'Get Subdomains': u'5cdaca754ce774c9618639d1',
 u'Hash Report': u'5ce3fed624977b5c1f7f2a03',
 u'Hostname Report': u'5ce3fed624977b5c1f7f2a0c',
 u'Lookup Subdomains': u'5cdaca754ce774c961863a45',
 u'MacAddress Vendor lookup (macaddress.io)': u'5cdaca754ce774c961863992',
 u'MalShare': u'5cdaca754ce774c96186399b',
 u'Malwares Hash Report': u'5ce3f9be4ce774c961ab6350',
 u'Malwares Hostname Report': u'5ce3f9be4ce774c961ab6359',
 u'Malwares Ip Report': u'5ce3f9be4ce774c961ab6362',
 u'NetworkWhois': u'5cdaca754ce774c9618639a4',
 u'Observed Http Traffic': u'5cdaca754ce774c961863a3c',
 u'Onyphe': u'5cdaca754ce774c961863910',
 u'PassiveTotal Passive DNS': u'5cdaca754ce774c9618639b6',
 u'PassiveTotal Reverse NS': u'5cdaca754ce774c9618639bf',
 u'PassiveTotal Reverse Whois': u'5cdaca754ce774c9618639c8',
 u'PassiveTotal Whois': u'5cdaca754ce774c9618639da',
 u'Related Hosts': u'5cdaca754ce774c961863a57',
 u'Related Samples': u'5cdaca754ce774c961863a60',
 u'Retrieve metadata.': u'5cdaca754ce774c961863a4e',
 u'Reverse IP': u'5cdaca754ce774c961863946',
 u'Reverse Passive DNS': u'5cdaca754ce774c96186393d',
 u'Shodan': u'5cdaca754ce774c961863a12',
 u'Submit To Cucukoo': u'5cdaca754ce774c961863919',
 u'ThreatCrowd': u'5cdaca754ce774c961863a33',
 u'ThreatMiner Email Reverse WHOIS': u'5cdaca754ce774c961863a7b',
 u'ThreatMiner PDNS': u'5cdaca754ce774c961863a72',
 u'ThreatMiner Uri': u'5cdaca754ce774c961863a69',
 u'UrlScanIo': u'5ce5099024977b5c1f82a4ec',
 u'Virustotal': u'5cdaca754ce774c961863a84',
 u'Whois': u'5cdaca754ce774c961863a8d',
 u'Whois History': u'5cdaca754ce774c96186396a'}
>>>
```

so this allows simplify the life to persons who wants to script it without need to give them access to backend/extract from html