### PR TITLE
Graph search can now select target vertices based on root_type (previously only leaf types)

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -546,7 +546,8 @@ class ArangoYetiConnector(AbstractYetiConnector):
         count: int = 0,
     ) -> tuple[
         dict[
-            str, "observable.Observable | entity.Entity | indicator.Indicator | tag.Tag"
+            str,
+            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag",
         ],
         List[List["Relationship | TagRelationship"]],
         int,

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -620,7 +620,6 @@ class ArangoYetiConnector(AbstractYetiConnector):
             self._build_vertices(vertices, path["vertices"])
         if not include_original:
             vertices.pop(self.extended_id, None)
-        print(vertices, paths, total)
         return vertices, paths, total or 0
 
     def _dedup_edges(self, edges):

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -583,7 +583,9 @@ class ArangoYetiConnector(AbstractYetiConnector):
             query_filter = "FILTER e.type IN @link_types"
         if target_types:
             args["target_types"] = target_types
-            query_filter = "FILTER v.type IN @target_types"
+            query_filter = (
+                "FILTER (v.type IN @target_types OR v.root_type IN @target_types)"
+            )
 
         limit = ""
         if count != 0:
@@ -618,6 +620,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
             self._build_vertices(vertices, path["vertices"])
         if not include_original:
             vertices.pop(self.extended_id, None)
+        print(vertices, paths, total)
         return vertices, paths, total or 0
 
     def _dedup_edges(self, edges):

--- a/core/web/apiv2/graph.py
+++ b/core/web/apiv2/graph.py
@@ -104,10 +104,10 @@ class GraphSearchResponse(BaseModel):
     vertices: dict[
         str,
         observable.Observable
-        | entity.Entity
-        | indicator.Indicator
+        | entity.EntityTypes
+        | indicator.IndicatorTypes
         | tag.Tag
-        | dfiq.DFIQBase,
+        | dfiq.DFIQTypes,
     ]
     paths: list[list[graph.Relationship | graph.TagRelationship]]
     total: int

--- a/tests/apiv2/graph.py
+++ b/tests/apiv2/graph.py
@@ -215,6 +215,51 @@ class SimpleGraphTest(unittest.TestCase):
         self.assertEqual(neighbor["query_type"], "opensearch")
         self.assertEqual(neighbor["target_systems"], ["system1"])
 
+    def test_neighbors_target_types(self):
+        self.entity1.link_to(self.observable1, "uses", "asd")
+        self.entity1.link_to(self.observable2, "uses", "asd")
+        response = client.post(
+            "/api/v2/graph/search",
+            json={
+                "source": self.entity1.extended_id,
+                "hops": 1,
+                "graph": "links",
+                "direction": "any",
+                "target_types": ["hostname"],
+                "include_original": False,
+            },
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(len(data["vertices"]), 1)
+        self.assertEqual(
+            data["vertices"][self.observable1.extended_id]["value"], "tomchop.me"
+        )
+
+    def test_neighbors_target_types_root_type(self):
+        self.entity1.link_to(self.observable1, "uses", "asd")
+        self.entity1.link_to(self.observable2, "uses", "asd")
+        response = client.post(
+            "/api/v2/graph/search",
+            json={
+                "source": self.entity1.extended_id,
+                "hops": 1,
+                "graph": "links",
+                "direction": "any",
+                "target_types": ["observable"],
+                "include_original": False,
+            },
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(len(data["vertices"]), 2)
+        self.assertEqual(
+            data["vertices"][self.observable1.extended_id]["value"], "tomchop.me"
+        )
+        self.assertEqual(
+            data["vertices"][self.observable2.extended_id]["value"], "127.0.0.1"
+        )
+
     def test_add_link(self):
         response = client.post(
             "/api/v2/graph/add",


### PR DESCRIPTION
* [enhancement] Graph search can now select target vertices based on root_type (previously only leaf types)