### PR TITLE
Change the way API keys are generated and used

### DIFF
--- a/core/schemas/user.py
+++ b/core/schemas/user.py
@@ -44,6 +44,7 @@ class RegisteredApiKey(BaseModel):
     last_used: datetime.datetime | None = None
     enabled: bool = True
 
+    @computed_field
     @property
     def expired(self) -> bool:
         if self.exp is None:

--- a/core/schemas/user.py
+++ b/core/schemas/user.py
@@ -60,7 +60,7 @@ class User(YetiModel, database_arango.ArangoYetiConnector):
     username: str
     enabled: bool = True
     admin: bool = False
-    api_keys: dict[str, RegisteredApiKey] = {}
+    api_keys: dict[str, RegisteredApiKey] | None = {}
 
     global_role: int = RBAC_DEFAULT_ROLES[
         str(yeti_config.get("rbac", "default_global_role", default="writer"))
@@ -109,7 +109,11 @@ class User(YetiModel, database_arango.ArangoYetiConnector):
         return key
 
     def delete_api_key(self, api_key_name) -> None:
-        del self.api_keys[api_key_name]
+        api_keys = self.api_keys
+        del api_keys[api_key_name]
+        self.api_keys = None
+        self.save()
+        self.api_keys = api_keys
         self.save()
 
     def has_permissions(self, target: str, permissions: roles.Permission) -> bool:

--- a/core/schemas/user.py
+++ b/core/schemas/user.py
@@ -1,12 +1,15 @@
-import re
+import datetime
+import json
 import secrets
 from typing import ClassVar, Literal
 
+from jose import jwt
 from passlib.context import CryptContext
-from pydantic import ConfigDict, Field, computed_field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from core import database_arango
 from core.config.config import yeti_config
+from core.helpers import now
 from core.schemas import graph, rbac, roles
 from core.schemas.model import YetiModel
 
@@ -16,10 +19,36 @@ RBAC_DEFAULT_ROLES = {
     "reader": roles.Role.READER,
     "writer": roles.Role.WRITER,
 }
+SECRET_KEY = yeti_config.get("auth", "secret_key")
+ALGORITHM = yeti_config.get("auth", "algorithm")
 
 
-def generate_api_key():
-    return secrets.token_hex(32)
+def create_access_token(
+    data: dict, expires_delta: datetime.timedelta | None = None
+) -> str:
+    to_encode = data.copy()
+    expire = None
+    if expires_delta:
+        expire = datetime.datetime.now(datetime.timezone.utc) + expires_delta
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+class RegisteredApiKey(BaseModel):
+    name: str
+    sub: str
+    scopes: list[str]
+    created: datetime.datetime = Field(default_factory=now)
+    exp: datetime.datetime | None = None
+    last_used: datetime.datetime | None = None
+    enabled: bool = True
+
+    @property
+    def expired(self) -> bool:
+        if self.exp is None:
+            return False
+        return self.exp > datetime.datetime.now(tz=datetime.timezone.utc)
 
 
 class User(YetiModel, database_arango.ArangoYetiConnector):
@@ -31,7 +60,7 @@ class User(YetiModel, database_arango.ArangoYetiConnector):
     username: str
     enabled: bool = True
     admin: bool = False
-    api_key: str = Field(default_factory=generate_api_key)
+    api_keys: dict[str, RegisteredApiKey] = {}
 
     global_role: int = RBAC_DEFAULT_ROLES[
         str(yeti_config.get("rbac", "default_global_role", default="writer"))
@@ -46,13 +75,42 @@ class User(YetiModel, database_arango.ArangoYetiConnector):
     def load(cls, object: dict) -> "User":
         return cls(**object)
 
-    def reset_api_key(self, api_key=None) -> None:
-        if api_key:
-            if not re.match(r"^[a-f0-9]{64}$", api_key):
-                raise ValueError("Invalid API key: must match ^[a-f0-9]{64}$")
-            self.api_key = api_key
-        else:
-            self.api_key = secrets.token_hex(32)
+    def create_api_key(
+        self,
+        key_name: str,
+        scopes: list[str] | None = None,
+        expiration_delta: datetime.timedelta | None = None,
+    ) -> str:
+        exp = None
+        if expiration_delta:
+            exp = datetime.datetime.now(datetime.timezone.utc) + expiration_delta
+        api_key = RegisteredApiKey(
+            name=key_name,
+            sub=self.username,
+            scopes=scopes or ["all"],
+            exp=exp,
+        )
+        self.api_keys[key_name] = api_key
+        self.save()
+        return create_access_token(json.loads(api_key.model_dump_json()))
+
+    def validate_api_key_payload(self, payload) -> RegisteredApiKey:
+        sub = payload.get("sub")
+        key_name = payload.get("name")
+        if key_name not in self.api_keys or sub != self.username:
+            raise ValueError("Could not validate credentials")
+
+        key = self.api_keys[key_name]
+        if not key.enabled:
+            raise ValueError("API key disabled.")
+        if key.expired:
+            raise ValueError("API key expired.")
+
+        return key
+
+    def delete_api_key(self, api_key_name) -> None:
+        del self.api_keys[api_key_name]
+        self.save()
 
     def has_permissions(self, target: str, permissions: roles.Permission) -> bool:
         return graph.RoleRelationship.has_permissions(self, target, permissions)

--- a/core/web/apiv2/auth.py
+++ b/core/web/apiv2/auth.py
@@ -64,6 +64,7 @@ def get_oauth_client() -> OAuth:
     )
     return client
 
+
 def get_current_user(
     request: Request,
     token: str = Depends(oauth2_scheme),

--- a/core/web/apiv2/auth.py
+++ b/core/web/apiv2/auth.py
@@ -17,7 +17,7 @@ from jose import JWTError, jwt
 from starlette.requests import Request
 
 from core.config.config import yeti_config
-from core.schemas.user import User, UserSensitive
+from core.schemas.user import User, UserSensitive, create_access_token
 
 ACCESS_TOKEN_EXPIRE_DELTA = datetime.timedelta(
     minutes=yeti_config.get("auth", "access_token_expire_minutes", default=30)
@@ -63,18 +63,6 @@ def get_oauth_client() -> OAuth:
         client_secret=client_secret,
     )
     return client
-
-
-def create_access_token(data: dict, expires_delta: datetime.timedelta | None = None):
-    to_encode = data.copy()
-    if expires_delta:
-        expire = datetime.datetime.utcnow() + expires_delta
-    else:
-        expire = datetime.datetime.utcnow() + datetime.timedelta(minutes=15)
-    to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
-    return encoded_jwt
-
 
 def get_current_user(
     request: Request,
@@ -277,20 +265,41 @@ if AUTH_MODULE == "local":
 
 
 @router.post("/api-token")
-def login_api(x_yeti_api_key: str = Security(api_key_header)) -> dict[str, str]:
-    user = UserSensitive.find(api_key=x_yeti_api_key)
+def login_api(x_yeti_api_key_token: str = Security(api_key_header)) -> dict[str, str]:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "x-yeti-apikey"},
+    )
+
+    try:
+        payload = jwt.decode(
+            x_yeti_api_key_token,
+            SECRET_KEY,
+            algorithms=[ALGORITHM],
+            options={"verify_exp": False, "requires_exp": False},
+        )
+    except JWTError:
+        raise credentials_exception
+
+    user = UserSensitive.find(username=payload.get("sub"))
     if not user:
+        raise credentials_exception
+
+    try:
+        user.validate_api_key_payload(payload)
+    except ValueError as error:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid API key",
-            headers={"WWW-Authenticate": "Bearer"},
+            detail=str(error),
+            headers={"WWW-Authenticate": "x-yeti-apikey"},
         )
 
     if not user.enabled:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="User account disabled. Please contact your server admin.",
