### PR TITLE
Yara bundles & optimized validation

### DIFF
--- a/core/errors.py
+++ b/core/errors.py
@@ -1,6 +1,6 @@
 class YetiError(RuntimeError):
-    def __init__(self, message: str, meta: dict):
-        self.meta = meta
+    def __init__(self, message: str, meta: dict | None = None):
+        self.meta = meta or {}
         super().__init__(message)
 
 

--- a/tests/apiv2/indicators.py
+++ b/tests/apiv2/indicators.py
@@ -172,10 +172,10 @@ class IndicatorTest(unittest.TestCase):
             "/api/v2/indicators/",
             json={"indicator": indicator_dict},
         )
-        self.assertEqual(response.status_code, 422)
+        self.assertEqual(response.status_code, 400)
         data = response.json()
         self.assertIn(
-            "No valid Yara rules found in the rule body", data["detail"][0]["msg"]
+            "No valid Yara rules found in the rule body", data["detail"]["description"]
         )
 
     def test_bad_yara_graceful_failure(self):


### PR DESCRIPTION
This PR introduces some changes in the way Yara rules are managed

* Validation of the rule is only called upon saving the object (no more validating when reading from the database, which caused many slowdowns. We're assuming that the rules that make it to the database are sound)
* New API endpoint to generate bulk Yara exports with dependency resolution. Tested on ~2k rules, this takes about 0.5 seconds.