### PR TITLE
Link to count

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -493,6 +493,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
             relationship = Relationship.load(neighbors[0])
             relationship.modified = datetime.datetime.now(datetime.timezone.utc)
             relationship.description = description
+            relationship.count += 1
             edge = json.loads(relationship.model_dump_json())
             edge["_id"] = neighbors[0]["_id"]
             graph.update_edge(edge)
@@ -502,6 +503,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
             type=relationship_type,
             source=self.extended_id,
             target=target.extended_id,
+            count=1,
             description=description,
             created=datetime.datetime.now(datetime.timezone.utc),
             modified=datetime.datetime.now(datetime.timezone.utc),

--- a/core/schemas/graph.py
+++ b/core/schemas/graph.py
@@ -24,6 +24,7 @@ class Relationship(BaseModel, database_arango.ArangoYetiConnector):
     source: str
     target: str
     type: str
+    count: int = 1
     description: str
     created: datetime.datetime
     modified: datetime.datetime


### PR DESCRIPTION
This PR adds `count` attribute to Relationship model. It is used to track how many time a link has been created between two objects.

In the model, the `count` is set to one by default to reflect database migration. Indeed, since `count` didn't exit in previous version, this fields would be set to zero which is non-sense since at least one relation exists. 