### PR TITLE
Speed up ACL checks doing manual queries

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -938,15 +938,19 @@ class ArangoYetiConnector(AbstractYetiConnector):
         if filter:
             filters = []
             for i, f in enumerate(filter):
+                if f.pathcompare.lower() not in {"any", "all", "none"}:
+                    f.pathcompare = ""
+
                 if f.operator.lower() not in {"=~", "==", "in"}:
                     f.operator = "=="
 
-                if f.pathcompare.lower() not in {"any", "all", "none"}:
-                    f.pathcompare = "any"
+                # =~ not compatible with path operators
+                if f.operator == "=~":
+                    f.pathcompare = ""
 
                 if f.operator in {"=~", "=="}:
                     filters.append(
-                        f"(p.edges[*].@filter_key{i} {f.pathcompare} {f.operator} @filter_value{i} OR p.vertices[*].@filter_key{i} {f.operator} @filter_value{i})"
+                        f"(p.edges[*].@filter_key{i} {f.pathcompare} {f.operator} @filter_value{i} OR p.vertices[*].@filter_key{i} {f.pathcompare} {f.operator} @filter_value{i})"
                     )
                 if f.operator == "in":
                     filters.append(

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -989,10 +989,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
             """
         else:
             tags_query = """
-            LET vertices = (
-                FOR object in p['vertices']
-                RETURN object
-            )
+            LET vertices = p['vertices']
             """
 
         aql = f"""

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -983,7 +983,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
             tags_query = """
             LET vertices = (
                 FOR object in p['vertices']
-                let innertags = (FOR tag, edge in 1..1 OUTBOUND object tagged RETURN {{ [tag.name]: edge }})
+                let innertags = (FOR tag, edge in 1..1 OUTBOUND object tagged RETURN { [tag.name]: edge })
                 RETURN MERGE(object, {tags: MERGE(innertags)})
             )
             """

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -1000,7 +1000,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
           {acl_query}
           {limit}
           {sorting_aql}
-          RETURN {{ vertices: v_with_tags, g: p }}
+          RETURN {{ vertices: {"v_with_tags" if include_tags else "v"}, g: p }}
         """
         neighbors = self._db.aql.execute(
             aql, bind_vars=args, count=True, full_count=True

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -8,8 +8,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, List, Type, TypeVar
 
 if TYPE_CHECKING:
-    from core.schemas import entity, indicator, observable, tag
-    from core.schemas.graph import GraphFilter, Relationship, TagRelationship
+    from core.schemas import entity, graph, indicator, observable, tag, user
 
 TYetiObject = TypeVar("TYetiObject")
 
@@ -85,7 +84,7 @@ class AbstractYetiConnector(ABC):
     @abstractmethod
     def link_to(
         self, target, relationship_type: str, description: str
-    ) -> "Relationship":
+    ) -> "graph.RelationshipTypes":
         """Creates a link from an existing object to a target object.
 
         Args:
@@ -103,29 +102,42 @@ class AbstractYetiConnector(ABC):
         target_types: List[str] = [],
         direction: str = "any",
         graph: str = "links",
-        filter: List["GraphFilter"] = [],
+        filter: List["graph.GraphFilter"] = [],
         include_original: bool = False,
         min_hops: int = 1,
         max_hops: int = 1,
         offset: int = 0,
         count: int = 0,
+        sorting: List[tuple[str, bool]] = [],
+        user: "user.User" = None,
+        include_tags: bool = True,
     ) -> tuple[
         dict[
-            str, "observable.Observable | entity.Entity | indicator.Indicator | tag.Tag"
+            str,
+            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag",
         ],
-        List[List["Relationship | TagRelationship"]],
+        List[List["graph.RelationshipTypes"]],
         int,
     ]:
         """Fetches neighbors of the YetiObject.
 
         Args:
-          link_type: The type of link.
+          link_types: The types of link.
+          target_types: The types of the target objects (as specified in the
+              'type' field).
           direction: outbound, inbound, or any.
           include_original: Whether the original object is to be included in the
               result or not.
-          hops: The maximum number of nodes to go through (defaults to 1:
+          min_hops: The minumum number of nodes to go through (defaults to 1:
               direct neighbors)
-          raw: Whether to return a raw dictionary or a Yeti object.
+          max_hops: The maximum number of nodes to go through (defaults to 1:
+              direct neighbors)
+
+        Returns:
+          Tuple[dict, list, int]:
+            - the neighbors (vertices),
+            - the relationships (edges),
+            - total neighbor (vertices) count
         """
         raise NotImplementedError
 

--- a/core/schemas/graph.py
+++ b/core/schemas/graph.py
@@ -120,22 +120,24 @@ class RoleRelationship(BaseModel, database_arango.ArangoYetiConnector):
         return cls(**object)
 
     @classmethod
