### PR TITLE
Improve schemas loader to handle several classes in same file

### DIFF
--- a/core/schemas/__init__.py
+++ b/core/schemas/__init__.py
@@ -63,7 +63,7 @@ def register_schemas_types(
     return modules
 
 
-def _register_classes(module_name, base_module):
+def register_module(module_name, base_module):
     """
     Register the classes for the schema implementation files
 

--- a/core/schemas/__init__.py
+++ b/core/schemas/__init__.py
@@ -1,6 +1,7 @@
 import importlib
 import inspect
 import logging
+import re
 from pathlib import Path
 
 import aenum
@@ -19,30 +20,76 @@ from core.schemas import (
 )
 
 logger = logging.getLogger(__name__)
+logging.getLogger().setLevel(logging.INFO)
+
+
+def register_schemas_types(
+    schema_root_type: str, schema_enum: aenum, type_pattern: re.Pattern
+) -> set:
+    """
+    Register the types of schemas from implementation files
+    :param schema_root_type: The schema root type to work with
+    :param schema_enum: The schema enum to extend
+    :param type_pattern: The pattern to match the types in the schema implementation files
+    """
+    logger.info(f"Loading {schema_root_type} types")
+    modules = set()
+    pattern_matcher = re.compile(type_pattern)
+    for schema_file in Path(__file__).parent.glob(f"{schema_root_type}/**/*.py"):
+        if schema_file.stem == "__init__":
+            continue
+        if schema_file.parent.stem == schema_root_type:
+            module_name = f"core.schemas.{schema_root_type}.{schema_file.stem}"
+        elif schema_file.parent.stem == "private":
+            module_name = f"core.schemas.{schema_root_type}.private.{schema_file.stem}"
+        with open(schema_file, "r") as f:
+            content = f.read()
+        for schema_type in pattern_matcher.findall(content):
+            if schema_type not in schema_enum.__members__:
+                logger.debug(
+                    f"Adding observable type <{schema_type}> to {schema_enum.__name__} enum"
+                )
+                if schema_root_type == "entities":
+                    aenum.extend_enum(
+                        schema_enum, schema_type, schema_type.replace("_", "-")
+                    )
+                else:
+                    aenum.extend_enum(schema_enum, schema_type, schema_type)
+                modules.add(module_name)
+            else:
+                logger.warning(
+                    f"Observable type {schema_type} defined in <{module_name}> already exists"
+                )
+    return modules
+
+
+def register_schema_classes(base_module, base_class, modules: set, type_mapping: dict):
+    """
+    Register the schemas from the implementation files
+    :param base_module: The schema root type to work with
+    :param base_class: base class that the schema class should inherit from
+    :param modules: The modules to register
+    :param type_mapping: schema type mapping to update
+    """
+    logger.info(f"Registering {base_module.__name__} classes")
+    for module_name in modules:
+        module = importlib.import_module(module_name)
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if issubclass(obj, base_class):
+                if "type" in obj.model_fields:
+                    obs_type = obj.model_fields["type"].default.value
+                    logger.debug(
+                        f"Registering class {obj.__name__} defining type <{obs_type}>"
+                    )
+                    type_mapping[obs_type] = obj
+                    setattr(base_module, obj.__name__, obj)
 
 
 def load_entities():
-    logger.info("Registering entities")
-    modules = dict()
-    for entity_file in Path(__file__).parent.glob("entities/**/*.py"):
-        if entity_file.stem == "__init__":
-            continue
-        logger.info(f"Registering entity type {entity_file.stem}")
-        if entity_file.parent.stem == "entities":
-            module_name = f"core.schemas.entities.{entity_file.stem}"
-        elif entity_file.parent.stem == "private":
-            module_name = f"core.schemas.entities.private.{entity_file.stem}"
-        enum_value = entity_file.stem.replace("_", "-")
-        if entity_file.stem not in entity.EntityType.__members__:
-            aenum.extend_enum(entity.EntityType, entity_file.stem, enum_value)
-        modules[module_name] = enum_value
     entity.TYPE_MAPPING = {"entity": entity.Entity, "entities": entity.Entity}
-    for module_name, enum_value in modules.items():
-        module = importlib.import_module(module_name)
-        for _, obj in inspect.getmembers(module, inspect.isclass):
-            if issubclass(obj, entity.Entity):
-                entity.TYPE_MAPPING[enum_value] = obj
-                setattr(entity, obj.__name__, obj)
+    types_pattern = r"Literal\[entity.EntityType.(.+?(?=\]))"
+    modules = register_schemas_types("entities", entity.EntityType, types_pattern)
+    register_schema_classes(entity, entity.Entity, modules, entity.TYPE_MAPPING)
     for key in entity.TYPE_MAPPING:
         if key in ["entity", "entities"]:
             continue
@@ -54,30 +101,17 @@ def load_entities():
 
 
 def load_indicators():
-    logger.info("Registering indicators")
-    modules = dict()
-    for indicator_file in Path(__file__).parent.glob("indicators/**/*.py"):
-        if indicator_file.stem == "__init__":
-            continue
-        logger.info(f"Registering indicator type {indicator_file.stem}")
-        if indicator_file.parent.stem == "indicators":
-            module_name = f"core.schemas.indicators.{indicator_file.stem}"
-        elif indicator_file.parent.stem == "private":
-            module_name = f"core.schemas.indicators.private.{indicator_file.stem}"
-        enum_value = indicator_file.stem
-        if indicator_file.stem not in indicator.IndicatorType.__members__:
-            aenum.extend_enum(indicator.IndicatorType, indicator_file.stem, enum_value)
-        modules[module_name] = enum_value
     indicator.TYPE_MAPPING = {
         "indicator": indicator.Indicator,
         "indicators": indicator.Indicator,
     }
-    for module_name, enum_value in modules.items():
-        module = importlib.import_module(module_name)
-        for _, obj in inspect.getmembers(module, inspect.isclass):
-            if issubclass(obj, indicator.Indicator):
-                indicator.TYPE_MAPPING[enum_value] = obj
-                setattr(indicator, obj.__name__, obj)
+    types_pattern = r"Literal\[indicator.IndicatorType.(.+?(?=\]))"
+    modules = register_schemas_types(
+        "indicators", indicator.IndicatorType, types_pattern
+    )
+    register_schema_classes(
+        indicator, indicator.Indicator, modules, indicator.TYPE_MAPPING
+    )
     for key in indicator.TYPE_MAPPING:
         if key in ["indicator", "indicators"]:
             continue
@@ -89,33 +123,19 @@ def load_indicators():
 
 
 def load_observables():
-    logger.info("Registering observables")
-    modules = dict()
-    for observable_file in Path(__file__).parent.glob("observables/**/*.py"):
-        if observable_file.stem == "__init__":
-            continue
-        logger.info(f"Registering observable type {observable_file.stem}")
-        if observable_file.parent.stem == "observables":
-            module_name = f"core.schemas.observables.{observable_file.stem}"
-        elif observable_file.parent.stem == "private":
-            module_name = f"core.schemas.observables.private.{observable_file.stem}"
-        if observable_file.stem not in observable.ObservableType.__members__:
-            aenum.extend_enum(
-                observable.ObservableType, observable_file.stem, observable_file.stem
-            )
-        modules[module_name] = observable_file.stem
-    if "guess" not in observable.ObservableType.__members__:
-        aenum.extend_enum(observable.ObservableType, "guess", "guess")
     observable.TYPE_MAPPING = {
         "observable": observable.Observable,
         "observables": observable.Observable,
     }
-    for module_name, enum_value in modules.items():
-        module = importlib.import_module(module_name)
-        for _, obj in inspect.getmembers(module, inspect.isclass):
-            if issubclass(obj, observable.Observable):
-                observable.TYPE_MAPPING[enum_value] = obj
-                setattr(observable, obj.__name__, obj)
+    if "guess" not in observable.ObservableType.__members__:
+        aenum.extend_enum(observable.ObservableType, "guess", "guess")
+    type_pattern = r"Literal\[observable.ObservableType.(.+?(?=\]))"
+    modules = register_schemas_types(
+        "observables", observable.ObservableType, type_pattern
+    )
+    register_schema_classes(
+        observable, observable.Observable, modules, observable.TYPE_MAPPING
+    )
     for key in observable.TYPE_MAPPING:
         if key in ["observable", "observables"]:
             continue

--- a/core/schemas/entities/attack_pattern.py
+++ b/core/schemas/entities/attack_pattern.py
@@ -4,7 +4,7 @@ from core.schemas import entity
 
 
 class AttackPattern(entity.Entity):
-    _type_filter: ClassVar[str] = entity.EntityType.attack_pattern
-    type: Literal[entity.EntityType.attack_pattern] = entity.EntityType.attack_pattern
+    _type_filter: ClassVar[str] = "attack-pattern"
+    type: Literal["attack-pattern"] = "attack-pattern"
     aliases: list[str] = []
     kill_chain_phases: list[str] = []

--- a/core/schemas/entities/campaign.py
+++ b/core/schemas/entities/campaign.py
@@ -8,8 +8,8 @@ from core.schemas import entity
 
 
 class Campaign(entity.Entity):
-    _type_filter: ClassVar[str] = entity.EntityType.campaign
-    type: Literal[entity.EntityType.campaign] = entity.EntityType.campaign
+    _type_filter: ClassVar[str] = "campaign"
+    type: Literal["campaign"] = "campaign"
 
     aliases: list[str] = []
     first_seen: datetime.datetime = Field(default_factory=now)

--- a/core/schemas/entities/company.py
+++ b/core/schemas/entities/company.py
@@ -4,5 +4,5 @@ from core.schemas import entity
 
 
 class Company(entity.Entity):
-    type: Literal[entity.EntityType.company] = entity.EntityType.company
-    _type_filter: ClassVar[str] = entity.EntityType.company
+    type: Literal["company"] = "company"
+    _type_filter: ClassVar[str] = "company"

--- a/core/schemas/entities/course_of_action.py
+++ b/core/schemas/entities/course_of_action.py
@@ -4,7 +4,5 @@ from core.schemas import entity
 
 
 class CourseOfAction(entity.Entity):
-    _type_filter: ClassVar[str] = entity.EntityType.course_of_action
-    type: Literal[entity.EntityType.course_of_action] = (
-        entity.EntityType.course_of_action
-    )
+    _type_filter: ClassVar[str] = "course-of-action"
+    type: Literal["course-of-action"] = "course-of-action"

--- a/core/schemas/entities/identity.py
+++ b/core/schemas/entities/identity.py
@@ -4,8 +4,8 @@ from core.schemas import entity
 
 
 class Identity(entity.Entity):
-    _type_filter: ClassVar[str] = entity.EntityType.identity
-    type: Literal[entity.EntityType.identity] = entity.EntityType.identity
+    _type_filter: ClassVar[str] = "identity"
+    type: Literal["identity"] = "identity"
 
     identity_class: str = ""
     sectors: list[str] = []

--- a/core/schemas/entities/intrusion_set.py
+++ b/core/schemas/entities/intrusion_set.py
@@ -8,8 +8,8 @@ from core.schemas import entity
 
 
 class IntrusionSet(entity.Entity):
-    _type_filter: ClassVar[str] = entity.EntityType.intrusion_set
-    type: Literal[entity.EntityType.intrusion_set] = entity.EntityType.intrusion_set
+    _type_filter: ClassVar[str] = "intrusion-set"
+    type: Literal["intrusion-set"] = "intrusion-set"
 
     aliases: list[str] = []
     first_seen: datetime.datetime = Field(default_factory=now)

--- a/core/schemas/entities/investigation.py
+++ b/core/schemas/entities/investigation.py
@@ -4,7 +4,7 @@ from core.schemas import entity
 
 
 class Investigation(entity.Entity):
-    _type_filter: ClassVar[str] = entity.EntityType.investigation
-    type: Literal[entity.EntityType.investigation] = entity.EntityType.investigation
+    _type_filter: ClassVar[str] = "investigation"
+    type: Literal["investigation"] = "investigation"
 
     reference: str = ""

--- a/core/schemas/entities/malware.py
+++ b/core/schemas/entities/malware.py
@@ -4,8 +4,8 @@ from core.schemas import entity
 
 
 class Malware(entity.Entity):
-    _type_filter: ClassVar[str] = entity.EntityType.malware
-    type: Literal[entity.EntityType.malware] = entity.EntityType.malware
+    _type_filter: ClassVar[str] = "malware"
+    type: Literal["malware"] = "malware"
 
     kill_chain_phases: list[str] = []
     aliases: list[str] = []

--- a/core/schemas/entities/note.py
+++ b/core/schemas/entities/note.py
@@ -4,5 +4,5 @@ from core.schemas import entity
 
 
 class Note(entity.Entity):
-    type: Literal[entity.EntityType.note] = entity.EntityType.note
-    _type_filter: ClassVar[str] = entity.EntityType.note
+    type: Literal["note"] = "note"
+    _type_filter: ClassVar[str] = "note"

--- a/core/schemas/entities/phone.py
+++ b/core/schemas/entities/phone.py
@@ -4,5 +4,5 @@ from core.schemas import entity
 
 
 class Phone(entity.Entity):
-    type: Literal[entity.EntityType.phone] = entity.EntityType.phone
-    _type_filter: ClassVar[str] = entity.EntityType.phone
+    type: Literal["phone"] = "phone"
+    _type_filter: ClassVar[str] = "phone"

--- a/core/schemas/entities/threat_actor.py
+++ b/core/schemas/entities/threat_actor.py
@@ -8,8 +8,8 @@ from core.schemas import entity
 
 
 class ThreatActor(entity.Entity):
-    _type_filter: ClassVar[str] = entity.EntityType.threat_actor
-    type: Literal[entity.EntityType.threat_actor] = entity.EntityType.threat_actor
+    _type_filter: ClassVar[str] = "threat-actor"
+    type: Literal["threat-actor"] = "threat-actor"
 
     threat_actor_types: list[str] = []
     aliases: list[str] = []

--- a/core/schemas/entities/tool.py
+++ b/core/schemas/entities/tool.py
@@ -4,8 +4,8 @@ from core.schemas import entity
 
 
 class Tool(entity.Entity):
-    _type_filter: ClassVar[str] = entity.EntityType.tool
-    type: Literal[entity.EntityType.tool] = entity.EntityType.tool
+    _type_filter: ClassVar[str] = "tool"
+    type: Literal["tool"] = "tool"
 
     aliases: list[str] = []
     kill_chain_phases: list[str] = []

--- a/core/schemas/entities/vulnerability.py
+++ b/core/schemas/entities/vulnerability.py
@@ -31,8 +31,8 @@ class Vulnerability(entity.Entity):
                   medium, high, critical.
     """
 
-    _type_filter: ClassVar[str] = entity.EntityType.vulnerability
-    type: Literal[entity.EntityType.vulnerability] = entity.EntityType.vulnerability
+    _type_filter: ClassVar[str] = "vulnerability"
+    type: Literal["vulnerability"] = "vulnerability"
 
     title: str = ""
     base_score: float = Field(ge=0.0, le=10.0, default=0.0)

--- a/core/schemas/indicators/forensicartifact.py
+++ b/core/schemas/indicators/forensicartifact.py
@@ -17,10 +17,8 @@ class ForensicArtifact(indicator.Indicator):
     As defined in https://github.com/ForensicArtifacts/artifacts
     """
 
-    _type_filter: ClassVar[str] = indicator.IndicatorType.forensicartifact
-    type: Literal[indicator.IndicatorType.forensicartifact] = (
-        indicator.IndicatorType.forensicartifact
-    )
+    _type_filter: ClassVar[str] = "forensicartifact"
+    type: Literal["forensicartifact"] = "forensicartifact"
 
     sources: list[dict] = []
     aliases: list[str] = []

--- a/core/schemas/indicators/query.py
+++ b/core/schemas/indicators/query.py
@@ -6,8 +6,8 @@ from core.schemas import indicator
 class Query(indicator.Indicator):
     """Represents a query that can be sent to another system."""
 
-    _type_filter: ClassVar[str] = indicator.IndicatorType.query
-    type: Literal[indicator.IndicatorType.query] = indicator.IndicatorType.query
+    _type_filter: ClassVar[str] = "query"
+    type: Literal["query"] = "query"
 
     query_type: str
     target_systems: list[str] = []

--- a/core/schemas/indicators/regex.py
+++ b/core/schemas/indicators/regex.py
@@ -7,9 +7,9 @@ from core.schemas import indicator
 
 
 class Regex(indicator.Indicator):
-    _type_filter: ClassVar[str] = indicator.IndicatorType.regex
+    _type_filter: ClassVar[str] = "regex"
     _compiled_pattern: re.Pattern | None = PrivateAttr(None)
-    type: Literal[indicator.IndicatorType.regex] = indicator.IndicatorType.regex
+    type: Literal["regex"] = "regex"
 
     @property
     def compiled_pattern(self):

--- a/core/schemas/indicators/sigma.py
+++ b/core/schemas/indicators/sigma.py
@@ -9,8 +9,8 @@ class Sigma(indicator.Indicator):
     Parsing and matching is yet TODO.
     """
 
-    _type_filter: ClassVar[str] = indicator.IndicatorType.sigma
-    type: Literal[indicator.IndicatorType.sigma] = indicator.IndicatorType.sigma
+    _type_filter: ClassVar[str] = "sigma"
+    type: Literal["sigma"] = "sigma"
 
     def match(self, value: str) -> indicator.IndicatorMatch | None:
         raise NotImplementedError

--- a/core/schemas/indicators/suricata.py
+++ b/core/schemas/indicators/suricata.py
@@ -13,8 +13,8 @@ class Suricata(indicator.Indicator):
     Parsing and matching is yet TODO.
     """
 
-    _type_filter: ClassVar[str] = indicator.IndicatorType.suricata
-    type: Literal[indicator.IndicatorType.suricata] = indicator.IndicatorType.suricata
+    _type_filter: ClassVar[str] = "suricata"
+    type: Literal["suricata"] = "suricata"
     sid: int = 0
     metadata: List[str] = []
     references: List[str] = []

--- a/core/schemas/indicators/yara.py
+++ b/core/schemas/indicators/yara.py
@@ -9,8 +9,8 @@ class Yara(indicator.Indicator):
     Parsing and matching is yet TODO.
     """
 
-    _type_filter: ClassVar[str] = indicator.IndicatorType.yara
-    type: Literal[indicator.IndicatorType.yara] = indicator.IndicatorType.yara
+    _type_filter: ClassVar[str] = "yara"
+    type: Literal["yara"] = "yara"
 
     def match(self, value: str) -> indicator.IndicatorMatch | None:
         raise NotImplementedError

--- a/core/schemas/observables/asn.py
+++ b/core/schemas/observables/asn.py
@@ -4,6 +4,6 @@ from core.schemas import observable
 
 
 class ASN(observable.Observable):
-    type: Literal[observable.ObservableType.asn] = observable.ObservableType.asn
+    type: Literal["asn"] = "asn"
     country: str | None = None
     description: str | None = None

--- a/core/schemas/observables/bic.py
+++ b/core/schemas/observables/bic.py
@@ -7,7 +7,7 @@ BIC_MATCHER_REGEX = re.compile("^[A-Z]{6}[A-Z0-9]{2}[A-Z0-9]{3}?")
 
 
 class BIC(observable.Observable):
-    type: Literal[observable.ObservableType.bic] = observable.ObservableType.bic
+    type: Literal["bic"] = "bic"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/certificate.py
+++ b/core/schemas/observables/certificate.py
@@ -22,9 +22,7 @@ class Certificate(observable.Observable):
         fingerprint: the certificate fingerprint.
     """
 
-    type: Literal[observable.ObservableType.certificate] = (
-        observable.ObservableType.certificate
-    )
+    type: Literal["certificate"] = "certificate"
     last_seen: datetime.datetime = Field(default_factory=now)
     first_seen: datetime.datetime = Field(default_factory=now)
     issuer: str | None = None

--- a/core/schemas/observables/cidr.py
+++ b/core/schemas/observables/cidr.py
@@ -4,4 +4,4 @@ from core.schemas import observable
 
 
 class CIDR(observable.Observable):
-    type: Literal[observable.ObservableType.cidr] = observable.ObservableType.cidr
+    type: Literal["cidr"] = "cidr"

--- a/core/schemas/observables/command_line.py
+++ b/core/schemas/observables/command_line.py
@@ -4,6 +4,4 @@ from core.schemas import observable
 
 
 class CommandLine(observable.Observable):
-    type: Literal[observable.ObservableType.command_line] = (
-        observable.ObservableType.command_line
-    )
+    type: Literal["command_line"] = "command_line"

--- a/core/schemas/observables/container_image.py
+++ b/core/schemas/observables/container_image.py
@@ -1,0 +1,12 @@
+from typing import Literal
+
+from core.schemas import observable
+
+
+class ContainerImage(observable.Observable):
+    type: Literal["container_image"] = "container_image"
+    registry: str = "docker.io"
+
+
+class DockerImage(ContainerImage):
+    type: Literal["docker_image"] = "docker_image"

--- a/core/schemas/observables/docker_image.py
+++ b/core/schemas/observables/docker_image.py
@@ -1,9 +1,0 @@
-from typing import Literal
-
-from core.schemas import observable
-
-
-class DockerImage(observable.Observable):
-    type: Literal[observable.ObservableType.docker_image] = (
-        observable.ObservableType.docker_image
-    )

--- a/core/schemas/observables/email.py
+++ b/core/schemas/observables/email.py
@@ -6,7 +6,7 @@ from core.schemas import observable
 
 
 class Email(observable.Observable):
-    type: Literal[observable.ObservableType.email] = observable.ObservableType.email
+    type: Literal["email"] = "email"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/file.py
+++ b/core/schemas/observables/file.py
@@ -10,7 +10,7 @@ class File(observable.Observable):
     Value should to be in the form FILE:<HASH>.
     """
 
-    type: Literal[observable.ObservableType.file] = observable.ObservableType.file
+    type: Literal["file"] = "file"
     name: str | None = None
     size: int | None = None
     sha256: str | None = None

--- a/core/schemas/observables/generic.py
+++ b/core/schemas/observables/generic.py
@@ -6,4 +6,4 @@ from core.schemas import observable
 class Generic(observable.Observable):
     """Use this type of Observable for any type of observable that doesn't fit into any other category."""
 
-    type: Literal[observable.ObservableType.generic] = observable.ObservableType.generic
+    type: Literal["generic"] = "generic"

--- a/core/schemas/observables/hostname.py
+++ b/core/schemas/observables/hostname.py
@@ -6,9 +6,7 @@ from core.schemas import observable
 
 
 class Hostname(observable.Observable):
-    type: Literal[observable.ObservableType.hostname] = (
-        observable.ObservableType.hostname
-    )
+    type: Literal["hostname"] = "hostname"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/iban.py
+++ b/core/schemas/observables/iban.py
@@ -6,7 +6,7 @@ from core.schemas import observable
 
 
 class IBAN(observable.Observable):
-    type: Literal[observable.ObservableType.iban] = observable.ObservableType.iban
+    type: Literal["iban"] = "iban"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/imphash.py
+++ b/core/schemas/observables/imphash.py
@@ -4,4 +4,4 @@ from core.schemas import observable
 
 
 class Imphash(observable.Observable):
-    type: Literal[observable.ObservableType.imphash] = observable.ObservableType.imphash
+    type: Literal["imphash"] = "imphash"

--- a/core/schemas/observables/ipv4.py
+++ b/core/schemas/observables/ipv4.py
@@ -6,7 +6,7 @@ from core.schemas import observable
 
 
 class IPv4(observable.Observable):
-    type: Literal[observable.ObservableType.ipv4] = observable.ObservableType.ipv4
+    type: Literal["ipv4"] = "ipv4"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/ipv6.py
+++ b/core/schemas/observables/ipv6.py
@@ -6,7 +6,7 @@ from core.schemas import observable
 
 
 class IPv6(observable.Observable):
-    type: Literal[observable.ObservableType.ipv6] = observable.ObservableType.ipv6
+    type: Literal["ipv6"] = "ipv6"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/ja3.py
+++ b/core/schemas/observables/ja3.py
@@ -4,4 +4,4 @@ from core.schemas import observable
 
 
 class JA3(observable.Observable):
-    type: Literal[observable.ObservableType.ja3] = observable.ObservableType.ja3
+    type: Literal["ja3"] = "ja3"

--- a/core/schemas/observables/jarm.py
+++ b/core/schemas/observables/jarm.py
@@ -4,4 +4,4 @@ from core.schemas import observable
 
 
 class JARM(observable.Observable):
-    type: Literal[observable.ObservableType.jarm] = observable.ObservableType.jarm
+    type: Literal["jarm"] = "jarm"

--- a/core/schemas/observables/mac_address.py
+++ b/core/schemas/observables/mac_address.py
@@ -4,6 +4,4 @@ from core.schemas import observable
 
 
 class MacAddress(observable.Observable):
-    type: Literal[observable.ObservableType.mac_address] = (
-        observable.ObservableType.mac_address
-    )
+    type: Literal["mac_address"] = "mac_address"

--- a/core/schemas/observables/md5.py
+++ b/core/schemas/observables/md5.py
@@ -6,7 +6,7 @@ from core.schemas import observable
 
 
 class MD5(observable.Observable):
-    type: Literal[observable.ObservableType.md5] = observable.ObservableType.md5
+    type: Literal["md5"] = "md5"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/mutex.py
+++ b/core/schemas/observables/mutex.py
@@ -4,4 +4,4 @@ from core.schemas import observable
 
 
 class Mutex(observable.Observable):
-    type: Literal[observable.ObservableType.mutex] = observable.ObservableType.mutex
+    type: Literal["mutex"] = "mutex"

--- a/core/schemas/observables/named_pipe.py
+++ b/core/schemas/observables/named_pipe.py
@@ -4,6 +4,4 @@ from core.schemas import observable
 
 
 class NamedPipe(observable.Observable):
-    type: Literal[observable.ObservableType.named_pipe] = (
-        observable.ObservableType.named_pipe
-    )
+    type: Literal["named_pipe"] = "named_pipe"

--- a/core/schemas/observables/package.py
+++ b/core/schemas/observables/package.py
@@ -4,6 +4,6 @@ from core.schemas import observable
 
 
 class Package(observable.Observable):
-    type: Literal[observable.ObservableType.package] = observable.ObservableType.package
+    type: Literal["package"] = "package"
     version: str = None
     regitry_type: str = None

--- a/core/schemas/observables/path.py
+++ b/core/schemas/observables/path.py
@@ -10,7 +10,7 @@ WINDOWS_PATH_REGEX = re.compile(
 
 
 class Path(observable.Observable):
-    type: Literal[observable.ObservableType.path] = observable.ObservableType.path
+    type: Literal["path"] = "path"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/registry_key.py
+++ b/core/schemas/observables/registry_key.py
@@ -26,9 +26,7 @@ class RegistryKey(observable.Observable):
         path_file: The filesystem path to the file that contains the registry key value.
     """
 
-    type: Literal[observable.ObservableType.registry_key] = (
-        observable.ObservableType.registry_key
-    )
+    type: Literal["registry_key"] = "registry_key"
     key: str
     data: bytes
     hive: RegistryHive

--- a/core/schemas/observables/sha1.py
+++ b/core/schemas/observables/sha1.py
@@ -6,7 +6,7 @@ from core.schemas import observable
 
 
 class SHA1(observable.Observable):
-    type: Literal[observable.ObservableType.sha1] = observable.ObservableType.sha1
+    type: Literal["sha1"] = "sha1"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/sha256.py
+++ b/core/schemas/observables/sha256.py
@@ -6,7 +6,7 @@ from core.schemas import observable
 
 
 class SHA256(observable.Observable):
-    type: Literal[observable.ObservableType.sha256] = observable.ObservableType.sha256
+    type: Literal["sha256"] = "sha256"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/ssdeep.py
+++ b/core/schemas/observables/ssdeep.py
@@ -4,4 +4,4 @@ from core.schemas import observable
 
 
 class Ssdeep(observable.Observable):
-    type: Literal[observable.ObservableType.ssdeep] = observable.ObservableType.ssdeep
+    type: Literal["ssdeep"] = "ssdeep"

--- a/core/schemas/observables/tlsh.py
+++ b/core/schemas/observables/tlsh.py
@@ -4,4 +4,4 @@ from core.schemas import observable
 
 
 class TLSH(observable.Observable):
-    type: Literal[observable.ObservableType.tlsh] = observable.ObservableType.tlsh
+    type: Literal["tlsh"] = "tlsh"

--- a/core/schemas/observables/url.py
+++ b/core/schemas/observables/url.py
@@ -6,7 +6,7 @@ from core.schemas import observable
 
 
 class Url(observable.Observable):
-    type: Literal[observable.ObservableType.url] = observable.ObservableType.url
+    type: Literal["url"] = "url"
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/core/schemas/observables/user_account.py
+++ b/core/schemas/observables/user_account.py
@@ -14,9 +14,7 @@ class UserAccount(observable.Observable):
     Value should to be in the form <ACCOUNT_TYPE>:<ACCOUNT_LOGIN>.
     """
 
-    type: Literal[observable.ObservableType.user_account] = (
-        observable.ObservableType.user_account
-    )
+    type: Literal["user_account"] = "user_account"
     user_id: str | None = None
     credential: str | None = None
     account_login: str | None = None

--- a/core/schemas/observables/user_agent.py
+++ b/core/schemas/observables/user_agent.py
@@ -4,6 +4,4 @@ from core.schemas import observable
 
 
 class UserAgent(observable.Observable):
-    type: Literal[observable.ObservableType.user_agent] = (
-        observable.ObservableType.user_agent
-    )
+    type: Literal["user_agent"] = "user_agent"

--- a/core/schemas/observables/wallet.py
+++ b/core/schemas/observables/wallet.py
@@ -10,6 +10,6 @@ class Wallet(observable.Observable):
     Value should be in the form <COIN>:<ADDRESS>.
     """
 
-    type: Literal[observable.ObservableType.wallet] = observable.ObservableType.wallet
+    type: Literal["wallet"] = "wallet"
     coin: str | None = None
     address: str | None = None

--- a/tests/schemas/observable.py
+++ b/tests/schemas/observable.py
@@ -10,7 +10,7 @@ from core.schemas.observables import (
     certificate,
     cidr,
     command_line,
-    docker_image,
+    container_image,
     email,
     file,
     generic,
@@ -336,10 +336,12 @@ class ObservableTest(unittest.TestCase):
 
     def test_create_docker_image(self) -> None:
         """Tests creating a docker image."""
-        observable = docker_image.DockerImage(value="yetiplatform/yeti:latest").save()
+        observable = container_image.DockerImage(
+            value="yetiplatform/yeti:latest"
+        ).save()
         self.assertIsNotNone(observable.id)
         self.assertEqual(observable.value, "yetiplatform/yeti:latest")
-        self.assertIsInstance(observable, docker_image.DockerImage)
+        self.assertIsInstance(observable, container_image.DockerImage)
 
     def test_create_email(self) -> None:
         """Tests creating an email."""


### PR DESCRIPTION
This PR improves schemas loader by handling all classes defined in one file. Previous version only handled one class registration. It also implements generic functions to build schemas enums and types mapping. 