### PR TITLE
Introduce min / max hops to graph search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     "python.testing.pytestEnabled": false,
     "python.testing.unittestEnabled": true,
     "python.analysis.typeCheckingMode": "basic",
-    "editor.defaultFormatter": "charliermarsh.ruff"
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "mypy-type-checker.importStrategy": "fromEnvironment"
 
 }

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -527,7 +527,8 @@ class ArangoYetiConnector(AbstractYetiConnector):
         direction: str = "any",
         graph: str = "links",
         include_original: bool = False,
-        hops: int = 1,
+        min_hops: int = 1,
+        max_hops: int = 1,
         offset: int = 0,
         count: int = 0,
     ) -> tuple[
@@ -546,7 +547,9 @@ class ArangoYetiConnector(AbstractYetiConnector):
           direction: outbound, inbound, or any.
           include_original: Whether the original object is to be included in the
               result or not.
-          hops: The maximum number of nodes to go through (defaults to 1:
+          min_hops: The minumum number of nodes to go through (defaults to 1:
+              direct neighbors)
+          max_hops: The maximum number of nodes to go through (defaults to 1:
               direct neighbors)
           raw: Whether to return a raw dictionary or a Yeti object.
 
@@ -578,12 +581,13 @@ class ArangoYetiConnector(AbstractYetiConnector):
             args["offset"] = offset
             args["count"] = count
 
-        args["hops"] = hops
+        args["min_hops"] = min_hops
+        args["max_hops"] = max_hops
         if direction not in {"any", "inbound", "outbound"}:
             direction = "any"
 
         aql = f"""
-        FOR v, e, p IN @hops..@hops {direction} @extended_id @@graph
+        FOR v, e, p IN @min_hops..@max_hops {direction} @extended_id @@graph
 
           {query_filter}
           LET v_with_tags = (

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -5,10 +5,11 @@ successfully carry out all interactions with the database.
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 if TYPE_CHECKING:
-    from core.schemas.graph import Relationship
+    from core.schemas import entity, indicator, observable, tag
+    from core.schemas.graph import Relationship, TagRelationship
 
 
 class AbstractYetiConnector(ABC):
@@ -73,8 +74,23 @@ class AbstractYetiConnector(ABC):
     @abstractmethod
     # pylint: disable=too-many-arguments
     def neighbors(
-        self, link_type, direction="any", include_original=False, hops=1, raw=False
-    ):
+        self,
+        link_types: List[str] = [],
+        target_types: List[str] = [],
+        direction: str = "any",
+        graph: str = "links",
+        include_original: bool = False,
+        min_hops: int = 1,
+        max_hops: int = 1,
+        offset: int = 0,
+        count: int = 0,
+    ) -> tuple[
+        dict[
+            str, "observable.Observable | entity.Entity | indicator.Indicator | tag.Tag"
+        ],
+        List[List["Relationship | TagRelationship"]],
+        int,
+    ]:
         """Fetches neighbors of the YetiObject.
 
         Args:

--- a/core/web/apiv2/graph.py
+++ b/core/web/apiv2/graph.py
@@ -28,7 +28,8 @@ class GraphSearchRequest(BaseModel):
     source: str
     link_types: list[str] = []
     target_types: list[str] = []
-    hops: int
+    min_hops: int
+    max_hops: int
     graph: str
     direction: GraphDirection
     include_original: bool
@@ -105,7 +106,8 @@ async def search(request: GraphSearchRequest) -> GraphSearchResponse:
         direction=request.direction,
         include_original=request.include_original,
         graph=request.graph,
-        hops=request.hops,
+        min_hops=request.min_hops,
+        max_hops=request.max_hops,
         count=request.count,
         offset=request.page * request.count,
     )

--- a/tests/apiv2/entities.py
+++ b/tests/apiv2/entities.py
@@ -68,6 +68,21 @@ class EntityTest(unittest.TestCase):
         self.assertEqual(len(data["entities"][0]["tags"]), 1, data)
         self.assertIn("ta1", data["entities"][0]["tags"])
 
+    def test_search_entities_tagged(self):
+        response = client.post(
+            "/api/v2/entities/search",
+            json={"query": {"name": "", "tags": ["ta1"]}},
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(len(data["entities"]), 1)
+        self.assertEqual(data["entities"][0]["name"], "ta1")
+        self.assertEqual(data["entities"][0]["type"], "threat-actor")
+
+        # Check tags
+        self.assertEqual(len(data["entities"][0]["tags"]), 1, data)
+        self.assertIn("ta1", data["entities"][0]["tags"])
+
     def test_search_entities_subfields(self):
         response = client.post(
             "/api/v2/entities/search",

--- a/tests/schemas/entity.py
+++ b/tests/schemas/entity.py
@@ -94,7 +94,9 @@ class EntityTest(unittest.TestCase):
         observable = hostname.Hostname(value="doman.com").save()
 
         observable.tag(["tag1"])
-        vertices, paths, count = observable.neighbors(graph="tagged", hops=2)
+        vertices, paths, count = observable.neighbors(
+            graph="tagged", min_hops=2, max_hops=2
+        )
 
         new_tag = tag.Tag.find(name="tag1")
 


### PR DESCRIPTION
Min / max hops used to be identical (e.g. a graph traversal request could go from `1..1` or `2..2` but not `1..4`.

Tweak to the API to account for min / max hops + backwards compatibility