### PR TITLE
Handle max results in Censys analytics to not burn all API quota in a day

### DIFF
--- a/plugins/analytics/public/censys.py
+++ b/plugins/analytics/public/censys.py
@@ -1,8 +1,8 @@
 import logging
+import math
 from datetime import timedelta
 
 from censys.search import CensysHosts
-
 from core import taskmanager
 from core.config.config import yeti_config
 from core.schemas import indicator, observable, task
@@ -18,6 +18,7 @@ class CensysApiQuery(task.AnalyticsTask):
     def run(self):
         api_key = yeti_config.get("censys", "api_key")
         api_secret = yeti_config.get("censys", "secret")
+        max_results = yeti_config.get("censys", "max_results", 1000)
 
         if not (api_key and api_secret):
             logging.error(
@@ -33,7 +34,7 @@ class CensysApiQuery(task.AnalyticsTask):
         censys_queries, _ = indicator.Query.filter({"query_type": "censys"})
 
         for query in censys_queries:
-            ip_addresses = query_censys(hosts_api, query.pattern)
+            ip_addresses = query_censys(hosts_api, query.pattern, max_results)
             for ip in ip_addresses:
                 ip_object = observable.save(value=ip)
                 ip_object.tag(query.relevant_tags)
@@ -42,10 +43,16 @@ class CensysApiQuery(task.AnalyticsTask):
                 )
 
 
-def query_censys(api: CensysHosts, query: str) -> set[str]:
+def query_censys(api: CensysHosts, query: str, max_results=1000) -> set[str]:
     """Queries Censys and returns all identified IP addresses."""
     ip_addresses: set[str] = set()
-    results = api.search(query, fields=["ip"], pages=-1)
+    if max_results <= 0:
+        results = api.search(query, fields=["ip"], pages=-1)
+    elif max_results < 100:
+        results = api.search(query, fields=["ip"], per_page=max_results, pages=1)
+    else:
+        pages = math.ceil(max_results / 100)
+        results = api.search(query, fields=["ip"], per_page=100, pages=pages)
 
     for result in results:
         for record in result:

--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -172,6 +172,7 @@ password =
 [censys]
 api_key =
 secret =
+max_results = 100
 
 [shodan]
 


### PR DESCRIPTION
This PR adds `max_results` setting for Censys analytics. The following options are handled:

* if <= 0, then all available results will be taken into account as previously implemented. Be careful about the number of results that could consume all your API quota in few hours.
* if < 100, then `per_page` is set to max_results and `page` to 1 
* if > 100, then `per_page` is set to 100 and page is computed as `math.ceil(max_results / 100)`