### PR TITLE
Switch I/O bound path operation functions to non-async

### DIFF
--- a/core/web/apiv2/auth.py
+++ b/core/web/apiv2/auth.py
@@ -188,9 +188,9 @@ if AUTH_MODULE == "oidc":
     @router.post("/oidc-callback-token")
     async def oidc_api_callback(request: Request):
         try:
-            req_body = request.body()
+            req_body = await request.body()
             id_token = json.loads(req_body)["id_token"]
-            idinfo = await google_oauth_id_token.verify_oauth2_token(
+            idinfo = google_oauth_id_token.verify_oauth2_token(
                 id_token, google_requests.Request()
             )
         except (google_exceptions.GoogleAuthError, ValueError, KeyError) as error:

--- a/core/web/apiv2/auth.py
+++ b/core/web/apiv2/auth.py
@@ -76,7 +76,7 @@ def create_access_token(data: dict, expires_delta: datetime.timedelta | None = N
     return encoded_jwt
 
 
-async def get_current_user(
+def get_current_user(
     request: Request,
     token: str = Depends(oauth2_scheme),
     cookie: str = Security(cookie_scheme),
@@ -107,7 +107,7 @@ async def get_current_user(
     return user
 
 
-async def get_current_active_user(current_user: User = Security(get_current_user)):
+def get_current_active_user(current_user: User = Security(get_current_user)):
     if not current_user.enabled:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -127,7 +127,7 @@ class GetCurrentUserWithPermissions:
     def __init__(self, admin: bool):
         self.admin = admin
 
-    async def __call__(self, user: User = Depends(get_current_user)) -> User:
+    def __call__(self, user: User = Depends(get_current_user)) -> User:
         if not user.admin:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
@@ -188,9 +188,9 @@ if AUTH_MODULE == "oidc":
     @router.post("/oidc-callback-token")
     async def oidc_api_callback(request: Request):
         try:
-            req_body = await request.body()
+            req_body = request.body()
             id_token = json.loads(req_body)["id_token"]
-            idinfo = google_oauth_id_token.verify_oauth2_token(
+            idinfo = await google_oauth_id_token.verify_oauth2_token(
                 id_token, google_requests.Request()
             )
         except (google_exceptions.GoogleAuthError, ValueError, KeyError) as error:
@@ -238,9 +238,7 @@ if AUTH_MODULE == "oidc":
 if AUTH_MODULE == "local":
 
     @router.post("/token")
-    async def login(
-        response: Response, form_data: OAuth2PasswordRequestForm = Depends()
-    ):
+    def login(response: Response, form_data: OAuth2PasswordRequestForm = Depends()):
         if not YETI_AUTH:
             user = UserSensitive.find(username="yeti")
             if not user:
@@ -271,7 +269,7 @@ if AUTH_MODULE == "local":
 
 
 @router.post("/api-token")
-async def login_api(x_yeti_api_key: str = Security(api_key_header)):
+def login_api(x_yeti_api_key: str = Security(api_key_header)):
     user = UserSensitive.find(api_key=x_yeti_api_key)
     if not user:
         raise HTTPException(
@@ -295,7 +293,7 @@ async def login_api(x_yeti_api_key: str = Security(api_key_header)):
 
 
 @router.get("/me")
-async def me(current_user: User = Depends(get_current_user)) -> User:
+def me(current_user: User = Depends(get_current_user)) -> User:
     return current_user
 
 

--- a/core/web/apiv2/auth.py
+++ b/core/web/apiv2/auth.py
@@ -238,7 +238,9 @@ if AUTH_MODULE == "oidc":
 if AUTH_MODULE == "local":
 
     @router.post("/token")
-    def login(response: Response, form_data: OAuth2PasswordRequestForm = Depends()):
+    def login(
+        response: Response, form_data: OAuth2PasswordRequestForm = Depends()
+    ) -> dict[str, str]:
         if not YETI_AUTH:
             user = UserSensitive.find(username="yeti")
             if not user:
@@ -269,7 +271,7 @@ if AUTH_MODULE == "local":
 
 
 @router.post("/api-token")
-def login_api(x_yeti_api_key: str = Security(api_key_header)):
+def login_api(x_yeti_api_key: str = Security(api_key_header)) -> dict[str, str]:
     user = UserSensitive.find(api_key=x_yeti_api_key)
     if not user:
         raise HTTPException(
@@ -298,6 +300,6 @@ def me(current_user: User = Depends(get_current_user)) -> User:
 
 
 @router.post("/logout")
-async def logout(response: Response):
+async def logout(response: Response) -> dict[str, str]:
     response.delete_cookie(key="yeti_session")
     return {"message": "Logged out"}

--- a/core/web/apiv2/dfiq.py
+++ b/core/web/apiv2/dfiq.py
@@ -94,10 +94,10 @@ def config() -> DFIQConfigResponse:
 
 
 @router.post("/from_archive")
-def from_archive(archive: UploadFile) -> dict[str, int]:
+async def from_archive(archive: UploadFile) -> dict[str, int]:
     """Uncompresses a ZIP archive and processes the DFIQ content inside it."""
     tempdir = tempfile.TemporaryDirectory()
-    contents = archive.file.read()
+    contents = await archive.read()
     ZipFile(BytesIO(contents)).extractall(path=tempdir.name)
     total_added = dfiq.read_from_data_directory(f"{tempdir.name}/*/*.yaml")
     return {"total_added": total_added}

--- a/core/web/apiv2/dfiq.py
+++ b/core/web/apiv2/dfiq.py
@@ -97,7 +97,7 @@ def config() -> DFIQConfigResponse:
 def from_archive(archive: UploadFile) -> dict[str, int]:
     """Uncompresses a ZIP archive and processes the DFIQ content inside it."""
     tempdir = tempfile.TemporaryDirectory()
-    contents = archive.read()
+    contents = archive.file.read()
     ZipFile(BytesIO(contents)).extractall(path=tempdir.name)
     total_added = dfiq.read_from_data_directory(f"{tempdir.name}/*/*.yaml")
     return {"total_added": total_added}

--- a/core/web/apiv2/dfiq.py
+++ b/core/web/apiv2/dfiq.py
@@ -70,7 +70,7 @@ router = APIRouter()
 
 
 @router.get("/config")
-async def config() -> DFIQConfigResponse:
+def config() -> DFIQConfigResponse:
     all_questions = dfiq.DFIQQuestion.list()
 
     stage_types = set()
@@ -94,17 +94,17 @@ async def config() -> DFIQConfigResponse:
 
 
 @router.post("/from_archive")
-async def from_archive(archive: UploadFile) -> dict[str, int]:
+def from_archive(archive: UploadFile) -> dict[str, int]:
     """Uncompresses a ZIP archive and processes the DFIQ content inside it."""
     tempdir = tempfile.TemporaryDirectory()
-    contents = await archive.read()
+    contents = archive.read()
     ZipFile(BytesIO(contents)).extractall(path=tempdir.name)
     total_added = dfiq.read_from_data_directory(f"{tempdir.name}/*/*.yaml")
     return {"total_added": total_added}
 
 
 @router.post("/from_yaml")
-async def new_from_yaml(request: NewDFIQRequest) -> dfiq.DFIQTypes:
+def new_from_yaml(request: NewDFIQRequest) -> dfiq.DFIQTypes:
     """Creates a new DFIQ object in the database."""
     try:
         new = dfiq.TYPE_MAPPING[request.dfiq_type].from_yaml(request.dfiq_yaml)
@@ -154,7 +154,7 @@ async def new_from_yaml(request: NewDFIQRequest) -> dfiq.DFIQTypes:
 
 
 @router.post("/to_archive")
-async def to_archive(request: DFIQSearchRequest) -> FileResponse:
+def to_archive(request: DFIQSearchRequest) -> FileResponse:
     """Compresses DFIQ objects into a ZIP archive.
 
     The structure of the archive is as follows:
@@ -229,7 +229,7 @@ async def to_archive(request: DFIQSearchRequest) -> FileResponse:
 
 
 @router.post("/validate")
-async def validate_dfiq_yaml(request: DFIQValidateRequest) -> DFIQValidateResponse:
+def validate_dfiq_yaml(request: DFIQValidateRequest) -> DFIQValidateResponse:
     """Validates a DFIQ YAML string."""
     try:
         obj = dfiq.TYPE_MAPPING[request.dfiq_type].from_yaml(request.dfiq_yaml)
@@ -263,7 +263,7 @@ async def validate_dfiq_yaml(request: DFIQValidateRequest) -> DFIQValidateRespon
 
 
 @router.patch("/{dfiq_id}")
-async def patch(request: PatchDFIQRequest, dfiq_id) -> dfiq.DFIQTypes:
+def patch(request: PatchDFIQRequest, dfiq_id) -> dfiq.DFIQTypes:
     """Modifies an DFIQ object in the database."""
     db_dfiq: dfiq.DFIQTypes = dfiq.DFIQBase.get(dfiq_id)  # type: ignore
     if not db_dfiq:
@@ -290,7 +290,7 @@ async def patch(request: PatchDFIQRequest, dfiq_id) -> dfiq.DFIQTypes:
 
 
 @router.get("/{dfiq_id}")
-async def details(dfiq_id) -> dfiq.DFIQTypes:
+def details(dfiq_id) -> dfiq.DFIQTypes:
     """Returns details about a DFIQ object."""
     db_dfiq: dfiq.DFIQTypes = dfiq.DFIQBase.get(dfiq_id)  # type: ignore
     if not db_dfiq:
@@ -299,7 +299,7 @@ async def details(dfiq_id) -> dfiq.DFIQTypes:
 
 
 @router.delete("/{dfiq_id}")
-async def delete(dfiq_id: str) -> None:
+def delete(dfiq_id: str) -> None:
     """Deletes a DFIQ object."""
     db_dfiq = dfiq.DFIQBase.get(dfiq_id)
     if not db_dfiq:
@@ -321,7 +321,7 @@ async def delete(dfiq_id: str) -> None:
 
 
 @router.post("/search")
-async def search(request: DFIQSearchRequest) -> DFIQSearchResponse:
+def search(request: DFIQSearchRequest) -> DFIQSearchResponse:
     """Searches for DFIQ objects."""
     query = request.query
     if request.type:

--- a/core/web/apiv2/dfiq.py
+++ b/core/web/apiv2/dfiq.py
@@ -94,10 +94,10 @@ def config() -> DFIQConfigResponse:
 
 
 @router.post("/from_archive")
-async def from_archive(archive: UploadFile) -> dict[str, int]:
+def from_archive(archive: UploadFile) -> dict[str, int]:
     """Uncompresses a ZIP archive and processes the DFIQ content inside it."""
     tempdir = tempfile.TemporaryDirectory()
-    contents = await archive.read()
+    contents = archive.file.read()
     ZipFile(BytesIO(contents)).extractall(path=tempdir.name)
     total_added = dfiq.read_from_data_directory(f"{tempdir.name}/*/*.yaml")
     return {"total_added": total_added}

--- a/core/web/apiv2/entities.py
+++ b/core/web/apiv2/entities.py
@@ -58,7 +58,7 @@ router = APIRouter()
 
 
 @router.post("/")
-async def new(request: NewEntityRequest) -> EntityTypes:
+def new(request: NewEntityRequest) -> EntityTypes:
     """Creates a new entity in the database."""
     new = request.entity.save()
     if request.tags:
@@ -67,7 +67,7 @@ async def new(request: NewEntityRequest) -> EntityTypes:
 
 
 @router.patch("/{entity_id}")
-async def patch(request: PatchEntityRequest, entity_id) -> EntityTypes:
+def patch(request: PatchEntityRequest, entity_id) -> EntityTypes:
     """Modifies entity in the database."""
     db_entity: EntityTypes = Entity.get(entity_id)
     if not db_entity:
@@ -84,7 +84,7 @@ async def patch(request: PatchEntityRequest, entity_id) -> EntityTypes:
 
 
 @router.get("/{entity_id}")
-async def details(entity_id) -> EntityTypes:
+def details(entity_id) -> EntityTypes:
     """Returns details about an observable."""
     db_entity: EntityTypes = Entity.get(entity_id)  # type: ignore
     if not db_entity:
@@ -94,7 +94,7 @@ async def details(entity_id) -> EntityTypes:
 
 
 @router.delete("/{entity_id}")
-async def delete(entity_id: str) -> None:
+def delete(entity_id: str) -> None:
     """Deletes an Entity."""
     db_entity = Entity.get(entity_id)
     if not db_entity:
@@ -103,7 +103,7 @@ async def delete(entity_id: str) -> None:
 
 
 @router.post("/search")
-async def search(request: EntitySearchRequest) -> EntitySearchResponse:
+def search(request: EntitySearchRequest) -> EntitySearchResponse:
     """Searches for observables."""
     query = request.query
     tags = query.pop("tags", [])
@@ -122,7 +122,7 @@ async def search(request: EntitySearchRequest) -> EntitySearchResponse:
 
 
 @router.post("/tag")
-async def tag(request: EntityTagRequest) -> EntityTagResponse:
+def tag(request: EntityTagRequest) -> EntityTagResponse:
     """Tags entities."""
     entities = []
     for entity_id in request.ids:

--- a/core/web/apiv2/graph.py
+++ b/core/web/apiv2/graph.py
@@ -122,7 +122,7 @@ router = APIRouter()
 
 
 @router.post("/search")
-async def search(request: GraphSearchRequest) -> GraphSearchResponse:
+def search(request: GraphSearchRequest) -> GraphSearchResponse:
     """Fetches neighbros for a given Yeti Object."""
     object_type, object_id = request.source.split("/")
     if object_type not in GRAPH_TYPE_MAPPINGS:
@@ -151,7 +151,7 @@ async def search(request: GraphSearchRequest) -> GraphSearchResponse:
 
 
 @router.post("/add")
-async def add(request: GraphAddRequest) -> graph.Relationship:
+def add(request: GraphAddRequest) -> graph.Relationship:
     """Adds a link to the graph."""
     source_type, source_id = request.source.split("/")
     target_type, target_id = request.target.split("/")
@@ -174,7 +174,7 @@ async def add(request: GraphAddRequest) -> graph.Relationship:
 
 
 @router.patch("/{relationship_id}")
-async def edit(relationship_id: str, request: GraphPatchRequest) -> graph.Relationship:
+def edit(relationship_id: str, request: GraphPatchRequest) -> graph.Relationship:
     """Edits a Relationship in the graph."""
     relationship = graph.Relationship.get(relationship_id)
     if relationship is None:
@@ -190,7 +190,7 @@ async def edit(relationship_id: str, request: GraphPatchRequest) -> graph.Relati
 
 
 @router.post("/{relationship_id}/swap")
-async def swap(relationship_id: str) -> graph.Relationship:
+def swap(relationship_id: str) -> graph.Relationship:
     """Swaps the source and target of a relationship."""
     relationship = graph.Relationship.get(relationship_id)
     if relationship is None:
@@ -202,7 +202,7 @@ async def swap(relationship_id: str) -> graph.Relationship:
 
 
 @router.delete("/{relationship_id}")
-async def delete(relationship_id: str) -> None:
+def delete(relationship_id: str) -> None:
     """Deletes a link from the graph."""
     relationship = graph.Relationship.get(relationship_id)
     if relationship is None:
@@ -230,7 +230,7 @@ class AnalysisResponse(BaseModel):
 
 
 @router.post("/match")
-async def match(request: AnalysisRequest) -> AnalysisResponse:
+def match(request: AnalysisRequest) -> AnalysisResponse:
     """Fetches neighbors for a given Yeti Object."""
 
     entities = []  # type: list[tuple[graph.Relationship, entity.Entity]]

--- a/core/web/apiv2/import_data.py
+++ b/core/web/apiv2/import_data.py
@@ -4,7 +4,7 @@ router = APIRouter()
 
 
 @router.post("/import_misp_json", tags=["import_misp_json"])
-async def import_misp_json(misp_file_json: UploadFile = File(...)):
+def import_misp_json(misp_file_json: UploadFile = File(...)):
     # contents = await misp_file_json.read()
     # data_json = json.loads(contents)
 

--- a/core/web/apiv2/import_data.py
+++ b/core/web/apiv2/import_data.py
@@ -4,7 +4,7 @@ router = APIRouter()
 
 
 @router.post("/import_misp_json", tags=["import_misp_json"])
-def import_misp_json(misp_file_json: UploadFile = File(...)):
+def import_misp_json(misp_file_json: UploadFile = File(...)) -> dict[str, bool]:
     # contents = await misp_file_json.read()
     # data_json = json.loads(contents)
 

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -62,14 +62,14 @@ router = APIRouter()
 
 
 @router.post("/")
-async def new(request: NewIndicatorRequest) -> IndicatorTypes:
+def new(request: NewIndicatorRequest) -> IndicatorTypes:
     """Creates a new indicator in the database."""
     new = request.indicator.save()
     return new
 
 
 @router.patch("/{indicator_id}")
-async def patch(request: PatchIndicatorRequest, indicator_id) -> IndicatorTypes:
+def patch(request: PatchIndicatorRequest, indicator_id) -> IndicatorTypes:
     """Modifies an indicator in the database."""
     db_indicator: IndicatorTypes = Indicator.get(indicator_id)  # type: ignore
     if not db_indicator:
@@ -93,7 +93,7 @@ async def patch(request: PatchIndicatorRequest, indicator_id) -> IndicatorTypes:
 
 
 @router.get("/{indicator_id}")
-async def details(indicator_id) -> IndicatorTypes:
+def details(indicator_id) -> IndicatorTypes:
     """Returns details about an indicator."""
     db_indicator: IndicatorTypes = Indicator.get(indicator_id)  # type: ignore
     if not db_indicator:
@@ -103,7 +103,7 @@ async def details(indicator_id) -> IndicatorTypes:
 
 
 @router.delete("/{indicator_id}")
-async def delete(indicator_id: str) -> None:
+def delete(indicator_id: str) -> None:
     """Deletes an indicator."""
     db_indicator = Indicator.get(indicator_id)
     if not db_indicator:
@@ -114,7 +114,7 @@ async def delete(indicator_id: str) -> None:
 
 
 @router.post("/search")
-async def search(request: IndicatorSearchRequest) -> IndicatorSearchResponse:
+def search(request: IndicatorSearchRequest) -> IndicatorSearchResponse:
     """Searches for indicators."""
     query = request.query
     tags = query.pop("tags", [])
@@ -133,7 +133,7 @@ async def search(request: IndicatorSearchRequest) -> IndicatorSearchResponse:
 
 
 @router.post("/tag")
-async def tag(request: IndicatorTagRequest) -> IndicatorTagResponse:
+def tag(request: IndicatorTagRequest) -> IndicatorTagResponse:
     """Tags entities."""
     indicators = []
     for indicator_id in request.ids:

--- a/core/web/apiv2/observables.py
+++ b/core/web/apiv2/observables.py
@@ -123,12 +123,12 @@ router = APIRouter()
 
 
 @router.get("/")
-async def observables_root() -> Iterable[Observable]:
+def observables_root() -> Iterable[Observable]:
     return Observable.list()
 
 
 @router.post("/")
-async def new(request: NewObservableRequest) -> ObservableTypes:
+def new(request: NewObservableRequest) -> ObservableTypes:
     """Creates a new observable in the database.
 
     Raises:
@@ -151,7 +151,7 @@ async def new(request: NewObservableRequest) -> ObservableTypes:
 
 
 @router.post("/extended")
-async def new_extended(request: NewExtendedObservableRequest) -> ObservableTypes:
+def new_extended(request: NewExtendedObservableRequest) -> ObservableTypes:
     """Creates a new observable in the database with extended properties.
 
     Raises:
@@ -174,7 +174,7 @@ async def new_extended(request: NewExtendedObservableRequest) -> ObservableTypes
 
 
 @router.patch("/{observable_id}")
-async def patch(request: PatchObservableRequest, observable_id) -> ObservableTypes:
+def patch(request: PatchObservableRequest, observable_id) -> ObservableTypes:
     """Modifies observable in the database."""
     db_observable = Observable.get(observable_id)
     if not db_observable:
@@ -193,7 +193,7 @@ async def patch(request: PatchObservableRequest, observable_id) -> ObservableTyp
 
 
 @router.post("/bulk")
-async def bulk_add(request: NewBulkObservableAddRequest) -> BulkObservableAddResponse:
+def bulk_add(request: NewBulkObservableAddRequest) -> BulkObservableAddResponse:
     """Bulk-creates new observables in the database."""
     response = BulkObservableAddResponse()
     for new_observable in request.observables:
@@ -216,7 +216,7 @@ async def bulk_add(request: NewBulkObservableAddRequest) -> BulkObservableAddRes
 
 
 @router.get("/{observable_id}")
-async def details(observable_id) -> ObservableTypes:
+def details(observable_id) -> ObservableTypes:
     """Returns details about an observable."""
     observable_obj = Observable.get(observable_id)
     if not observable_obj:
@@ -226,7 +226,7 @@ async def details(observable_id) -> ObservableTypes:
 
 
 @router.post("/{observable_id}/context")
-async def add_context(observable_id, request: AddContextRequest) -> ObservableTypes:
+def add_context(observable_id, request: AddContextRequest) -> ObservableTypes:
     """Adds context to an observable."""
     observable_obj = Observable.get(observable_id)
     if not observable_obj:
@@ -241,9 +241,7 @@ async def add_context(observable_id, request: AddContextRequest) -> ObservableTy
 
 
 @router.post("/{observable_id}/context/delete")
-async def delete_context(
-    observable_id, request: DeleteContextRequest
-) -> ObservableTypes:
+def delete_context(observable_id, request: DeleteContextRequest) -> ObservableTypes:
     """Removes context to an observable."""
     observable_obj = Observable.get(observable_id)
     if not observable_obj:
@@ -258,7 +256,7 @@ async def delete_context(
 
 
 @router.post("/search")
-async def search(request: ObservableSearchRequest) -> ObservableSearchResponse:
+def search(request: ObservableSearchRequest) -> ObservableSearchResponse:
     """Searches for observables."""
     query = request.query
     tags = query.pop("tags", [])
@@ -276,7 +274,7 @@ async def search(request: ObservableSearchRequest) -> ObservableSearchResponse:
 
 
 @router.post("/add_text", deprecated=True)
-async def add_text(request: AddTextRequest) -> ObservableTypes:
+def add_text(request: AddTextRequest) -> ObservableTypes:
     """Adds and returns an observable for a given string, attempting to guess
     its type."""
     try:
@@ -286,7 +284,7 @@ async def add_text(request: AddTextRequest) -> ObservableTypes:
 
 
 @router.post("/import/text")
-async def import_from_text(request: ImportTextRequest) -> BulkObservableAddResponse:
+def import_from_text(request: ImportTextRequest) -> BulkObservableAddResponse:
     """Adds and returns an observable for a given string, attempting to guess
     its type."""
     try:
@@ -300,7 +298,7 @@ async def import_from_text(request: ImportTextRequest) -> BulkObservableAddRespo
 
 
 @router.post("/import/url")
-async def import_from_url(request: ImportUrlRequest) -> BulkObservableAddResponse:
+def import_from_url(request: ImportUrlRequest) -> BulkObservableAddResponse:
     """Adds and returns observables from a given url, attempting to guess
     their types."""
     if not validators.url(request.text):
@@ -333,7 +331,7 @@ def import_from_file(
 
 
 @router.post("/tag")
-async def tag_observable(request: ObservableTagRequest) -> ObservableTagResponse:
+def tag_observable(request: ObservableTagRequest) -> ObservableTagResponse:
     """Tags a set of observables, individually or in bulk."""
     observables = []
     for observable_id in request.ids:
@@ -354,7 +352,7 @@ async def tag_observable(request: ObservableTagRequest) -> ObservableTagResponse
 
 
 @router.delete("/{observable_id}")
-async def delete(observable_id: str) -> None:
+def delete(observable_id: str) -> None:
     """Deletes an observable."""
     observable_obj = Observable.get(observable_id)
     if not observable_obj:

--- a/core/web/apiv2/system.py
+++ b/core/web/apiv2/system.py
@@ -33,7 +33,7 @@ class SystemConfigResponse(BaseModel):
 
 
 @router.get("/config")
-async def get_config() -> SystemConfigResponse:
+def get_config() -> SystemConfigResponse:
     """Gets the system config."""
     config = SystemConfigResponse(
         auth={
@@ -46,7 +46,7 @@ async def get_config() -> SystemConfigResponse:
 
 
 @router.get("/workers", dependencies=[Depends(get_current_active_user)])
-async def get_worker_status() -> WorkerStatusResponse:
+def get_worker_status() -> WorkerStatusResponse:
     inspect = app.control.inspect(timeout=5, destination=None)
 
     registered = {}
@@ -68,7 +68,7 @@ async def get_worker_status() -> WorkerStatusResponse:
 @router.post(
     "/restartworker/{worker_name}", dependencies=[Depends(get_current_active_user)]
 )
-async def restart_worker(worker_name: str) -> WorkerRestartResponse:
+def restart_worker(worker_name: str) -> WorkerRestartResponse:
     """Restarts a single or all Celery workers."""
     destination = [worker_name] if worker_name != "all" else None
     response = app.control.broadcast(

--- a/core/web/apiv2/tag.py
+++ b/core/web/apiv2/tag.py
@@ -59,7 +59,7 @@ router = APIRouter()
 
 
 @router.post("/")
-async def new(request: NewRequest) -> Tag:
+def new(request: NewRequest) -> Tag:
     """Creates a new observable in the database."""
     tag = Tag(
         name=request.name,
@@ -73,7 +73,7 @@ async def new(request: NewRequest) -> Tag:
 
 
 @router.get("/{tag_id}")
-async def details(tag_id: str) -> Tag:
+def details(tag_id: str) -> Tag:
     """Returns details about a Tag."""
     tag = Tag.get(tag_id)
     if not tag:
@@ -82,7 +82,7 @@ async def details(tag_id: str) -> Tag:
 
 
 @router.put("/{tag_id}")
-async def update(tag_id: str, request: UpdateRequest) -> Tag:
+def update(tag_id: str, request: UpdateRequest) -> Tag:
     """Updates an observable."""
     tag = Tag.get(tag_id)
     if not tag:
@@ -97,7 +97,7 @@ async def update(tag_id: str, request: UpdateRequest) -> Tag:
 
 
 @router.post("/search")
-async def search(request: TagSearchRequest) -> TagSearchResponse:
+def search(request: TagSearchRequest) -> TagSearchResponse:
     """Searches for Tags."""
     request_args = request.model_dump(exclude_unset=True)
     count = request_args.pop("count")
@@ -107,7 +107,7 @@ async def search(request: TagSearchRequest) -> TagSearchResponse:
 
 
 @router.delete("/{tag_id}")
-async def delete(tag_id: str) -> None:
+def delete(tag_id: str) -> None:
     """Deletes a Tag."""
     tag = Tag.get(tag_id)
     if not tag:
@@ -116,7 +116,7 @@ async def delete(tag_id: str) -> None:
 
 
 @router.post("/merge")
-async def merge(request: MergeTagRequest) -> MergeTagResult:
+def merge(request: MergeTagRequest) -> MergeTagResult:
     target_tag = Tag.find(name=request.merge_into)
     if not target_tag:
         raise HTTPException(

--- a/core/web/apiv2/tasks.py
+++ b/core/web/apiv2/tasks.py
@@ -44,7 +44,7 @@ router = APIRouter()
 
 
 @router.post("/{task_name}/run")
-def run(task_name, params: TaskParams | None = None) -> dict:
+def run(task_name, params: TaskParams | None = None) -> dict[str, str]:
     """Runs a task asynchronously."""
     if params is None:
         params = TaskParams()
@@ -112,7 +112,7 @@ def patch_export(export_name: str, request: PatchExportRequest) -> ExportTask:
 
 
 @router.get("/export/{export_id}/content")
-def export_content(export_id: str):
+def export_content(export_id: str) -> StreamingResponse:
     """Downloads the latest contents of a given ExportTask."""
     export = ExportTask.get(export_id)
     if not export:
@@ -127,7 +127,7 @@ def export_content(export_id: str):
 
 
 @router.delete("/export/{export_name}")
-def delete_export(export_name: str):
+def delete_export(export_name: str) -> dict[str, str]:
     """Deletes an ExportTask."""
     export = ExportTask.find(name=export_name)
     if not export:

--- a/core/web/apiv2/tasks.py
+++ b/core/web/apiv2/tasks.py
@@ -44,7 +44,7 @@ router = APIRouter()
 
 
 @router.post("/{task_name}/run")
-async def run(task_name, params: TaskParams | None = None) -> dict:
+def run(task_name, params: TaskParams | None = None) -> dict:
     """Runs a task asynchronously."""
     if params is None:
         params = TaskParams()
@@ -53,7 +53,7 @@ async def run(task_name, params: TaskParams | None = None) -> dict:
 
 
 @router.post("/{task_name}/toggle")
-async def toggle(task_name) -> TaskTypes:
+def toggle(task_name) -> TaskTypes:
     """Toggles the enabled status on a task."""
     db_task: Task = Task.find(name=task_name)  # type: ignore
     db_task.enabled = not db_task.enabled
@@ -62,7 +62,7 @@ async def toggle(task_name) -> TaskTypes:
 
 
 @router.post("/search")
-async def search(request: TaskSearchRequest) -> TaskSearchResponse:
+def search(request: TaskSearchRequest) -> TaskSearchResponse:
     """Searches for tasks."""
     query = request.query
     if request.type:
@@ -77,7 +77,7 @@ async def search(request: TaskSearchRequest) -> TaskSearchResponse:
 
 
 @router.post("/export/new")
-async def new_export(request: NewExportRequest) -> ExportTask:
+def new_export(request: NewExportRequest) -> ExportTask:
     """Creates a new ExportTask in the database."""
     template = Template.find(name=request.export.template_name)
     if not template:
@@ -90,7 +90,7 @@ async def new_export(request: NewExportRequest) -> ExportTask:
 
 
 @router.patch("/export/{export_name}")
-async def patch_export(export_name: str, request: PatchExportRequest) -> ExportTask:
+def patch_export(export_name: str, request: PatchExportRequest) -> ExportTask:
     """Pathes an existing ExportTask in the database."""
     db_export = ExportTask.find(name=export_name)
     if not db_export:
@@ -112,7 +112,7 @@ async def patch_export(export_name: str, request: PatchExportRequest) -> ExportT
 
 
 @router.get("/export/{export_id}/content")
-async def export_content(export_id: str):
+def export_content(export_id: str):
     """Downloads the latest contents of a given ExportTask."""
     export = ExportTask.get(export_id)
     if not export:
@@ -127,7 +127,7 @@ async def export_content(export_id: str):
 
 
 @router.delete("/export/{export_name}")
-async def delete_export(export_name: str):
+def delete_export(export_name: str):
     """Deletes an ExportTask."""
     export = ExportTask.find(name=export_name)
     if not export:

--- a/core/web/apiv2/templates.py
+++ b/core/web/apiv2/templates.py
@@ -45,7 +45,7 @@ router = APIRouter()
 
 
 @router.post("/search")
-async def search(request: TemplateSearchRequest) -> TemplateSearchResponse:
+def search(request: TemplateSearchRequest) -> TemplateSearchResponse:
     """Searches for observables."""
     glob = "*"
     if request.name:
@@ -70,7 +70,7 @@ async def search(request: TemplateSearchRequest) -> TemplateSearchResponse:
 
 
 @router.post("/render")
-async def render(request: RenderTemplateRequest) -> StreamingResponse:
+def render(request: RenderTemplateRequest) -> StreamingResponse:
     """Renders a template."""
     if not request.search_query and not request.observable_ids:
         raise HTTPException(

--- a/core/web/apiv2/users.py
+++ b/core/web/apiv2/users.py
@@ -60,7 +60,7 @@ router = APIRouter()
 
 
 @router.get("/{user_id}")
-async def get(user_id: str) -> User:
+def get(user_id: str) -> User:
     """Gets a user by ID."""
     user = UserSensitive.get(user_id)
     if not user:
@@ -69,7 +69,7 @@ async def get(user_id: str) -> User:
 
 
 @router.post("/search")
-async def search(request: SearchUserRequest) -> SearchUserResponse:
+def search(request: SearchUserRequest) -> SearchUserResponse:
     """Searches for users."""
     request_args = request.model_dump(exclude={"count", "page"})
     users, total = UserSensitive.filter(
@@ -79,7 +79,7 @@ async def search(request: SearchUserRequest) -> SearchUserResponse:
 
 
 @router.post("/toggle")
-async def toggle(
+def toggle(
     request: ToggleUserRequest,
     current_user: User = Depends(GetCurrentUserWithPermissions(admin=True)),
 ) -> User:
@@ -100,7 +100,7 @@ async def toggle(
 
 
 @router.post("/reset-api-key")
-async def reset_api_key(
+def reset_api_key(
     request: ResetApiKeyRequest, current_user: UserSensitive = Depends(get_current_user)
 ) -> User:
     """Resets a user's API key."""
@@ -118,7 +118,7 @@ async def reset_api_key(
 
 
 @router.post("/reset-password")
-async def reset_password(
+def reset_password(
     request: ResetPasswordRequest,
     current_user: UserSensitive = Depends(get_current_user),
 ) -> User:
@@ -138,7 +138,7 @@ async def reset_password(
 
 
 @router.delete("/{user_id}")
-async def delete(
+def delete(
     user_id: str,
     current_user: User = Depends(GetCurrentUserWithPermissions(admin=True)),
 ) -> None:
@@ -150,7 +150,7 @@ async def delete(
 
 
 @router.post("/")
-async def create(
+def create(
     request: NewUserRequest,
     current_user: User = Depends(GetCurrentUserWithPermissions(admin=True)),
 ) -> User:


### PR DESCRIPTION
This PR resolves web api performance issues by removing async usage on I/O bound (ArangoDB calls) path operation functions. Since backend does not support async calls, web api was not running concurrently. Switching to non-async definitions lets FastAPI run calls in awaited thread pool as explained in [documentation](https://fastapi.tiangolo.com/async/#in-a-hurry):

> If you are using a third party library that communicates with something (a database, an API, the file system, etc.) and doesn't have support for using await, (this is currently the case for most database libraries), then declare your path operation functions as normally, with just def.

Regarding technical details, this is how [FastAPI handles concurrency](https://fastapi.tiangolo.com/async/#path-operation-functions) with non-async path operation functions:

> When you declare a path operation function with normal def instead of async def, it is run in an external threadpool that is then awaited, instead of being called directly (as it would block the server).

Some path operation functions are still async because:
* they call others async functions and make non time-consuming calls to ArangoDB.
* they do not perform any ArangoDB calls.