### PR TITLE
Arango concurrency

### DIFF
--- a/core/events/consumers.py
+++ b/core/events/consumers.py
@@ -138,7 +138,6 @@ class Worker(multiprocessing.Process):
         logger.info(f"Worker {self.name} started")
         from core.database_arango import db
 
-        db.set_lock(lock)
         while not self.stop_event.is_set():
             try:
                 self._worker.run()
@@ -151,7 +150,7 @@ class Worker(multiprocessing.Process):
 
 
 if __name__ == "__main__":
-    lock = multiprocessing.Lock()
+    multiprocessing.set_start_method("spawn")
     parser = argparse.ArgumentParser(
         prog="yeti-consumer", description="Consume events and logs from the event bus"
     )

--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -179,9 +179,9 @@ def save(
     return observable_obj
 
 
-def find(*, value, **kwargs) -> ObservableTypes:
-    if "type" in kwargs:
-        obs = Observable.find(value=refang(value), type=kwargs["type"])
+def find(value: str, type: str = None) -> ObservableTypes:
+    if type:
+        obs = Observable.find(value=refang(value), type=type)
     else:
         obs = Observable.find(value=refang(value))
     return obs

--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -166,7 +166,7 @@ def save(
     tags is an optional list of tags to add to the observable.
     """
     observable_obj = create(value=value, type=type, **kwargs)
-    db_obs = find(value=observable_obj.value, type=observable_obj.type, **kwargs)
+    db_obs = find(value=observable_obj.value, type=observable_obj.type)
     if db_obs:
         if overwrite:
             observable_obj = observable_obj.save()

--- a/plugins/analytics/public/dockerhub.py
+++ b/plugins/analytics/public/dockerhub.py
@@ -234,7 +234,7 @@ class DockerHubUserAnalytics(task.OneShotTask):
             ):
                 user_obj.created = date_joined
                 user_obj = user_obj.save()
-        del metadata["date_joined"]
+        metadata.pop("date_joined", None)
         user_obj.add_context("hub.docker.com", metadata)
         for image in DockerHubApi.user_images(user_obj.value):
             image_name = f'{image["namespace"]}/{image["name"]}'

--- a/plugins/events/public/dockerhub.py
+++ b/plugins/events/public/dockerhub.py
@@ -43,10 +43,12 @@ class DockerHubImageEvent(task.EventTask):
                 f"Skipping {container_image.type} {container_image.value} not from docker.io"
             )
             return
+        self.logger.info(f"Fetching metadata for {container_image.value}")
         metadata = DockerHubApi.image_full_details(container_image.value)
         if not metadata:
             self.logger.info(f"Image metadata for {container_image.value} not found")
             return
+        self.logger.info(f"Adding context for {container_image.value}")
         context = get_image_context(metadata)
         container_image.add_context("hub.docker.com", context)
         make_relationships(container_image, metadata)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1985,13 +1985,13 @@ test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
 name = "python-arango"
-version = "7.9.1"
+version = "8.1.2"
 description = "Python Driver for ArangoDB"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "python-arango-7.9.1.tar.gz", hash = "sha256:18f7d365fb6cf45778fa73b559e3865d0a1c00081de65ef00ba238db52e374ab"},
-    {file = "python_arango-7.9.1-py3-none-any.whl", hash = "sha256:23ec7b3aad774db5f99df20f6a1036385c85eb5c9864e47628bc622ea812f2f8"},
+    {file = "python_arango-8.1.2-py3-none-any.whl", hash = "sha256:2b9f604b0f4eaf5209893cdb7a2f96448aa27d540300939b0a854ded75c031cb"},
+    {file = "python_arango-8.1.2.tar.gz", hash = "sha256:4a39525ed426b23d7ae031e071f786ac35e6aa571d158ec54c59b74d6ae7a27f"},
 ]
 
 [package.dependencies]
@@ -2004,7 +2004,7 @@ setuptools = ">=42"
 urllib3 = ">=1.26.0"
 
 [package.extras]
-dev = ["black (>=22.3.0)", "flake8 (>=4.0.1)", "isort (>=5.10.1)", "mock", "mypy (>=0.942)", "pre-commit (>=2.17.0)", "pytest (>=7.1.1)", "pytest-cov (>=3.0.0)", "sphinx", "sphinx-rtd-theme", "types-pkg-resources", "types-requests", "types-setuptools"]
+dev = ["black (>=22.3.0)", "flake8 (>=4.0.1)", "isort (>=5.10.1)", "mock", "mypy (>=0.942)", "pre-commit (>=2.17.0)", "pytest (>=7.1.1)", "pytest-cov (>=3.0.0)", "sphinx", "sphinx-rtd-theme", "types-requests", "types-setuptools"]
 
 [[package]]
 name = "python-dateutil"
@@ -2883,4 +2883,4 @@ s3 = ["boto3"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.12"
-content-hash = "136fff7a12b53a9850aea529fccacb9d45e9d576e4c5620df7632bd25e54bfec"
+content-hash = "248a01002d6f5561f9502092e66dfec66fcd3fa27d7430c53b1d62e856682383"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 python = ">=3.10,<3.12"
 uvicorn = "^0.23.2"
 fastapi = "^0.109.0"
-python-arango = "^7.9.1"
+python-arango = "^8.1.2"
 celery = "^5.3.4"
 validators = "^0.34.0"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}


### PR DESCRIPTION
This PR improves arangodb API calls resiliency when dealing with high concurrency. It adds a custom http client that acquires a lock before sending a request to arangodb webserver. This is particularly useful when dealing with multiple events consumers processes.