### PR TITLE
Only show unique source of contexts

### DIFF
--- a/core/web/api/templates/observable_api.html
+++ b/core/web/api/templates/observable_api.html
@@ -19,7 +19,7 @@
         <td class="icon-cell"><a href="{{ url_for('frontend.InvestigationView:graph_node', id=observable['id'], klass='observable')}}"><i class="flaticon-network38"></i></a></td>
         <td><a href="{{ url_for('frontend.ObservableView:get', id=observable['id'])}}">{{observable['value']}}</a></td>
         <td>{{macros.display_tags(observable['tags'])}}</td>
-        <td>{{ observable['context']|join(', ', attribute='source')}}</td>
+        <td>{{ observable['context']|unique(attribute='source')|join(', ', attribute='source')}}</td>
         <td>{{macros.display_datetime(observable['created'])}}</td>
         <td>{{ observable['sources']|join(', ')}}</td>
       </tr>

--- a/core/web/frontend/templates/macros/malware.html
+++ b/core/web/frontend/templates/macros/malware.html
@@ -10,7 +10,7 @@
       <td>{{link.description}}</td>
       <td>{{ node.family.name }}</td>
       <td>{{ macros.display_tags(node.aliases)}}</td>
-      <td>{{node.context|join(', ', attribute='source')}}</td>
+      <td>{{node.context|unique(attribute='source')|join(', ', attribute='source')}}</td>
     </tr>
     {% endfor %}
   {%endfor%}

--- a/core/web/frontend/templates/observable/search_results.html
+++ b/core/web/frontend/templates/observable/search_results.html
@@ -32,7 +32,7 @@ Search results
         <table class="table table-condensed">
           <tr><th>Value</th><th>Tags</th><th>Context</th><th>Creation date</th></tr>
           {% for obs in data['known']%}
-          <tr><td><a href="{{url_for("frontend.ObservableView:get", id=obs["id"])}}">{{obs['value']}}</a></td><td>{{macros.display_tags(obs['tags'])}}</td><td>{{obs['context']|join(', ', attribute='source')}}</td><td>{{macros.display_datetime(obs['created'])}}</td></tr>
+          <tr><td><a href="{{url_for("frontend.ObservableView:get", id=obs["id"])}}">{{obs['value']}}</a></td><td>{{macros.display_tags(obs['tags'])}}</td><td>{{obs['context']|unique(attribute='source')|join(', ', attribute='source')}}</td><td>{{macros.display_datetime(obs['created'])}}</td></tr>
           {% endfor %}
         </table>
         {% endif %}
@@ -41,7 +41,7 @@ Search results
 				<table class="table table-condensed">
           <tr><th>Value</th><th>Tags</th><th>Context</th><th>Creation date</th></tr>
           {% for link, obs in data["neighbors"]%}
-          <tr><td><a href="{{url_for("frontend.ObservableView:get", id=obs["id"])}}">{{obs["value"]}}</a> <span class="small">({% if obs["value"] == link["dst"]%}{{link["src"]}}{%else%}{{link["dst"]}}{%endif%}{%if link["description"]%} - {{link["description"]}}{%endif%})</span></td><td>{{macros.display_tags(obs["tags"])}}</td><td>{{obs["context"]|join(", ", attribute="source")}}</td><td>{{macros.display_datetime(obs["created"])}}</td></tr>
+          <tr><td><a href="{{url_for("frontend.ObservableView:get", id=obs["id"])}}">{{obs["value"]}}</a> <span class="small">({% if obs["value"] == link["dst"]%}{{link["src"]}}{%else%}{{link["dst"]}}{%endif%}{%if link["description"]%} - {{link["description"]}}{%endif%})</span></td><td>{{macros.display_tags(obs["tags"])}}</td><td>{{obs["context"]|unique(attribute="source")|join(", ", attribute="source")}}</td><td>{{macros.display_datetime(obs["created"])}}</td></tr>
           {% endfor %}
         </table>
         {% endif %}

--- a/core/web/frontend/templates/observable/single.html
+++ b/core/web/frontend/templates/observable/single.html
@@ -79,7 +79,7 @@
                     <td><a href="{{ url_for("frontend.ObservableView:get", id=node.id) }}">{{node.value}}</a></td>
                     <td>{{link.description}}</td>
                     <td>{{ macros.display_tags(node.tags)}}</td>
-                    <td>{{node.context|join(', ', attribute='source')}}</td>
+                    <td>{{node.context|unique(attribute='source')|join(', ', attribute='source')}}</td>
                   </tr>
                   {% endfor %}
                 {%endfor%}


### PR DESCRIPTION
We have multiple contexts for an observable from the same source. And since the output shows the name of the source for each observable, the output sometimes lists 50 times the same source on the web page which makes it unusable. Showing each source name only once is sufficient for the search.