### PR TITLE
fix celery connection issue

### DIFF
--- a/core/config/celeryctl.py
+++ b/core/config/celeryctl.py
@@ -1,11 +1,10 @@
 from __future__ import unicode_literals
 
 from celery import Celery
-from mongoengine import connect
 from celery.signals import celeryd_init, worker_process_init
-
 from core.config.config import yeti_config
-
+from mongoengine.connection import (DEFAULT_CONNECTION_NAME, connect,
+                                    disconnect, register_connection)
 
 celery_app = Celery("yeti")
 
@@ -47,34 +46,40 @@ class CeleryConfig:
 celery_app.config_from_object(CeleryConfig)
 
 
+is_tls = False
+if yeti_config.mongodb.tls:
+    is_tls = True
+
+register_connection(DEFAULT_CONNECTION_NAME,
+    db=yeti_config.mongodb.database,
+    host=yeti_config.mongodb.host,
+    port=yeti_config.mongodb.port,
+    username=yeti_config.mongodb.username,
+    password=yeti_config.mongodb.password,
+    tls=is_tls,
+    connect=False,
+)
+
+
 @worker_process_init.connect
 def connect_mongo(**kwargs):
     """Connect to mongo and load modules in each worker process."""
     from core.config import celeryimports
     from core.yeti_plugins import get_plugins
 
-    is_tls = False
-    if yeti_config.mongodb.tls:
-        is_tls = True
+    connect(db=yeti_config.mongodb.database)
 
-    connect(
-        yeti_config.mongodb.database,
-        host=yeti_config.mongodb.host,
-        port=yeti_config.mongodb.port,
-        username=yeti_config.mongodb.username,
-        password=yeti_config.mongodb.password,
-        tls=is_tls,
-        connect=False,
-    )
     celeryimports.loaded_modules = get_plugins()
 
 
 @celeryd_init.connect
 def unlock_scheduled_entries(**kwargs):
     from core.analytics import ScheduledAnalytics
-    from core.feed import Feed
     from core.exports.export import Export
+    from core.feed import Feed
     from core.yeti_plugins import get_plugin_classes
+
+    connect(db=yeti_config.mongodb.database)
 
     # Make sure plugin classes are loaded
     get_plugin_classes()
@@ -92,3 +97,5 @@ def unlock_scheduled_entries(**kwargs):
             locked_entries[queue].objects(lock=True).update(
                 lock=False, status="Unlocked"
             )
+
+    disconnect()


### PR DESCRIPTION
Celery was not able to connect to the mongodb in `unlock_scheduled_entries` and thus the lock state resets failed when the celery worker started. This circumvents this by explictly (dis-)connecting before and after the lock reset takes place.