### PR TITLE
Add user agent observable type, closes #869 

### DIFF
--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -37,6 +37,7 @@ class ObservableType(str, Enum):
     ssdeep = "ssdeep"
     tlsh = "tlsh"
     url = "url"
+    user_agent = "user_agent"
 
 
 class Observable(BaseModel, database_arango.ArangoYetiConnector):
@@ -180,4 +181,5 @@ from core.schemas.observables import (asn, bitcoin_wallet, certificate, cidr,
                                       command_line, docker_image, email, file,
                                       hostname, imphash, ipv4, ipv6,
                                       mac_address, md5, path, registry_key,
-                                      sha1, sha256, ssdeep, tlsh, url)
+                                      sha1, sha256, ssdeep, tlsh, url,
+                                      user_agent)

--- a/core/schemas/observables/user_agent.py
+++ b/core/schemas/observables/user_agent.py
@@ -1,0 +1,10 @@
+from typing import Literal
+
+from core.schemas import observable
+
+
+class UserAgent(observable.Observable):
+    type: Literal[observable.ObservableType.user_agent] = observable.ObservableType.user_agent
+
+
+observable.TYPE_MAPPING[observable.ObservableType.user_agent] = UserAgent

--- a/tests/schemas/observable.py
+++ b/tests/schemas/observable.py
@@ -8,7 +8,7 @@ from core.schemas.observables import (asn, bitcoin_wallet, certificate, cidr,
                                       generic_observable, hostname, imphash,
                                       ipv4, ipv6, mac_address, md5, path,
                                       registry_key, sha1, sha256, ssdeep, tlsh,
-                                      url)
+                                      url, user_agent)
 
 
 class ObservableTest(unittest.TestCase):
@@ -346,3 +346,10 @@ class ObservableTest(unittest.TestCase):
         self.assertIsNotNone(observable.id)
         self.assertEqual(observable.value, "https://www.google.com")
         self.assertIsInstance(observable, url.Url)
+
+    def test_create_user_agent(self) -> None:
+        """Tests creating a user agent."""
+        observable = user_agent.UserAgent(value="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36").save() # noqa: E501
+        self.assertIsNotNone(observable.id)
+        self.assertEqual(observable.value, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36") # noqa: E501
+        self.assertIsInstance(observable, user_agent.UserAgent)


### PR DESCRIPTION
This PR add support for user agent observable type as requested by https://github.com/yeti-platform/yeti/issues/869