### PR TITLE
name otx variables in conf sample according feed naming

### DIFF
--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -82,8 +82,8 @@
 # token =
 
 [otx]
-# otx_key = YourOTXKey
-# number_page = 1
+# key = YourOTXKey
+# pages = 1
 
 [abuseIPDB]
 # key = YourKey


### PR DESCRIPTION
So, I entered key in conf file as in example, but got AssertionError
After reading [otx_alienvault.py](https://github.com/yeti-platform/yeti/blob/master/plugins/feeds/public/otx_alienvault.py) changed naming in yeti.conf file:
"otx_key" to "key" and "number_page" to "pages" and it solved that problem 

related issue #518 