### PR TITLE
minor fix in urlhaus

### DIFF
--- a/plugins/feeds/public/urlhaus.py
+++ b/plugins/feeds/public/urlhaus.py
@@ -59,7 +59,8 @@ class UrlHaus(Feed):
         if url:
             try:
                 url_obs = Url.get_or_create(value=url)
-                url_obs.tag(tags.split(","))
+                if tags != "None":
+                    url_obs.tag(tags.split(","))
                 url_obs.add_context(context, dedup_list=["date_added"])
                 url_obs.add_source(self.name)
             except ObservableValidationError as e:


### PR DESCRIPTION
Sometimes there no (None) tags e.g.:
`"2289968","2022-09-02 18:54:34","http://117.215.250.160:55176/mozi.m","offline","None","malware_download","None","https://urlhaus.abuse.ch/url/2289968/","tammeto"`
So, that feed produce observable's with none tag
![photo_2022-09-07_22-48-29](https://user-images.githubusercontent.com/34004367/188964236-a95fb5ed-6c4b-4dff-aa83-a467353491ce.jpg)
