### PR TITLE
Implement plugins loader to automagically add new ones

### DIFF
--- a/core/taskmanager.py
+++ b/core/taskmanager.py
@@ -1,60 +1,12 @@
 import datetime
-import importlib
-import inspect
-import json
 import logging
-import pathlib
-import pkgutil
 import traceback
 from typing import Type
 
-from celery import Celery
-from celery.utils.log import get_task_logger
-from core.config.config import yeti_config
 from core.schemas.task import ExportTask, Task, TaskParams, TaskStatus
 
-logger = get_task_logger(__name__)
-
-
-def get_plugins_packages():
-    plugins_list = set()
-    plugins_path = pathlib.Path(yeti_config.get('system', 'plugins_path'))
-    if not plugins_path.exists():
-        logger.warning(f"Plugins path {str(plugin_path.absolute())} does not exist")
-        return plugins_list
-    for module_info in pkgutil.walk_packages([str(plugins_path.absolute())], prefix=f"{plugins_path.name}."):
-        if not module_info.ispkg:
-            try:
-                module = importlib.import_module(module_info.name)
-                for _, obj in inspect.getmembers(module, inspect.isclass):
-                    if issubclass(obj, Task):
-                        plugins_list.add(module_info.name)
-            except Exception as error:
-                logger.warning(f"Cannot import plugin {module_info.name}\n{traceback.format_exc()}")
-    return plugins_list
-
-app = Celery(
-    "tasks",
-    broker=f"redis://{yeti_config.get('redis', 'host')}/",
-    worker_pool_restarts=True,
-    imports=get_plugins_packages()
-)
-
-@app.on_after_configure.connect
-def setup_periodic_tasks(sender, **kwargs):
-    """Registers periodic tasks."""
-    for task in Task.list():
-        if not task.frequency:
-            continue
-        logger.info("Registering periodic task %s (%s)", task.name, task.frequency)
-        sender.add_periodic_task(
-            task.frequency,
-            run_task.s(task.name, '{}'),
-            name=f'Schedule for {task.name}')
-    return
 
 class TaskManager:
-
     _store = {}  # type: dict[str, Task]
 
     @classmethod
@@ -88,7 +40,7 @@ class TaskManager:
         """Loads tasks from the database and refreshes cache."""
         if task_name not in cls._store:
             # Only ExportTasks are registered dynamically
-            logging.info(f'Registering ExportTask {task_name}')
+            logging.info(f"Registering ExportTask {task_name}")
             cls.register_task(ExportTask, task_name=task_name)
 
         if task_name not in cls._store:
@@ -137,16 +89,3 @@ class TaskManager:
         task.last_run = datetime.datetime.now(datetime.timezone.utc)
         task.status_message = ""
         task.save()
-
-
-@app.task
-def run_task(task_name: str, params: str):
-    """Runs a task.
-
-    Args:
-        task_name: The name of a registered task to run.
-        params: A string-encoded JSON representation of a TaskParams object
-            (obtained through model_dump_json)
-    """
-    task_params = TaskParams(**json.loads(params))
-    TaskManager.run_task(task_name, task_params)

--- a/core/taskscheduler.py
+++ b/core/taskscheduler.py
@@ -1,0 +1,65 @@
+import importlib
+import inspect
+import json
+import logging
+import pathlib
+import pkgutil
+
+from celery import Celery
+from celery.utils.log import get_task_logger
+from core.config.config import yeti_config
+from core.schemas.task import Task, TaskParams
+from core.taskmanager import TaskManager
+
+logger = get_task_logger(__name__)
+
+def get_plugins_list():
+    plugins_list = set()
+    plugins_path = pathlib.Path(yeti_config.get('system', 'plugins_path'))
+    if not plugins_path.exists():
+        logging.warning(f"Plugins path {str(plugin_path.absolute())} does not exist")
+        return plugins_list
+    for module_info in pkgutil.walk_packages([str(plugins_path.absolute())], prefix=f"{plugins_path.name}."):
+        if not module_info.ispkg:
+            try:
+                module = importlib.import_module(module_info.name)
+                for _, obj in inspect.getmembers(module, inspect.isclass):
+                    if issubclass(obj, Task):
+                        plugins_list.add(module_info.name)
+            except Exception as error:
+                logging.warning(f"Cannot import plugin {module_info.name}\n{error}")
+    return plugins_list
+
+
+app = Celery(
+    "tasks",
+    broker=f"redis://{yeti_config.get('redis', 'host')}/",
+    worker_pool_restarts=True,
+    imports=get_plugins_list()
+)
+
+@app.on_after_configure.connect
+def setup_periodic_tasks(sender, **kwargs):
+    """Registers periodic tasks."""
+    for task in Task.list():
+        if not task.frequency:
+            continue
+        logger.info("Registering periodic task %s (%s)", task.name, task.frequency)
+        sender.add_periodic_task(
+            task.frequency,
+            run_task.s(task.name, '{}'),
+            name=f'Schedule for {task.name}')
+    return
+
+@app.task
+def run_task(task_name: str, params: str):
+    """Runs a task.
+
+    Args:
+        task_name: The name of a registered task to run.
+        params: A string-encoded JSON representation of a TaskParams object
+            (obtained through model_dump_json)
+    """
+    task_params = TaskParams(**json.loads(params))
+    TaskManager.run_task(task_name, task_params)
+

