### PR TITLE
Entrypoint must be executable

### DIFF
--- a/extras/docker/dev/Dockerfile
+++ b/extras/docker/dev/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /var/log/yeti
 # Update tld domain list
 RUN poetry run tldextract --update
 
-COPY ./extras/docker/scripts/docker-entrypoint.sh /docker-entrypoint.sh
+COPY --chmod=744 ./extras/docker/scripts/docker-entrypoint.sh /docker-entrypoint.sh
 
 ENV PYTHONPATH /app
 


### PR DESCRIPTION
Ensure ``/docker-entrypoint.sh`` is executable, otherwise Docker daemon will fail to start container.