### PR TITLE
Remove duplicate AutonomousSystem observable

### DIFF
--- a/core/observables/ip.py
+++ b/core/observables/ip.py
@@ -55,23 +55,3 @@ class Ip(Observable):
         info["version"] = self.version
         info["geoip"] = self.geoip
         return info
-
-
-class AutonomousSystem(Observable):
-
-    """Autonomous System observable"""
-
-    as_num = IntField(verbose_name="Autonomous System number")
-
-    DISPLAY_FIELDS = Observable.DISPLAY_FIELDS + [
-        ("as_num", "Autonomous System number"),
-    ]
-
-    def info(self):
-        info = super(AutonomousSystem, self).info()
-        info["as_num"] = (self.as_num,)
-        return info
-
-    @staticmethod
-    def check_type(txt):
-        return True


### PR DESCRIPTION
This is already defined in `asn.py`.
This entry seems to have been inadvertently re-introduced in fbe309111efce3f2be37c5e39518d8a97e15241c.