### PR TITLE
Update urlhaus.py

### DIFF
--- a/plugins/feeds/public/urlhaus.py
+++ b/plugins/feeds/public/urlhaus.py
@@ -12,7 +12,7 @@ class UrlHaus(Feed):
     default_values = {
         "frequency": timedelta(minutes=20),
         "name": "UrlHaus",
-        "source": "https://urlhaus.abuse.ch/downloads/csv/",
+        "source": "https://urlhaus.abuse.ch/downloads/csv_recent/",
         "description":
             "URLhaus is a project from abuse.ch with the goal of sharing malicious URLs that are being used for malware distribution.",
     }


### PR DESCRIPTION
Replacing the source url with the 'recent/ last 30 days' feed as your ignoring anything beyond your frequency anyway and it means less resources are getting pulled from their service. Users wont notice any difference, but it helps Roman out on bandwidth.