### PR TITLE
Exclude related_observables_count from model_dump_json in save method

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -250,13 +250,25 @@ class ArangoYetiConnector(AbstractYetiConnector):
         Returns:
           The created Yeti object.
         """
-        doc_dict = self.model_dump(exclude_unset=True, exclude=["tags"])
+        doc_dict = self.model_dump(
+            exclude_unset=True, exclude=["tags", "related_observables_count"]
+        )
         if doc_dict.get("id") is not None:
-            result = self._update(self.model_dump_json(exclude=["tags"]))
+            result = self._update(
+                self.model_dump_json(exclude=["tags", "related_observables_count"])
+            )
         else:
-            result = self._insert(self.model_dump_json(exclude=["tags", "id"]))
+            result = self._insert(
+                self.model_dump_json(
+                    exclude=["tags", "id", "related_observables_count"]
+                )
+            )
             if not result:
-                result = self._update(self.model_dump_json(exclude=exclude_overwrite))
+                result = self._update(
+                    self.model_dump_json(
+                        exclude=exclude_overwrite + ["related_observables_count"]
+                    )
+                )
         yeti_object = self.__class__(**result)
         # TODO: Override this if we decide to implement YetiTagModel
         if hasattr(self, "tags"):


### PR DESCRIPTION
This PR fixes a performance issue when saving entities. This was introduced with `Entity.related_observables_count` computed field which is called each time an entity is saved. This means at each `save` call, `neighbors` method was also called. This mainly impacts feeds or tasks creating / updating lots of entities.

Fixing this issue relies on excluding `related_observables_count` when calling `model_json_dump` in `ArangoDatabase.save` method.