-            headers={"WWW-Authenticate": "Bearer"},
+            headers={"WWW-Authenticate": "x-yeti-apikey"},
         )
 
     access_token = create_access_token(

--- a/core/web/apiv2/auth.py
+++ b/core/web/apiv2/auth.py
@@ -306,6 +306,9 @@ def login_api(x_yeti_api_key_token: str = Security(api_key_header)) -> dict[str,
         data={"sub": user.username, "enabled": user.enabled},
         expires_delta=ACCESS_TOKEN_EXPIRE_DELTA,
     )
+    user.api_keys[payload["name"]].last_used = datetime.datetime.now(
+        tz=datetime.timezone.utc
+    )
     return {"access_token": access_token, "token_type": "bearer"}
 
 

--- a/core/web/apiv2/users.py
+++ b/core/web/apiv2/users.py
@@ -47,6 +47,7 @@ class PatchRoleRequest(BaseModel):
     user_id: str
     role: roles.Permission
 
+
 class NewApiKeyRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -70,6 +71,7 @@ class DeleteApiKeyRequest(BaseModel):
     user_id: str
     name: str
 
+
 class DeleteApiKeyResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -81,6 +83,7 @@ class ToggleApiKeyRequest(BaseModel):
 
     user_id: str
     name: str
+
 
 class ResetPasswordRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -164,6 +167,7 @@ def update_user_role(
         raise HTTPException(status_code=404, detail=f"user {request.user_id} not found")
     user.global_role = request.role
     return user.save()
+
 
 @router.post("/new-api-key")
 def new_api_key(

--- a/tests/apiv2/dfiq.py
+++ b/tests/apiv2/dfiq.py
@@ -21,8 +21,9 @@ class DFIQTest(unittest.TestCase):
         database_arango.db.truncate()
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
 

--- a/tests/apiv2/entities.py
+++ b/tests/apiv2/entities.py
@@ -21,8 +21,9 @@ class EntityTest(unittest.TestCase):
         database_arango.db.truncate()
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
         self.entity1 = entity.ThreatActor(

--- a/tests/apiv2/graph.py
+++ b/tests/apiv2/graph.py
@@ -22,8 +22,9 @@ class SimpleGraphTest(unittest.TestCase):
         database_arango.db.connect(database="yeti_test")
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
         self.observable1 = hostname.Hostname(value="tomchop.me").save()
@@ -369,8 +370,9 @@ class ComplexGraphTest(unittest.TestCase):
         database_arango.db.truncate()
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
         self.observable1 = hostname.Hostname(value="test1.com").save()
@@ -564,8 +566,9 @@ class GraphTraversalTest(unittest.TestCase):
         database_arango.db.truncate()
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
 

--- a/tests/apiv2/groups.py
+++ b/tests/apiv2/groups.py
@@ -29,18 +29,21 @@ class rbacTest(unittest.TestCase):
         self.user2.link_to_acl(self.group2, roles.Role.OWNER)
         self.admin = user.UserSensitive(username="yeti", admin=True).save()
 
+        user1_apikey = self.user1.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": self.user1.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user1_apikey}
         ).json()
-
         self.user1_token = token_data["access_token"]
+
+        user2_apikey = self.user2.create_api_key("default")
         user_token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": self.user2.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user2_apikey}
         ).json()
         self.user2_token = user_token_data["access_token"]
 
+        admin_apikey = self.admin.create_api_key("default")
         admin_token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": self.admin.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": admin_apikey}
         ).json()
         self.admin_token = admin_token_data["access_token"]
 

