### PR TITLE
Improved Log Redaction and Filtering

### DIFF
--- a/core/logger.py
+++ b/core/logger.py
@@ -87,6 +87,7 @@ class JsonFormatter(Formatter):
             json_record["err"] = self.formatException(record.exc_info)
         return json.dumps(json_record)
 
+
 class LogFilter(logging.Filter):
     no_log_endpoints = {
         "/api/v2/system/config",

--- a/core/logger.py
+++ b/core/logger.py
@@ -4,7 +4,6 @@ import logging
 import os
 import queue
 from logging import Formatter
-import json
 from logging.handlers import QueueHandler, QueueListener
 
 from core.config.config import yeti_config

--- a/core/logger.py
+++ b/core/logger.py
@@ -4,6 +4,7 @@ import logging
 import os
 import queue
 from logging import Formatter
+import json
 from logging.handlers import QueueHandler, QueueListener
 
 from core.config.config import yeti_config
@@ -87,24 +88,63 @@ class JsonFormatter(Formatter):
             json_record["err"] = self.formatException(record.exc_info)
         return json.dumps(json_record)
 
+class LogFilter(logging.Filter):
+    no_log_endpoints = {
+        "/api/v2/system/config",
+    }
 
+    sensitive_endpoint_prefixes = (
+        "/api/v2/auth",
+        "/api/v2/users",
+    )
+
+    sensitive_field_substrings = ("password",)
+
+    def filter_on_path(self, record) -> bool:
+        if hasattr(record, "path") and record.path in self.no_log_endpoints:
+            return False
+        return True
+
+    def redact_sensitive_fields(self, record):
+        if hasattr(record, "path") and hasattr(record, "body"):
+            if record.path.startswith(self.sensitive_endpoint_prefixes):
+                try:
+                    json_body = json.loads(record.body)
+                    for sensitive_field in self.sensitive_field_substrings:
+                        for key in json_body:
+                            if sensitive_field in key:
+                                json_body[key] = "REDACTED"
+                    record.body = json.dumps(json_body)
+                except Exception:
+                    pass
+        return
+
+    def filter(self, record):
+        if not self.filter_on_path(record):
+            return False
+
+        self.redact_sensitive_fields(record)
+
+        return True
+
+
+# Base logging config
 logger = logging.getLogger("yeti.audit.log")
 logger.setLevel(logging.INFO)
 logger.propagate = False
 
+# Queue handler
 log_queue = queue.Queue(-1)
 queue_handler = QueueHandler(log_queue)
 logger.addHandler(queue_handler)
-
-json_formatter = JsonFormatter()
-console_formatter = logging.Formatter(
-    "%(asctime)s - %(name)s - %(levelname)s - %(message)s - %(username)s - %(path)s - %(method)s - %(body)s - %(client)s - %(status_code)s"
-)
-
 handlers = list()
 
+# Console handler
+log_format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s - %(username)s - %(path)s - %(method)s - %(body)s - %(client)s - %(status_code)s"
+
 console_handler = logging.StreamHandler()
-console_handler.setFormatter(console_formatter)
+console_handler.addFilter(LogFilter())
+console_handler.setFormatter(logging.Formatter(log_format))
 handlers.append(console_handler)
 
 audit_logfile = yeti_config.get("system", "audit_logfile")
@@ -112,15 +152,20 @@ audit_logfile = yeti_config.get("system", "audit_logfile")
 if audit_logfile:
     if os.access(audit_logfile, os.W_OK):
         file_handler = logging.FileHandler(audit_logfile)
-        file_handler.setFormatter(json_formatter)
+        file_handler.addFilter(LogFilter())
+        file_handler.setFormatter(JsonFormatter())
         handlers.append(file_handler)
     else:
         logging.getLogger().warning("Audit log file not writable, using console only")
 else:
     logging.getLogger().warning("Audit log file not configured, using console only")
 
+
+# Arango Handler
 arango_handler = ArangoHandler()
+arango_handler.addFilter(LogFilter())
 handlers.append(arango_handler)
 
+# Listen for Logs
 listener = QueueListener(log_queue, *handlers)
 listener.start()

--- a/core/web/webapp.py
+++ b/core/web/webapp.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import json
 
 from fastapi import APIRouter, Depends, FastAPI, Request
 from starlette.middleware.sessions import SessionMiddleware
@@ -105,22 +106,11 @@ api_router.include_router(
 
 app.include_router(api_router, prefix="/api/v2")
 
-LOGGING_EXCLUDELIST = ["/auth/"]
-LOGGING_SENSITIVE_BODY = [
-    "/users/",
-]
-LOG_BODY_SIZE_LIMIT = 2000
-CONTENT_TOO_LARGE_MESSAGE = f"[Request body > {LOG_BODY_SIZE_LIMIT} bytes, not logged]"
-
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
     req_body = await request.body()
     response = await call_next(request)
-    # Do not log auth-related requests
-    for path in LOGGING_EXCLUDELIST:
-        if path in request.url.path:
-            return response
     try:
         extra = {
             "type": "audit.log",
@@ -137,14 +127,33 @@ async def log_requests(request: Request, call_next):
         if getattr(request.state, "username", None):
             extra["username"] = request.state.username
         if req_body:
-            if len(req_body) > LOG_BODY_SIZE_LIMIT:
-                extra["body"] = CONTENT_TOO_LARGE_MESSAGE.encode("utf-8")
-            else:
-                extra["body"] = req_body
+            extra["body"] = req_body
 
-        for path in LOGGING_SENSITIVE_BODY:
-            if path in request.url.path:
-                extra["body"] = b""
+            # Check if the request body is JSON or form data
+            if request.headers.get("content-type", "").startswith(
+                "multipart/form-data"
+            ):
+                try:
+                    # Try to parse the request body as form data
+                    form_data = await request.form()
+                    out = {}
+
+                    # Redact sensitive fields
+                    for key, value in form_data.items():
+                        out[key] = value
+
+                    extra["body"] = json.dumps(out)
+                except:
+                    # If parsing fails, just log the request body as is
+                    pass
+            else:
+                try:
+                    # Try to parse the request body as JSON
+                    json_body = await request.json()
+                    extra["body"] = json.dumps(json_body)
+                except:
+                    # If parsing fails, just log the request body as is
+                    pass
 
         if response.status_code == 200:
             logger.info("Authorized request", extra=extra)

--- a/core/web/webapp.py
+++ b/core/web/webapp.py
@@ -1,6 +1,6 @@
+import json
 import logging
 import os
-import json
 
 from fastapi import APIRouter, Depends, FastAPI, Request
 from starlette.middleware.sessions import SessionMiddleware
@@ -143,7 +143,7 @@ async def log_requests(request: Request, call_next):
                         out[key] = value
 
                     extra["body"] = json.dumps(out)
-                except:
+                except Exception:
                     # If parsing fails, just log the request body as is
                     pass
             else:
@@ -151,7 +151,7 @@ async def log_requests(request: Request, call_next):
                     # Try to parse the request body as JSON
                     json_body = await request.json()
                     extra["body"] = json.dumps(json_body)
-                except:
+                except Exception:
                     # If parsing fails, just log the request body as is
                     pass
 


### PR DESCRIPTION
This PR implements a new `LogFilter()` in `logger.py` which allows for redaction of specific fields and ignoring the logging of specific endpoints.

With this the logging middleware in `webapp.py` is modified to push all logs and have `logger.py` handle them and likewise attempt to convert all requests to a JSON format (Yeti login uses `multipart/form-data`)