### PR TITLE
handle when key doesn't exist, malware bazaar doesn't contain data ke…

### DIFF
--- a/core/feed.py
+++ b/core/feed.py
@@ -354,9 +354,12 @@ class Feed(ScheduleEntry):
         r = self._make_request(method=method, headers=headers, auth=auth, params=params, data=data, verify=verify)
 
         if key:
-            content = r.json()[key]
+            content = r.json().get(key)
         else:
             content = r.json()
+        if not content:
+            return []
+
         if filter_row:
             df = pd.read_json(StringIO(json.dumps(content)), orient='values',
                               convert_dates=[filter_row])


### PR DESCRIPTION
…y when no data

```
>>> url = "https://mb-api.abuse.ch/api/v1/"
>>> data = {"query": "get_recent", "selector": "time"}
>>> r = requests.post(url, data=data)
>>> r
<Response [200]>
>>> q = r.json()
>>> q.keys()
[u'query_status']
>>> q["query_status"]
u'no_results'
```

this will avoid exception  that it tries to access key that doesn't exist, this time i have better tested pr :)