### PR TITLE
Regex and Observable upload patch

### DIFF
--- a/core/observables/url.py
+++ b/core/observables/url.py
@@ -20,12 +20,12 @@ class Url(Observable):
     regex = (
         r"(?P<search>((?P<scheme>[\w]{2,9}):\/\/)?([\S]*\:[\S]*\@)?(?P<hostname>"
         + Hostname.main_regex
-        + ")(\:[\d]{1,5})?(?P<path>(\/[^\?]*?)?(\?[^#]*?)?(\#.*?)?))"
+        + r")(\:[\d]{1,5})?(?P<path>(\/[^\?]*?)?(\?[^#]*?)?(\#.*?)?))"
     )
     search_regex = (
         r"(?P<search>((?P<scheme>[\w]{2,9}):\/\/)?([\S]*\:[\S]*\@)?(?P<hostname>"
         + Hostname.main_regex
-        + ")(\:[\d]{1,5})?(?P<path>((\/[^\?]*?)?(\?[^#]*?)?(\#.*?)?)[\w/])?)"
+        + r")(\:[\d]{1,5})?(?P<path>((\/[^\?]*?)?(\?[^#]*?)?(\#.*?)?)[\w/])?)"
     )
 
     DISPLAY_FIELDS = Observable.DISPLAY_FIELDS + [

--- a/core/observables/url.py
+++ b/core/observables/url.py
@@ -20,12 +20,12 @@ class Url(Observable):
     regex = (
         r"(?P<search>((?P<scheme>[\w]{2,9}):\/\/)?([\S]*\:[\S]*\@)?(?P<hostname>"
         + Hostname.main_regex
-        + ")(\:[\d]{1,5})?(?P<path>(\/[\S]*)?(\?[\S]*)?(\#[\S]*)?))"
+        + ")(\:[\d]{1,5})?(?P<path>(\/[^\?]*?)?(\?[^#]*?)?(\#.*?)?))"
     )
     search_regex = (
         r"(?P<search>((?P<scheme>[\w]{2,9}):\/\/)?([\S]*\:[\S]*\@)?(?P<hostname>"
         + Hostname.main_regex
-        + ")(\:[\d]{1,5})?(?P<path>((\/[\S]*)?(\?[\S]*)?(\#[\S]*)?)[\w/])?)"
+        + ")(\:[\d]{1,5})?(?P<path>((\/[^\?]*?)?(\?[^#]*?)?(\#.*?)?)[\w/])?)"
     )
 
     DISPLAY_FIELDS = Observable.DISPLAY_FIELDS + [

--- a/core/web/frontend/observables.py
+++ b/core/web/frontend/observables.py
@@ -84,10 +84,17 @@ class ObservableView(GenericView):
         if request.method == "POST":
             lines = []
             obs = {}
+
             if request.files.get("bulk-file"):  # request files
-                lines = request.files.get("bulk-file").readlines()
+                lines = request.files.get("bulk-file").read()
             else:
-                lines = request.form["bulk-text"].split("\n")
+                lines = request.form["bulk-text"]
+
+            if type(lines) is bytes:
+                lines = lines.decode()
+
+            lines = lines.split("\n")
+
 
             invalid_observables = 0
             if bool(request.form.get("add", False)) and current_user.has_permission(


### PR DESCRIPTION
Two changes:
* The URL regex did not match on URLs which have a space character in them after URL decoding. For example `https://example.com/?foo=first second` would never pass the regex test when queried/inserted by the API.
* the frontend did not treat uploaded files as `bytes` which ultimately raised an exception when a list of observables was queried via the frontend's "upload" function