### PR TITLE
Update url.py

### DIFF
--- a/core/observables/url.py
+++ b/core/observables/url.py
@@ -41,6 +41,7 @@ class Url(Observable):
             if re.match(r"[^:]+://", self.value) is None:
                 # if no schema is specified, assume http://
                 self.value = u"http://{}".format(self.value)
+            self.value = self.value.replace("[.]", "").replace("[.", "").replace(".]", "")
             self.value = urlnorm.norm(self.value).replace(' ', '%20')
             self.parse()
         except urlnorm.InvalidUrl:

--- a/core/observables/url.py
+++ b/core/observables/url.py
@@ -41,7 +41,7 @@ class Url(Observable):
             if re.match(r"[^:]+://", self.value) is None:
                 # if no schema is specified, assume http://
                 self.value = u"http://{}".format(self.value)
-            self.value = self.value.replace("[.]", "").replace("[.", "").replace(".]", "")
+            self.value = self.value.replace("[.]", ".").replace("[.", ".").replace(".]", ".")
             self.value = urlnorm.norm(self.value).replace(' ', '%20')
             self.parse()
         except urlnorm.InvalidUrl:


### PR DESCRIPTION
```
urlnorm.norm("http://cdtmaster.]com.br")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/urlnorm.py", line 157, in norm
    url_tuple = urlparse(url)
  File "/usr/local/Cellar/python@2/2.7.16/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urlparse.py", line 143, in urlparse
    tuple = urlsplit(url, scheme, allow_fragments)
  File "/usr/local/Cellar/python@2/2.7.16/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urlparse.py", line 191, in urlsplit
    raise ValueError("Invalid IPv6 URL")
ValueError: Invalid IPv6 URL
```
to 
```
urlnorm.norm("http://cdtmaster.]com.br".replace("[.]", "").replace("[.", "").replace(".]", ""))
u'http://cdtmastercom.br/'
```