--- a/core/web/apiv2/system.py
+++ b/core/web/apiv2/system.py
@@ -1,8 +1,7 @@
+from core.config.config import yeti_config
+from core.taskscheduler import app
 from fastapi import APIRouter
 from pydantic import BaseModel, ConfigDict
-
-from core.config.config import yeti_config
-from core.taskmanager import app
 
 # API endpoints
 router = APIRouter()

--- a/core/web/apiv2/tasks.py
+++ b/core/web/apiv2/tasks.py
@@ -1,12 +1,11 @@
 import os
 
+from core import taskscheduler
+from core.schemas.task import ExportTask, Task, TaskParams, TaskType, TaskTypes
+from core.schemas.template import Template
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, ConfigDict
-
-from core.schemas.task import ExportTask, Task, TaskParams, TaskType, TaskTypes
-from core import taskmanager
-from core.schemas.template import Template
 
 
 # Request schemas
@@ -47,7 +46,7 @@ async def run(task_name, params: TaskParams | None = None) -> dict:
     """Runs a task asynchronously."""
     if params is None:
         params = TaskParams()
-    taskmanager.run_task.delay(task_name, params.model_dump_json())
+    taskscheduler.run_task.delay(task_name, params.model_dump_json())
     return {"status": "ok"}
 
 

--- a/extras/docker/docker-entrypoint.sh
+++ b/extras/docker/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 if [[ "$1" = 'webserver' ]]; then
     poetry run uvicorn core.web.webapp:app --reload --host 0.0.0.0
 elif [[ "$1" = 'tasks' ]]; then
-    poetry run celery -A core.taskmanager worker --loglevel=INFO --purge -B -P threads
+    poetry run celery -A core.taskscheduler worker --loglevel=INFO --purge -B -P threads
 elif [[ "$1" = 'create-user' ]]; then
     poetry run python yetictl/cli.py create-user "${@:2}"
 elif [[ "$1" = 'reset-password' ]]; then

--- a/tests/apiv2/tasks.py
+++ b/tests/apiv2/tasks.py
@@ -2,13 +2,12 @@ import datetime
 import unittest
 from unittest import mock
 
-from fastapi.testclient import TestClient
-
 from core import database_arango, taskmanager
 from core.schemas.observable import Observable
 from core.schemas.task import ExportTask, FeedTask
 from core.schemas.template import Template
 from core.web import webapp
+from fastapi.testclient import TestClient
 
 client = TestClient(webapp.app)
 
@@ -53,7 +52,7 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(data["name"], "FakeTask")
         self.assertEqual(data["enabled"], False)
 
-    @mock.patch("core.taskmanager.run_task.delay")
+    @mock.patch("core.taskscheduler.run_task.delay")
     def test_run_task(self, mock_delay):
         response = client.post("/api/v2/tasks/FakeTask/run")
         data = response.json()
@@ -61,7 +60,7 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(data["status"], "ok")
         mock_delay.assert_called_once_with("FakeTask", '{"params":{}}')
 
-    @mock.patch("core.taskmanager.run_task.delay")
+    @mock.patch("core.taskscheduler.run_task.delay")
     def test_run_task_with_params(self, mock_delay):
         response = client.post(
             "/api/v2/tasks/FakeTask/run", json={"params": {"value": "test"}}

--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -6,6 +6,7 @@
 
 export_root = /var/opt/yeti
 logging = /var/log/yeti_user_activity.log
+plugins_path = ./plugins
 
 [auth]
 


### PR DESCRIPTION
This PR removes Celery code from taskmanager which is now part of taskscheduler. This was needed to prevent circular imports when loading plugins to generate the plugins list used by Celery.