### PR TITLE
Update celeryctl.py config for v6

### DIFF
--- a/core/config/celeryctl.py
+++ b/core/config/celeryctl.py
@@ -16,15 +16,15 @@ class CeleryConfig:
 
         redis_scheme = redis_scheme + "s"
 
-    BROKER_URL = "{}://{}:{}/{}".format(
+    broker_url = "{}://{}:{}/{}".format(
         redis_scheme,
         yeti_config.redis.host,
         yeti_config.redis.port,
         yeti_config.redis.database,
     )
-    CELERY_TASK_SERIALIZER = "json"
-    CELERY_ACCEPT_CONTENT = ["json"]
-    CELERY_IMPORTS = (
+    task_serializer = "json"
+    accept_content = ["json"]
+    imports = (
         "core.config.celeryimports",
         "core.analytics_tasks",
         "core.exports.export",
@@ -32,9 +32,9 @@ class CeleryConfig:
         "core.investigation",
         "plugins",
     )
-    CELERY_TIMEZONE = "UTC"
-    CELERYD_POOL_RESTARTS = True
-    CELERY_ROUTES = {
+    timezone = "UTC"
+    worker_pool_restarts = True
+    task_routes = {
         "core.analytics_tasks.single": {"queue": "oneshot"},
         "core.feed.update_feed": {"queue": "feeds"},
         "core.exports.export.execute_export": {"queue": "exports"},


### PR DESCRIPTION
In celery v6, support for the current syntax will cease, we need to prepare for these changes.

![image](https://user-images.githubusercontent.com/34004367/187495346-ee88f4ec-a3f9-4f45-8934-590d20d95353.png)

```
WARNING/MainProcess] /usr/local/lib/python3.8/dist-packages/celery/app/utils.py:204: CDeprecationWarning:
    The 'CELERY_ROUTES' setting is deprecated and scheduled for removal in
    version 6.0.0. Use the task_routes instead

  deprecated.warn(description=f'The {setting!r} setting'
```