### PR TITLE
Lazy validation

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -1098,7 +1098,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
         aql_args["@collection"] = colname
         logging.debug(f"aql_string: {aql_string}, aql_args: {aql_args}")
         documents = cls._db.aql.execute(
-            aql_string, bind_vars=aql_args, count=True, full_count=using_view
+            aql_string, bind_vars=aql_args, count=True, full_count=True
         )
         stats = documents.statistics()
         results = []

--- a/core/schemas/audit.py
+++ b/core/schemas/audit.py
@@ -1,13 +1,15 @@
 import datetime
 from typing import ClassVar, Literal
 
-from pydantic import computed_field
+from pydantic import ConfigDict, computed_field
 
 from core import database_arango
 from core.schemas.model import YetiModel
 
 
 class AuditLog(YetiModel, database_arango.ArangoYetiConnector):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
     _collection_name: ClassVar[str] = "auditlog"
     _type_filter: ClassVar[str | None] = None
     _root_type: Literal["auditlog"] = "auditlog"

--- a/core/schemas/entity.py
+++ b/core/schemas/entity.py
@@ -2,7 +2,7 @@ import datetime
 from enum import Enum
 from typing import ClassVar, List, Literal
 
-from pydantic import Field, computed_field
+from pydantic import ConfigDict, Field, computed_field
 
 from core import database_arango
 from core.helpers import now
@@ -19,6 +19,7 @@ TYPE_MAPPING = {}
 
 
 class Entity(YetiTagModel, database_arango.ArangoYetiConnector):
+    model_config = ConfigDict(str_strip_whitespace=True)
     _exclude_overwrite: list[str] = ["related_observables_count"]
     _collection_name: ClassVar[str] = "entities"
     _type_filter: ClassVar[str] = ""

--- a/core/schemas/graph.py
+++ b/core/schemas/graph.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import ClassVar, Literal
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, ConfigDict, computed_field
 
 from core import database_arango
 
