### PR TITLE
update to ubuntu 20.04 and fix typos

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -25,7 +25,7 @@ Install dependencies::
 
   $ sudo apt install build-essential git python-dev mongodb-org mongodb-org-shell mongodb-org-server mongodb-org-mongos redis-server libcurl4 libxml2-dev libxslt-dev zlib1g-dev python-virtualenv wkhtmltopdf python-pip python3-pip
 
-Return at home and download Yeti:
+Return at home and download Yeti::
   
   $ cd
   $ git clone https://github.com/yeti-platform/yeti.git
@@ -64,7 +64,7 @@ This will only enable the web interface - if you want to use Feeds and Analytics
   $ celery -A core.config.celeryctl.celery_app worker --loglevel=ERROR -Q oneshot -n oneshot -c 2 --purge
   $ celery -A core.config.celeryctl beat -S core.scheduling.Scheduler --loglevel=ERROR
 
-Or, to bootstrap a production use instance of Yeti on Ubuntu 18.04 (without the Redis tweaks), everyone's favorite command::
+Or, to bootstrap a production use instance of Yeti on Ubuntu 20.04 (without the Redis tweaks), everyone's favorite command::
 
   $ curl https://raw.githubusercontent.com/yeti-platform/yeti/master/extras/ubuntu_bootstrap.sh | sudo /bin/bash
 
@@ -123,9 +123,10 @@ systemd protips::
 
 To enable the systemd scripts once you've installed them::
 
-    sudo systemctl enable yeti_uwsgi
+    $ sudo systemctl enable yeti_uwsgi
 
 For install yeti with development webserver::
+
     $ sudo systemctl enable mongod.service
     $ sudo systemctl enable yeti_web.service
     $ sudo systemctl enable yeti_oneshot.service
@@ -142,6 +143,7 @@ For install yeti with development webserver::
     $ sudo systemctl start yeti_beat.service
 
 For install yeti with nginx reverse proxy::
+
     $ sudo systemctl enable mongod.service
     $ sudo systemctl enable yeti_uwsgi.service
     $ sudo systemctl enable yeti_oneshot.service

--- a/extras/ubuntu_bootstrap.sh
+++ b/extras/ubuntu_bootstrap.sh
@@ -20,11 +20,11 @@ $APT install -y dirmngr gnupg apt-transport-https curl wget
 curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
-wget -qO - https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add -
-echo "deb https://repo.mongodb.org/apt/ubuntu bionic/mongodb-org/4.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-4.4.list
+wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | sudo apt-key add -
+echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-5.0.list
 
 $APT update -y
-$APT install -y build-essential git python-dev mongodb-org mongodb-org-server mongodb-org-mongos mongodb-org-shell redis-server libcurl4 libxml2-dev libxslt-dev zlib1g-dev python-virtualenv python-pip python3-pip nginx yarn uwsgi-plugin-python3
+$APT install -y build-essential git python3-dev mongodb-org mongodb-org-server mongodb-org-mongos mongodb-org-shell redis-server libcurl4 libxml2-dev libxslt-dev zlib1g-dev python3-virtualenv python3-pip nginx yarn uwsgi-plugin-python3
 
 # Clone project
 cd /opt


### PR DESCRIPTION
Ported ubuntu bootstrap script to 20.04 version because 18.04 EOL soon
I also slightly corrected the text in the documentation
As it turned out, the public documentation was not updated for a some time because the `_build` folder is located in gitignore, so probably it should be removed (and then do a sphinx rebuild)? Then in close #690 #718 