-    def has_permissions(cls, src, target_id: str, permission: roles.Permission) -> bool:
-        vertices, paths, total = src.neighbors(
-            graph="acls",
-            direction="outbound",
-            max_hops=2,
-            filter=[
-                GraphFilter(
-                    key="target", value=target_id, operator="==", pathcompare="ANY"
-                )
-            ],
-            include_tags=False,
+    def has_permissions(
+        cls, user, target_id: str, permission: roles.Permission
+    ) -> bool:
+        acl_acl = """
+         WITH observables, entities, dfiq, indicators
+        FOR v, e IN 1..2 outbound @user_extended_id acls
+          OPTIONS { uniqueVertices: "path" }
+        FILTER e.target == @target_id
+        RETURN e
+        """
+
+        results = cls._db.aql.execute(
+            acl_acl,
+            bind_vars={"target_id": target_id, "user_extended_id": user.extended_id},
         )
-        for path in paths:
-            for edge in path:
-                if edge.role & permission == permission and edge.target == target_id:
-                    return True
+        for edge in results:
+            if edge["role"] & permission == permission and edge["target"] == target_id:
+                return True
         return False
 
 

--- a/core/schemas/model.py
+++ b/core/schemas/model.py
@@ -1,6 +1,11 @@
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel, computed_field
 
 from core.schemas.graph import RoleRelationship, TagRelationship
+
+if TYPE_CHECKING:
+    from core.schemas.tag import Tag
 
 
 class YetiBaseModel(BaseModel):
@@ -30,23 +35,28 @@ class YetiAclModel(YetiBaseModel):
     def acls(self):
         return self._acls
 
-    def get_acls(self) -> None:
+    def get_acls(self) -> dict[str, RoleRelationship]:
         """Returns the permissions assigned to a user.
 
         Args:
             user: The user to check permissions for.
         """
-        vertices, paths, total = self.neighbors(
-            graph="acls", direction="inbound", max_hops=2
+        acl_acl = """
+         WITH observables, entities, dfiq, indicators
+
+        FOR v, e IN 1..2 inbound @extended_id acls
+          OPTIONS { uniqueVertices: "path" }
+
+        RETURN  {name: v.username || v.name, edge: e}
+        """
+        results = self._db.aql.execute(
+            acl_acl, bind_vars={"extended_id": self.extended_id}
         )
-        for path in paths:
-            for edge in path:
-                if edge.target == self.extended_id:
-                    identity = vertices[edge.source]
-                    if identity.root_type == "rbacgroup":
-                        self._acls[identity.name] = edge
-                    if identity.root_type == "user":
-                        self._acls[identity.username] = edge
+        for r in results:
+            if r["edge"]["target"] == self.extended_id:
+                self._acls[r["name"]] = RoleRelationship(**r["edge"])
+
+        return self._acls
 
 
 class YetiModel(YetiBaseModel):
@@ -66,3 +76,34 @@ class YetiTagModel(YetiModel):
     @property
     def tags(self):
         return self._tags
+
+    def get_tags(self) -> list[tuple[TagRelationship, "Tag"]]:
+        """Returns the tags linked to this object.
+
+        Returns:
+          A list of tuples (TagRelationship, Tag) representing each tag linked
+          to this object.
+        """
+        from core.schemas.graph import TagRelationship
+        from core.schemas.tag import Tag
+
+        tag_aql = """
+            for v, e, p IN 1..1 OUTBOUND @extended_id GRAPH tags
+            OPTIONS {uniqueVertices: "path"}
+            RETURN p
+        """
+        tag_paths = self._db.aql.execute(
+            tag_aql, bind_vars={"extended_id": self.extended_id}
+        )
+        if tag_paths.empty():
+            return []
+        relationships = []
+        self._tags = {}
+        for path in tag_paths:
+            tag_data = Tag.load(path["vertices"][1])
+            edge_data = path["edges"][0]
+            edge_data["__id"] = edge_data.pop("_id")
+            tag_relationship = TagRelationship.load(edge_data)
+            relationships.append((tag_relationship, tag_data))
+            self._tags[tag_data.name] = tag_relationship
+        return relationships

--- a/core/web/apiv2/dfiq.py
+++ b/core/web/apiv2/dfiq.py
@@ -293,7 +293,6 @@ def patch(httpreq: Request, request: PatchDFIQRequest, id: str) -> dfiq.DFIQType
             status_code=400,
             detail=f"DFIQ type mismatch: {db_dfiq.type} != {update_data.type}",
         )
-    db_dfiq.get_tags()
     db_dfiq.get_acls()
     updated_dfiq = db_dfiq.model_copy(
         update=update_data.model_dump(exclude=["created"])


### PR DESCRIPTION
* changes in database_arango.py : cleanup in the way neighbors are queried. Make resolving tags optional (can be expensive when we don't need it)
* Only deserialize objects if we haven't done it before when building vertices

* change `has_permissions` to use a raw AQL query. This happens at every object load, and we want to be as fast as possible by not deserializing things we don't need to. This saves about 50ms by request. 
* move get_tags to the appropriate model