### PR TITLE
Add force_type support for bulk-add API

### DIFF
--- a/core/web/api/observable.py
+++ b/core/web/api/observable.py
@@ -80,11 +80,12 @@ class Observable(CrudApi):
         for item in bulk:
             value = item['value']
             tags = item.get('tags', [])
+            forced_type = item.get('force_type', None)
 
             if _refang:
-                obs = self.objectmanager.add_text(refang(value), tags)
+                obs = self.objectmanager.add_text(refang(value), tags=tags, force_type=forced_type)
             else:
-                obs = self.objectmanager.add_text(value, tags)
+                obs = self.objectmanager.add_text(value, tags=tags, force_type=forced_type)
             self._modify_observable(
                 obs, {
                     'source': item.get('source'),


### PR DESCRIPTION
I had a use-case where I wanted to submit observables in bulk as type _Text_ via the API. This was currently not possible with the _/observable/bulk_ (bulk-add) API. I have added support for _forced_type_ in the bulk-add API, using the per-object parameter name _force_type_ which is consistent with the naming and usage in the standard _/observable/_ new submission API.