### PR TITLE
Update tld list on creation

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -59,6 +59,9 @@ RUN groupadd yeti && \
         chown -R yeti.yeti /opt/yeti
 RUN mkdir /var/log/yeti; chown yeti /var/log/yeti
 
+# Update tld domain list
+RUN tldextract --update
+
 USER yeti
 
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
The tldextract version does not recognize `.onion` addresses. An update of the tld list solves this problem during the installation process (as well as the update process of yeti).

Further, I would recomment updating the documentation for a non-docker installation to execute this command in order to solve this problem there as well.