### PR TITLE
Fixing correct link

### DIFF
--- a/plugins/feeds/public/phishtank.py
+++ b/plugins/feeds/public/phishtank.py
@@ -15,7 +15,7 @@ class PhishTank(Feed):
     default_values = {
         'frequency': timedelta(hours=4),
         'name': 'PhishTank',
-        'source': 'http://data.phishtank.com/data/%s/online-valid.csv' % key,
+        'source': 'http://data.phishtank.com/data/online-valid.csv',
         'description':
             'PhishTank community feed. Contains a list of possible Phishing URLs.'
     }


### PR DESCRIPTION
You do not need a key for PhishTank. The data can be accessed at http://data.phishtank.com/data/None/online-valid.csv