--- a/tests/apiv2/import_data.py
+++ b/tests/apiv2/import_data.py
@@ -22,8 +22,9 @@ class ImportData(unittest.TestCase):
         user.set_password("test")
         user.save()
 
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
 

--- a/tests/apiv2/indicators.py
+++ b/tests/apiv2/indicators.py
@@ -22,8 +22,9 @@ class IndicatorTest(unittest.TestCase):
         # database_arango.db.create_views(testing=True)
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
         self.indicator1 = indicator.Regex(

--- a/tests/apiv2/observables.py
+++ b/tests/apiv2/observables.py
@@ -35,8 +35,9 @@ class ObservableTest(unittest.TestCase):
         database_arango.db.connect(database="yeti_test")
         database_arango.db.truncate()
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
 
@@ -465,8 +466,9 @@ class ObservableContextTest(unittest.TestCase):
         database_arango.db.truncate()
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
         self.observable = hostname.Hostname(value="tomchop.me").save()

--- a/tests/apiv2/rbac.py
+++ b/tests/apiv2/rbac.py
@@ -26,16 +26,18 @@ class rbacTest(unittest.TestCase):
         self.entity2 = entity.Malware(name="test2").save()
 
         self.user1 = user.UserSensitive(username="user1").save()
+        user1_apikey = self.user1.create_api_key("default")
         self.user2 = user.UserSensitive(username="user2").save()
+        user2_apikey = self.user2.create_api_key("default")
         self.admin = user.UserSensitive(username="yeti", admin=True).save()
 
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": self.user1.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user1_apikey}
         ).json()
         self.user1_token = token_data["access_token"]
 
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": self.user2.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user2_apikey}
         ).json()
         self.user2_token = token_data["access_token"]
 

