### PR TITLE
Fixed bulk API to return observable info

### DIFF
--- a/core/web/api/observable.py
+++ b/core/web/api/observable.py
@@ -86,12 +86,11 @@ class Observable(CrudApi):
                 obs = self.objectmanager.add_text(refang(value), tags=tags, force_type=forced_type)
             else:
                 obs = self.objectmanager.add_text(value, tags=tags, force_type=forced_type)
-            self._modify_observable(
+            added.append(self._modify_observable(
                 obs, {
                     'source': item.get('source'),
                     'context': item.get('context'),
-                })
-            added.append(obs)
+                }))
         return render(added)
 
     @route("/<id>/context", methods=["POST"])


### PR DESCRIPTION
The bulk API for observables was trying to return raw objects instead of observable.info(). This resulted in an exception being thrown when certain data in the object could not be understood by the encoder.

For example, I had a _Hostname_ observable in the db which contained a _context_ document that had a DBRef to a _File_ observable, like this:

```javascript
{
    "_id" : ObjectId("abc123"),
    "_cls" : "Observable.Hostname",
    "value" : "something.example.com",
    "created" : ISODate("2018-06-06T16:10:19.313Z"),
    "idna" : "something.example.com",
    "domain" : false,
    "tags" : [],
    "last_tagged" : ISODate("2019-07-18T06:00:12.199Z"),
    "context" : [
        {
            "contacted_by" : DBRef("observable", ObjectId("xyz456")), // <--- Problem for encoder
            "source" : "HybridAnalysis"
        }
    ],
    "sources" : [
            "feed"
    ]
}
```

If I tried to submit this existing observable via the bulk API, yeti threw the following exception:

```python
ERROR:app:Exception on /api/observable/bulk [POST]
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 2292, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1815, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1718, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/flask_classy.py", line 200, in proxy
    response = view(**request.view_args)
  File "./core/web/helpers.py", line 37, in inner
    return f(*args, **kwargs)
  File "./core/web/api/observable.py", line 89, in bulk
    return render(added)
  File "/usr/local/lib/python2.7/dist-packages/flask_negotiation/__init__.py", line 76, in __call__
    body = renderer.render(data, template, ctx)
  File "/usr/local/lib/python2.7/dist-packages/flask_negotiation/renderers.py", line 96, in render
    return self.fn(data, template=template, ctx=ctx)
  File "./core/web/api/api.py", line 22, in bson_renderer
    return dumps(data, default=to_json)
  File "/usr/lib/python2.7/json/__init__.py", line 251, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/usr/lib/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "./core/web/json.py", line 56, in to_json
    return default(obj)
  File "/usr/local/lib/python2.7/dist-packages/bson/json_util.py", line 857, in default
    raise TypeError("%r is not JSON serializable" % obj)
TypeError: <File: FILE:e831740ce14381235117e03f0bda163315925153a88f88b5ec7173bd618afba9 (1 context)> is not JSON serializable
```

This is easily fixable by modifying the bulk API to return the result of __modify_observable()_ instead of the result of _objectmanager.add_text()_.

Ideally, though, the bulk API function should probably just pass through everything in _item_ to __modify_observable()_ like the single submission API function does. At the moment you submit tags via _objectmanager.add_text()_ and then submit any _source_ and _context_ using __modify_observable()_ . But this could all be done by __modify_observable()_ by just passing _item_ as the second parameter in the same way that _params_ is passed to it in the single submission function on line 64.