### PR TITLE
minor fix for threatfox

### DIFF
--- a/plugins/feeds/public/threatfox.py
+++ b/plugins/feeds/public/threatfox.py
@@ -33,7 +33,6 @@ class ThreatFox(Feed):
             df["last_seen_utc"] = pd.to_datetime(df["last_seen_utc"])
             if self.last_run:
                 df = df[df["first_seen_utc"] > self.last_run]
-            df.fillna("-", inplace=True)
             return df.iterrows()
 
     def analyze(self, item):
@@ -99,5 +98,3 @@ class ThreatFox(Feed):
             obs.add_source(self.name)
             if tags:
                 obs.tag(tags)
-            if malware_printable:
-                obs.tags


### PR DESCRIPTION
I noticed that this feed adds an extra tag "-"
Example:
![image](https://user-images.githubusercontent.com/34004367/188954427-ac99d925-1158-42d0-8bac-8b607ad0f2bb.png)
![image](https://user-images.githubusercontent.com/34004367/188954463-df4bdeca-7485-44ec-ba69-7bcfea11a6b0.png)
![image](https://user-images.githubusercontent.com/34004367/188954503-e8d44e9f-4fc6-423f-89b8-d5d4f399fef9.png)