--- a/tests/apiv2/tags.py
+++ b/tests/apiv2/tags.py
@@ -19,8 +19,9 @@ class tagTest(unittest.TestCase):
         database_arango.db.truncate()
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
         self.tag = Tag(name="tag1").save()

--- a/tests/apiv2/tasks.py
+++ b/tests/apiv2/tasks.py
@@ -35,8 +35,9 @@ class TaskTest(unittest.TestCase):
         database_arango.db.truncate()
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
         taskmanager.TaskManager.register_task(FakeTask)
@@ -88,8 +89,9 @@ class ExportTaskTest(unittest.TestCase):
         database_arango.db.connect(database="yeti_test")
         database_arango.db.truncate()
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
 

--- a/tests/apiv2/templates.py
+++ b/tests/apiv2/templates.py
@@ -30,8 +30,9 @@ class TemplateTest(unittest.TestCase):
         database_arango.db.truncate()
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
         temp_path = Path("/opt/yeti/templates")

--- a/tests/apiv2/timeline.py
+++ b/tests/apiv2/timeline.py
@@ -20,8 +20,9 @@ class TimelineLogTest(unittest.TestCase):
         database_arango.db.truncate()
 
         user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
         token_data = client.post(
-            "/api/v2/auth/api-token", headers={"x-yeti-apikey": user.api_key}
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
 

--- a/tests/apiv2/users.py
+++ b/tests/apiv2/users.py
@@ -136,6 +136,62 @@ class userTest(unittest.TestCase):
         self.assertEqual(data["name"], "my API key")
         self.assertTrue(len(data["token"]) > 32)
 
+    def test_toggle_api_key(self):
+        response = client.post(
+            "/api/v2/users/new-api-key",
+            json={"user_id": self.user.id, "name": "my API key"},
+            headers={"Authorization": f"Bearer {self.admin_token}"},
+        )
+
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertIsNotNone(data)
+        self.assertEqual(data["name"], "my API key")
+        self.assertTrue(len(data["token"]) > 32)
+
+        response = client.post(
+            "/api/v2/users/toggle-api-key",
+            json={"user_id": self.user.id, "name": "my API key"},
+            headers={"Authorization": f"Bearer {self.admin_token}"},
+        )
+
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertIsNotNone(data)
+        self.assertEqual(data["enabled"], False)
+
+        response = client.get(
+            f"/api/v2/users/{self.user.id}",
+            headers={"Authorization": f"Bearer {self.user_token}"},
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["user"]["api_keys"]["my API key"]["enabled"], False, data)
+
+    def test_delete_api_key(self):
+        response = client.post(
+            "/api/v2/users/new-api-key",
+            json={"user_id": self.user.id, "name": "my API key"},
+            headers={"Authorization": f"Bearer {self.admin_token}"},
+        )
+
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertIsNotNone(data)
+        self.assertEqual(data["name"], "my API key")
+        self.assertTrue(len(data["token"]) > 32)
+
+        response = client.post(
+            "/api/v2/users/delete-api-key",
+            json={"user_id": self.user.id, "name": "my API key"},
+            headers={"Authorization": f"Bearer {self.admin_token}"},
+        )
+
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertIsNotNone(data)
+        self.assertNotIn("my API key", data["api_keys"])
+
     def test_reset_own_password(self):
         response = client.post(
             "/api/v2/users/reset-password",

--- a/tests/schemas/user.py
+++ b/tests/schemas/user.py
@@ -20,7 +20,7 @@ class UserTest(unittest.TestCase):
         self.assertTrue(user.verify_password("test"))
         self.assertFalse(user.verify_password("password"))
 
-    def test_reset_api_key(self) -> None:
+    def test_create_api_key(self) -> None:
         self.user1.create_api_key("apikey")
         old_api_key = self.user1.api_keys["apikey"]
         self.user1.create_api_key("apikey")
@@ -30,3 +30,18 @@ class UserTest(unittest.TestCase):
         new_api_key = user.api_keys["apikey"]
         self.assertNotEqual(old_api_key.created, new_api_key.created)
         self.assertEqual(old_api_key.sub, new_api_key.sub)
+
+    def test_delete_api_key(self) -> None:
+        user = UserSensitive.find(username="tomchop")
+        self.assertEqual(len(user.api_keys), 0)
+
+        self.user1.create_api_key("apikey")
+        self.user1.save()
+
+        user = UserSensitive.find(username="tomchop")
+        self.assertEqual(len(user.api_keys), 1)
+
+        user.delete_api_key("apikey")
+        user.save()
+        user = UserSensitive.find(username="tomchop")
+        self.assertEqual(len(user.api_keys), 0)

--- a/tests/schemas/user.py
+++ b/tests/schemas/user.py
@@ -10,10 +10,6 @@ class UserTest(unittest.TestCase):
         database_arango.db.truncate()
         self.user1 = UserSensitive(username="tomchop").save()
 
-    def test_has_api_key(self) -> None:
-        self.assertRegex(self.user1.api_key, r"[a-f0-9]{32}")
-        self.assertTrue(self.user1.api_key)
-
     def test_set_user_password(self) -> None:
         self.user1.set_password("test")
         self.user1.save()
@@ -25,24 +21,12 @@ class UserTest(unittest.TestCase):
         self.assertFalse(user.verify_password("password"))
 
     def test_reset_api_key(self) -> None:
-        old_api_key = self.user1.api_key
-        self.user1.reset_api_key()
+        self.user1.create_api_key("apikey")
+        old_api_key = self.user1.api_keys["apikey"]
+        self.user1.create_api_key("apikey")
         self.user1.save()
 
         user = UserSensitive.find(username="tomchop")
-        assert user is not None
-        self.assertNotEqual(old_api_key, self.user1.api_key)
-        self.assertRegex(user.api_key, r"[a-f0-9]{64}")
-
-    def test_reset_api_key_with_param(self) -> None:
-        self.user1.reset_api_key(
-            api_key="1234123412341234123412341234123412341234123412341234123412341234"
-        )
-        self.user1.save()
-
-        user = UserSensitive.find(username="tomchop")
-        assert user is not None
-        self.assertEqual(
-            self.user1.api_key,
-            "1234123412341234123412341234123412341234123412341234123412341234",
-        )
+        new_api_key = user.api_keys["apikey"]
+        self.assertNotEqual(old_api_key.created, new_api_key.created)
+        self.assertEqual(old_api_key.sub, new_api_key.sub)

--- a/yetictl/cli.py
+++ b/yetictl/cli.py
@@ -20,9 +20,7 @@ def cli():
 def list_users():
     users = User.list()
     for user in users:
-        click.echo(
-            f"Username: {user.username} | API key: {user.api_key} | Admin: {user.admin}"
-        )
+        click.echo(f"Username: {user.username} | Admin: {user.admin}")
 
 
 @cli.command()
@@ -42,9 +40,8 @@ def create_user(
     if api_key:
         user.reset_api_key(api_key=api_key)
     user.save()
-    click.echo(
-        f"User {username} succesfully created! API key: {username}:{user.api_key}"
-    )
+    token = user.create_api_key("default")
+    click.echo(f"User {username} succesfully created! API key: {username}:{token}")
 
 
 @cli.command()
@@ -93,11 +90,8 @@ def reset_password(username: str, new_password: str) -> None:
     if not user:
         raise RuntimeError(f"User with username {username} could not be found")
     user.set_password(new_password)
-    user.reset_api_key()
     user.save()
-    click.echo(
-        f"Password for {username} succesfully reset. New API key: {user.api_key}"
-    )
+    click.echo(f"Password for {username} succesfully reset.")
 
 
 @cli.command()


### PR DESCRIPTION
This PR introduces several changes in the way API keys are used and managed

* Users can now have multiple API keys
* API keys are JTWs that are displayed only once to the user, they are never stored server-side
* Introduces scopes for future use