### PR TITLE
Introduce search aliases

### DIFF
--- a/.github/workflows/feedtest.yml
+++ b/.github/workflows/feedtest.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run:
         sudo apt-get update && sudo apt-get install -y python3-pip && sudo pip3 install poetry
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -7,7 +7,7 @@ jobs:
     name: Lint using Ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
       - name: Install ruff
         run: pip install ruff

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run:
         sudo apt-get update && sudo apt-get install -y python3-pip && sudo pip3 install poetry
     - name: Set up Python ${{ matrix.python-version }}

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -5,11 +5,13 @@ successfully carry out all interactions with the database.
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Any, List, Type, TypeVar
 
 if TYPE_CHECKING:
     from core.schemas import entity, indicator, observable, tag
     from core.schemas.graph import Relationship, TagRelationship
+
+TYetiObject = TypeVar("TYetiObject")
 
 
 class AbstractYetiConnector(ABC):
@@ -50,13 +52,32 @@ class AbstractYetiConnector(ABC):
 
     @classmethod
     @abstractmethod
-    def filter(cls, args, offset=None, count=None):
-        """Filters objects according to args.
+    def filter(
+        cls: Type[TYetiObject],
+        query_args: dict[str, Any],
+        tag_filter: List[str] = [],
+        offset: int = 0,
+        count: int = 0,
+        sorting: List[tuple[str, bool]] = [],
+        graph_queries: List[tuple[str, str, str, str]] = [],
+    ) -> tuple[List[TYetiObject], int]:
+        """Search in an ArangoDb collection.
+
+        Search the collection for all objects whose 'value' attribute matches
+        the regex defined in the 'value' key of the args dict.
 
         Args:
-          args: parameters used to filter the objects.
-          offset: Skip this many objects when querying the DB.
-          count: How many objecst after `offset` to return.
+            query_args: A key:value dictionary containing keys to filter objects
+                on.
+            tag_filter: A list of tags to filter on.
+            offset: Skip this many objects when querying the DB.
+            count: How many objecst after `offset` to return.
+            sorting: A list of (order, ascending) fields to sort by.
+            graph_queries: A list of (name, graph, direction, field) tuples to
+                query the graph with.
+
+        Returns:
+            A List of Yeti objects, and the total object count.
         """
         raise NotImplementedError
 

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -25,6 +25,7 @@ class IndicatorSearchRequest(BaseModel):
     query: dict[str, str | int | list] = {}
     type: indicator.IndicatorType | None = None
     sorting: list[tuple[str, bool]] = []
+    filter_aliases: list[tuple[str, str]] = []
     count: int = 50
     page: int = 0
 
@@ -107,9 +108,10 @@ async def search(request: IndicatorSearchRequest) -> IndicatorSearchResponse:
     if request.type:
         query["type"] = request.type
     indicators, total = indicator.Indicator.filter(
-        query,
+        query_args=query,
         offset=request.page * request.count,
         count=request.count,
         sorting=request.sorting,
+        aliases=request.filter_aliases,
     )
     return IndicatorSearchResponse(indicators=indicators, total=total)


### PR DESCRIPTION
This PR introduces search aliases. The API can now be provided extra fields to also check for regex matches (useful when e.g. filtering for `name` but also `alias` in Malware entities)

Missing:

- [ ] Tests