@@ -9,6 +9,7 @@ from core import database_arango
 
 
 class GraphFilter(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
     key: str
     value: str
     operator: str
@@ -17,6 +18,7 @@ class GraphFilter(BaseModel):
 # Relationship and TagRelationship do not inherit from YetiModel
 # because they represent and id in the form of collection_name/id
 class Relationship(BaseModel, database_arango.ArangoYetiConnector):
+    model_config = ConfigDict(str_strip_whitespace=True)
     _exclude_overwrite: list[str] = list()
     _collection_name: ClassVar[str] = "links"
     _type_filter: ClassVar[str | None] = None
@@ -51,6 +53,7 @@ class Relationship(BaseModel, database_arango.ArangoYetiConnector):
 
 
 class TagRelationship(BaseModel, database_arango.ArangoYetiConnector):
+    model_config = ConfigDict(str_strip_whitespace=True)
     _exclude_overwrite: list[str] = list()
     _collection_name: ClassVar[str] = "tagged"
     _root_type: Literal["tag_relationship"] = "tag_relationship"

--- a/core/schemas/indicator.py
+++ b/core/schemas/indicator.py
@@ -3,7 +3,7 @@ import logging
 from enum import Enum
 from typing import ClassVar, List, Literal
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from core import database_arango
 from core.helpers import now
@@ -41,6 +41,7 @@ class DiamondModel(Enum):
 
 
 class Indicator(YetiTagModel, database_arango.ArangoYetiConnector):
+    model_config = ConfigDict(str_strip_whitespace=True)
     _collection_name: ClassVar[str] = "indicators"
     _type_filter: ClassVar[str] = ""
     _root_type: Literal["indicator"] = "indicator"

--- a/core/schemas/model.py
+++ b/core/schemas/model.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, ConfigDict, computed_field
 
 from core.schemas.graph import TagRelationship
 
@@ -10,6 +10,8 @@ class YetiModel(BaseModel):
     __id: str | None = None
     total_links: int | None = None
     aggregated_links: dict[str, dict[str, int]] | None = None
+
+    model_config = ConfigDict(str_strip_whitespace=True)
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/core/schemas/model.py
+++ b/core/schemas/model.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, computed_field
+from pydantic import BaseModel, computed_field
 
 from core.schemas.graph import TagRelationship
 
@@ -10,8 +10,6 @@ class YetiModel(BaseModel):
     __id: str | None = None
     total_links: int | None = None
     aggregated_links: dict[str, dict[str, int]] | None = None
-
-    model_config = ConfigDict(str_strip_whitespace=True)
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -58,7 +58,7 @@ class Observable(YetiTagModel, database_arango.ArangoYetiConnector):
         valid = True
         if hasattr(self, "validator"):
             try:
-                valid = self.__class__.validator(self.value)
+                valid = self.validator(self.value)
             except ValueError:
                 return False
         return valid

--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -14,7 +14,7 @@ from typing import IO, ClassVar, List, Literal, Tuple
 
 import requests
 from bs4 import BeautifulSoup
-from pydantic import Field, computed_field
+from pydantic import ConfigDict, Field, computed_field
 
 from core import database_arango
 from core.helpers import now, refang
@@ -32,6 +32,7 @@ FileLikeObject = str | os.PathLike | IO | tempfile.SpooledTemporaryFile
 
 
 class Observable(YetiTagModel, database_arango.ArangoYetiConnector):
+    model_config = ConfigDict(str_strip_whitespace=True)
     _collection_name: ClassVar[str] = "observables"
     _type_filter: ClassVar[str | None] = None
     _root_type: Literal["observable"] = "observable"

--- a/core/schemas/observables/bic.py
+++ b/core/schemas/observables/bic.py
@@ -11,9 +11,9 @@ BIC_MATCHER_REGEX = re.compile("^[A-Z]{6}[A-Z0-9]{2}[A-Z0-9]{3}?")
 class BIC(observable.Observable):
     type: Literal["bic"] = "bic"
 
-    @field_validator("value")
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        if not BIC_MATCHER_REGEX.match(value):
-            raise ValueError("Invalid BIC")
-        return value
+    def validator(cls, value: str) -> bool:
+        if BIC_MATCHER_REGEX.match(value):
+            return True
+        else:
+            return False

--- a/core/schemas/observables/email.py
+++ b/core/schemas/observables/email.py
@@ -9,10 +9,10 @@ from core.schemas import observable
 class Email(observable.Observable):
     type: Literal["email"] = "email"
 
-    @field_validator("value")
+    @field_validator("value", mode="before")
+    def refang(cls, v) -> str:
+        return observable.refang(v)
+
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        value = observable.refang(value)
-        if not validators.email(value):
-            raise ValueError("Invalid email address")
-        return value
+    def validator(cls, value: str) -> bool:
+        return validators.email(value) or False

--- a/core/schemas/observables/hostname.py
+++ b/core/schemas/observables/hostname.py
@@ -9,13 +9,13 @@ from core.schemas import observable
 class Hostname(observable.Observable):
     type: Literal["hostname"] = "hostname"
 
-    @field_validator("value")
+    @field_validator("value", mode="before")
+    def refang(cls, v) -> str:
+        return observable.refang(v)
+
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        value = observable.refang(value)
+    def validator(cls, value: str) -> bool:
         # Replace underscores with hyphens in the domain
         # https://stackoverflow.com/a/14622263
-        temp_value = value.replace("_", "-")
-        if not validators.domain(temp_value):
-            raise ValueError("Invalid hostname")
-        return value
+        value = value.replace("_", "-")
+        return validators.domain(value) or False

--- a/core/schemas/observables/iban.py
+++ b/core/schemas/observables/iban.py
@@ -9,10 +9,6 @@ from core.schemas import observable
 class IBAN(observable.Observable):
     type: Literal["iban"] = "iban"
 
-    @field_validator("value")
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        value = observable.refang(value)
-        if not validators.iban(value):
-            raise ValueError("Invalid IBAN")
-        return value
+    def validator(cls, value: str) -> bool:
+        return validators.iban(value) or False

--- a/core/schemas/observables/ipv4.py
+++ b/core/schemas/observables/ipv4.py
@@ -9,10 +9,10 @@ from core.schemas import observable
 class IPv4(observable.Observable):
     type: Literal["ipv4"] = "ipv4"
 
-    @field_validator("value")
+    @field_validator("value", mode="before")
+    def refang(cls, v) -> str:
+        return observable.refang(v)
+
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        value = observable.refang(value)
-        if not validators.ipv4(value):
-            raise ValueError("Invalid ipv4 address")
-        return value
+    def validator(cls, value: str) -> bool:
+        return validators.ipv4(value) or False

--- a/core/schemas/observables/ipv6.py
+++ b/core/schemas/observables/ipv6.py
@@ -9,10 +9,6 @@ from core.schemas import observable
 class IPv6(observable.Observable):
     type: Literal["ipv6"] = "ipv6"
 
-    @field_validator("value")
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        value = observable.refang(value)
-        if not validators.ipv6(value):
-            raise ValueError("Invalid ipv6 address")
-        return value
+    def validator(cls, value: str) -> bool:
+        return validators.ipv6(value) or False

--- a/core/schemas/observables/mac_address.py
+++ b/core/schemas/observables/mac_address.py
@@ -9,9 +9,6 @@ from core.schemas import observable
 class MacAddress(observable.Observable):
     type: Literal["mac_address"] = "mac_address"
 
-    @field_validator("value")
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        if not validators.mac_address(value):
-            raise ValueError("Invalid mac address")
-        return value
+    def validator(cls, value: str) -> bool:
+        return validators.mac_address(value) or False

--- a/core/schemas/observables/md5.py
+++ b/core/schemas/observables/md5.py
@@ -9,9 +9,6 @@ from core.schemas import observable
 class MD5(observable.Observable):
     type: Literal["md5"] = "md5"
 
-    @field_validator("value")
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        if not validators.md5(value):
-            raise ValueError("Invalid md5 hash")
-        return value
+    def validator(cls, value: str) -> bool:
+        return validators.md5(value) or False

--- a/core/schemas/observables/path.py
+++ b/core/schemas/observables/path.py
@@ -47,9 +47,9 @@ $
 class Path(observable.Observable):
     type: Literal["path"] = "path"
 
-    @field_validator("value")
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        if not (LINUX_PATH_REGEX.match(value) or WINDOWS_PATH_REGEX.match(value)):
-            raise ValueError("Invalid path")
-        return value
+    def validator(cls, value: str) -> bool:
+        if LINUX_PATH_REGEX.match(value) or WINDOWS_PATH_REGEX.match(value):
+            return True
+        else:
+            return False

--- a/core/schemas/observables/sha1.py
+++ b/core/schemas/observables/sha1.py
@@ -1,7 +1,6 @@
 from typing import Literal
 
 import validators
-from pydantic import field_validator
 
 from core.schemas import observable
 
@@ -9,9 +8,6 @@ from core.schemas import observable
 class SHA1(observable.Observable):
     type: Literal["sha1"] = "sha1"
 
-    @field_validator("value")
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        if not validators.sha1(value):
-            raise ValueError("Invalid sha1 hash")
-        return value
+    def validator(cls, value: str) -> bool:
+        return validators.sha1(value) or False

--- a/core/schemas/observables/sha256.py
+++ b/core/schemas/observables/sha256.py
@@ -1,7 +1,6 @@
 from typing import Literal
 
 import validators
-from pydantic import field_validator
 
 from core.schemas import observable
 
@@ -9,9 +8,6 @@ from core.schemas import observable
 class SHA256(observable.Observable):
     type: Literal["sha256"] = "sha256"
 
-    @field_validator("value")
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        if not validators.sha256(value):
-            raise ValueError("Invalid sha256 hash")
-        return value
+    def validator(cls, value: str) -> bool:
+        return validators.sha256(value) or False

--- a/core/schemas/observables/url.py
+++ b/core/schemas/observables/url.py
@@ -10,14 +10,14 @@ from core.schemas import observable
 class Url(observable.Observable):
     type: Literal["url"] = "url"
 
-    @field_validator("value")
+    @field_validator("value", mode="before")
+    def refang(cls, v) -> str:
+        return observable.refang(v)
+
     @classmethod
-    def validate_value(cls, value: str) -> str:
-        value = observable.refang(value)
+    def validator(cls, value: str) -> bool:
         # Replace underscores with hyphens in the domain
         # https://stackoverflow.com/a/14622263
         o = urlparse(value)
-        temp_value = o._replace(netloc=o.netloc.replace("_", "-")).geturl()
-        if not validators.url(temp_value, strict_query=False):
-            raise ValueError("Invalid url")
-        return value
+        value = o._replace(netloc=o.netloc.replace("_", "-")).geturl()
+        return validators.url(value, strict_query=False) or False

--- a/core/schemas/package.py
+++ b/core/schemas/package.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, Field, computed_field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 from typing_extensions import Self
 
 from core.schemas import entity, indicator, observable
@@ -10,6 +10,7 @@ from core.schemas.observable import ObservableTypes
 
 
 class YetiPackageRelationship(BaseModel):
+    model_config = ConfigDict(str_strip_whitespace=True)
     target: str
     link_type: str = "observes"
 
@@ -28,6 +29,8 @@ class YetiPackage(BaseModel):
     indicators: List[Indicator]: list of indicators to be added
     relationships: Dict[str, List[YetiPackageRelationship]]: relationships between elements.
     """
+
+    model_config = ConfigDict(str_strip_whitespace=True)
 
     timestamp: datetime = datetime.now()
     source: str = Field(min_length=3)

--- a/core/schemas/tag.py
+++ b/core/schemas/tag.py
@@ -3,7 +3,7 @@ import re
 import unicodedata
 from typing import ClassVar, Literal
 
-from pydantic import Field, computed_field
+from pydantic import ConfigDict, Field, computed_field
 
 from core import database_arango
 from core.config.config import yeti_config
@@ -37,6 +37,8 @@ def normalize_name(tag_name: str) -> str:
 
 
 class Tag(YetiModel, database_arango.ArangoYetiConnector):
+    model_config = ConfigDict(str_strip_whitespace=True)
+
     _collection_name: ClassVar[str] = "tags"
     _root_type: Literal["tags"] = "tag"
     _type_filter: ClassVar[str | None] = None

--- a/core/schemas/task.py
+++ b/core/schemas/task.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import requests
 from dateutil import parser
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from core import database_arango
 from core.clients import file_storage
@@ -52,6 +52,7 @@ class TaskParams(BaseModel):
 
 
 class Task(YetiModel, database_arango.ArangoYetiConnector):
+    model_config = ConfigDict(str_strip_whitespace=True)
     _collection_name: ClassVar[str] = "tasks"
     _type_filter: ClassVar[str] = ""
     _defaults: ClassVar[dict] = {}

--- a/core/schemas/template.py
+++ b/core/schemas/template.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional
 
 import jinja2
-from pydantic import BaseModel, computed_field
+from pydantic import BaseModel, ConfigDict, computed_field
 
 from core.config.config import yeti_config
 
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 class Template(BaseModel):
     """A template for exporting data to an external system."""
 
+    model_config = ConfigDict(str_strip_whitespace=True)
     _root_type: Literal["template"] = "template"
     name: str
     template: str

--- a/core/schemas/user.py
+++ b/core/schemas/user.py
@@ -3,7 +3,7 @@ import secrets
 from typing import ClassVar, Literal
 
 from passlib.context import CryptContext
-from pydantic import Field, computed_field
+from pydantic import ConfigDict, Field, computed_field
 
 from core import database_arango
 from core.schemas.model import YetiModel
@@ -16,6 +16,7 @@ def generate_api_key():
 
 
 class User(YetiModel, database_arango.ArangoYetiConnector):
+    model_config = ConfigDict(str_strip_whitespace=True)
     _collection_name: ClassVar[str] = "users"
     _root_type: Literal["user"] = "user"
     _type_filter: ClassVar[None] = None

--- a/tests/core_tests/events.py
+++ b/tests/core_tests/events.py
@@ -121,8 +121,10 @@ class EventsTest(unittest.TestCase):
             producer.producer.event_producer.publish(msg.model_dump_json())
             if producer.producer._trim_queue_size("events"):
                 trimmed = True
-        self.assertLess(
-            self.redis_client.memory_usage("events"), producer.producer._memory_limit
+        self.assertAlmostEqual(
+            self.redis_client.memory_usage("events"),
+            producer.producer._memory_limit,
+            delta=1024,
         )
         redis_payload = self.redis_client.lpop("events")
         body_payload = json.loads(redis_payload).get("body")

--- a/tests/schemas/observable.py
+++ b/tests/schemas/observable.py
@@ -842,3 +842,51 @@ S30WAvQCCo2yU1orfgqr41mM70MBAgMBAAE="""
             self.assertEqual(observables[i].tags["tag1"].fresh, True)
             self.assertEqual(observables[i].tags["tag2"].fresh, True)
         self.assertEqual(unknown[0], "junk")
+
+    def test_refang_ipv4_observable(self) -> None:
+        """Tests refanging an ipv4 observable."""
+        obs = observable.save(value="1.1.1[.]1")
+        self.assertIsNotNone(obs)
+        self.assertIsNotNone(obs.id)
+        self.assertEqual(obs.value, "1.1.1.1")
+        self.assertEqual(obs.is_valid, True)
+
+    def test_refang_hostname_observable(self) -> None:
+        """Tests refanging an hostname observable."""
+        obs = observable.save(value="tomchop[.]me")
+        self.assertIsNotNone(obs)
+        self.assertIsNotNone(obs.id)
+        self.assertEqual(obs.value, "tomchop.me")
+        self.assertEqual(obs.is_valid, True)
+
+    def test_refang_email_observable(self) -> None:
+        """Tests refanging an email observable."""
+        obs = observable.save(value="tom@chop[.]me")
+        self.assertIsNotNone(obs)
+        self.assertIsNotNone(obs.id)
+        self.assertEqual(obs.value, "tom@chop.me")
+        self.assertEqual(obs.is_valid, True)
+
+    def test_refang_url_observable(self) -> None:
+        """Tests refanging an url observable."""
+        obs = observable.save(value="http://www[.]google[.]com")
+        self.assertIsNotNone(obs)
+        self.assertIsNotNone(obs.id)
+        self.assertEqual(obs.value, "http://www.google.com")
+        self.assertEqual(obs.is_valid, True)
+
+    def test_create_not_stripped_observable(self) -> None:
+        """Tests creating an observable that is not stripped."""
+        obs = observable.save(value=" hostname.com ")
+        self.assertIsNotNone(obs)
+        self.assertIsNotNone(obs.id)
+        self.assertEqual(obs.is_valid, True)
+        self.assertEqual(obs.value, "hostname.com")
+
+    def test_create_invalid_observable(self) -> None:
+        """Tests creating an invalid observable."""
+        obs = observable.IPv4(value="192.168.1.258").save()
+        self.assertIsNotNone(obs)
+        self.assertIsNotNone(obs.id)
+        self.assertEqual(obs.is_valid, False)
+        self.assertEqual(obs.value, "192.168.1.258")


### PR DESCRIPTION
This PR updates observables validation and make it lazy. This means:

* An invalid observable can be created and saved.
* An invalid observable can be loaded from a previously invalid database document

To correctly distinguish valid versus invalid observables, a new attributes has been added to the model `is_valid`. This means that observable can now be filtered based on their validator, which can be useful when exporting.

Observable validation is handled by implementing `validator` class method:

```python
@classmethod
def validator(cls, value: str) -> bool:
```

Observable that must be refanged before being stored in database must implement a pydantic field_validator on value before Pydantic's internal parsing and validation:

```python
@field_validator("value", mode="before")
def refang(cls, v) -> str:
```

This PR also automatically strips string value with whitespaces for all schemas except DFIQ.

Finally, this PR also reverts to `full_count=True` when calling `aql_execute` in `filter` method