### PR TITLE
fix viriback_tracker

### DIFF
--- a/plugins/feeds/public/viriback_tracker.py
+++ b/plugins/feeds/public/viriback_tracker.py
@@ -16,7 +16,8 @@ class ViriBackTracker(Feed):
 
     def update(self):
         for index, line in self.update_csv(
-            delimiter=",", filter_row="FirstSeen", header=0
+            delimiter=",", filter_row="FirstSeen", header=0,
+            comment=None
         ):
             self.analyze(line)
 


### PR DESCRIPTION
The CSV contains at least one URL with a `#` in it and thus breaks parsing because per default the comment parameter of the CSV parser is set to `#` as well.