### PR TITLE
Move context attributes to a mixin

### DIFF
--- a/core/schemas/indicator.py
+++ b/core/schemas/indicator.py
@@ -7,7 +7,7 @@ from pydantic import ConfigDict, Field, computed_field
 
 from core import database_arango
 from core.helpers import now
-from core.schemas.model import YetiAclModel, YetiTagModel
+from core.schemas.model import YetiAclModel, YetiContextModel, YetiTagModel
 
 
 def future():
@@ -35,7 +35,9 @@ class DiamondModel(Enum):
     victim = "victim"
 
 
-class Indicator(YetiTagModel, YetiAclModel, database_arango.ArangoYetiConnector):
+class Indicator(
+    YetiTagModel, YetiAclModel, YetiContextModel, database_arango.ArangoYetiConnector
+):
     model_config = ConfigDict(str_strip_whitespace=True)
     _collection_name: ClassVar[str] = "indicators"
     _type_filter: ClassVar[str] = ""

--- a/core/schemas/model.py
+++ b/core/schemas/model.py
@@ -22,6 +22,44 @@ class YetiBaseModel(BaseModel):
         return self.__id
 
 
+class YetiContextModel(YetiBaseModel):
+    context: list[dict] = []
+
+    def add_context(self, source: str, context: dict, skip_compare: set = set()):
+        """Adds context to a Yeti object."""
+        compare_fields = set(context.keys()) - skip_compare - {"source"}
+        for idx, db_context in enumerate(list(self.context)):
+            if db_context["source"] != source:
+                continue
+            for field in compare_fields:
+                if db_context.get(field) != context.get(field):
+                    context["source"] = source
+                    self.context[idx] = context
+                    break
+            else:
+                db_context.update(context)
+                break
+        else:
+            context["source"] = source
+            self.context.append(context)
+        return self.save()
+
+    def delete_context(self, source: str, context: dict, skip_compare: set = set()):
+        """Deletes context from an observable."""
+        compare_fields = set(context.keys()) - skip_compare - {"source"}
+        for idx, db_context in enumerate(list(self.context)):
+            if db_context["source"] != source:
+                continue
+            for field in compare_fields:
+                if db_context.get(field) != context.get(field):
+                    break
+            else:
+                del self.context[idx]
+                break
+
+        return self.save()
+
+
 class YetiAclModel(YetiBaseModel):
     _acls: dict[str, RoleRelationship] = {}
 

--- a/core/schemas/model.py
+++ b/core/schemas/model.py
@@ -25,23 +25,44 @@ class YetiBaseModel(BaseModel):
 class YetiContextModel(YetiBaseModel):
     context: list[dict] = []
 
-    def add_context(self, source: str, context: dict, skip_compare: set = set()):
-        """Adds context to a Yeti object."""
+    def add_context(
+        self,
+        source: str,
+        context: dict,
+        skip_compare: set = set(),
+        overwrite: bool = False,
+    ):
+        """Adds context to a Yeti object.
+
+        Args:
+            source: The source of the context.
+            context: The context to add.
+            skip_compare: Fields to skip when comparing context.
+            overwrite: Whether to overwrite existing context regardless of comparison.
+        """
         compare_fields = set(context.keys()) - skip_compare - {"source"}
+
+        found_idx = -1
+        temp_context = {key: context.get(key) for key in compare_fields}
+
         for idx, db_context in enumerate(list(self.context)):
             if db_context["source"] != source:
                 continue
-            for field in compare_fields:
-                if db_context.get(field) != context.get(field):
-                    context["source"] = source
-                    self.context[idx] = context
-                    break
-            else:
-                db_context.update(context)
+            if overwrite:
+                found_idx = idx
                 break
+            temp_db = {key: db_context.get(key) for key in compare_fields}
+
+            if temp_db == temp_context:
+                found_idx = idx
+                break
+
+        context["source"] = source
+        if found_idx != -1:
+            self.context[found_idx] = context
         else:
-            context["source"] = source
             self.context.append(context)
+
         return self.save()
 
     def delete_context(self, source: str, context: dict, skip_compare: set = set()):

--- a/core/web/apiv2/context.py
+++ b/core/web/apiv2/context.py
@@ -1,0 +1,78 @@
+from typing import Type, TypeVar
+
+from fastapi import HTTPException, Request
+from pydantic import BaseModel, ConfigDict
+
+from core.schemas import audit
+
+T = TypeVar("T")
+
+
+class AddContextRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    context: dict
+    skip_compare: set = set()
+
+
+class DeleteContextRequest(AddContextRequest):
+    pass
+
+
+class ReplaceContextRequest(BaseModel):
+    context: list[dict]
+
+
+def replace_context(
+    base_type: Type[T], httpreq: Request, id: str, request: ReplaceContextRequest
+) -> T:
+    """Replaces context in an arbitrary Yeti Object."""
+    obj = base_type.get(id)
+    if not obj:
+        raise HTTPException(
+            status_code=404, detail=f"{base_type.__name__} {id} not found"
+        )
+
+    old_context = obj.context.copy()
+    obj.context = request.context
+    refreshed_obj = obj.save()
+    obj.context = old_context
+    audit.log_timeline(httpreq.state.username, refreshed_obj, old=obj)
+    return refreshed_obj
+
+
+def add_context(
+    base_type: Type[T], httpreq: Request, id: str, request: AddContextRequest
+) -> T:
+    """Adds context to an arbitrary Yeti Object."""
+    obj = base_type.get(id)
+    if not obj:
+        raise HTTPException(
+            status_code=404, detail=f"{base_type.__name__} {id} not found"
+        )
+
+    old_context = obj.context.copy()
+    refreshed_obj = obj.add_context(
+        request.source, request.context, skip_compare=request.skip_compare
+    )
+    obj.context = old_context
+    audit.log_timeline(httpreq.state.username, refreshed_obj, old=obj)
+    return refreshed_obj
+
+
+def delete_context(
+    base_type: Type[T], httpreq: Request, id: str, request: DeleteContextRequest
+) -> T:
+    """Deletes context from an arbitrary Yeti Object."""
+    obj = base_type.get(id)
+    if not obj:
+        raise HTTPException(
+            status_code=404, detail=f"{base_type.__name__} {id} not found"
+        )
+
+    old_context = obj.context.copy()
+    refreshed_obj = obj.delete_context(request.source, request.context)
+    obj.context = old_context
+    audit.log_timeline(httpreq.state.username, refreshed_obj, old=obj)
+    return refreshed_obj

--- a/core/web/apiv2/context.py
+++ b/core/web/apiv2/context.py
@@ -34,6 +34,12 @@ def replace_context(
             status_code=404, detail=f"{base_type.__name__} {id} not found"
         )
 
+    for item in request.context:
+        if "source" not in item:
+            raise HTTPException(
+                status_code=400, detail=f"Source is required in context {item}"
+            )
+
     old_context = obj.context.copy()
     obj.context = request.context
     refreshed_obj = obj.save()

--- a/core/web/apiv2/entities.py
+++ b/core/web/apiv2/entities.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field, conlist
 
-from core.schemas import audit, graph, rbac, roles, user
+from core.schemas import audit, graph, rbac, roles
 from core.schemas.entity import Entity, EntityType, EntityTypes
 from core.schemas.tag import MAX_TAGS_REQUEST
+
+from . import context
 
 
 # Request schemas
@@ -87,6 +89,33 @@ def patch(httpreq: Request, request: PatchEntityRequest, id: str) -> EntityTypes
     new = updated_entity.save()
     audit.log_timeline(httpreq.state.username, new, old=db_entity)
     return new
+
+
+@router.post("/{id}/context")
+@rbac.permission_on_target(roles.Permission.WRITE)
+def add_context(
+    httpreq: Request, id: str, request: context.AddContextRequest
+) -> EntityTypes:
+    """Adds context to an Entity."""
+    return context.add_context(Entity, httpreq, id, request)
+
+
+@router.put("/{id}/context")
+@rbac.permission_on_target(roles.Permission.WRITE)
+def replace_context(
+    httpreq: Request, id: str, request: context.ReplaceContextRequest
+) -> EntityTypes:
+    """Replaces context in an Entity."""
+    return context.replace_context(Entity, httpreq, id, request)
+
+
+@router.post("/{id}/context/delete")
+@rbac.permission_on_target(roles.Permission.WRITE)
+def delete_context(
+    httpreq: Request, id, request: context.DeleteContextRequest
+) -> EntityTypes:
+    """Removes context to an Entity."""
+    return context.delete_context(Entity, httpreq, id, request)
 
 
 @router.get("/{id}")

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -15,6 +15,8 @@ from core.schemas.indicator import (
 from core.schemas.rbac import global_permission, permission_on_ids, permission_on_target
 from core.schemas.tag import MAX_TAGS_REQUEST
 
+from . import context
+
 logger = logging.getLogger(__name__)
 
 
@@ -121,6 +123,33 @@ def patch(httpreq: Request, request: PatchIndicatorRequest, id: str) -> Indicato
     audit.log_timeline(httpreq.state.username, new, old=db_indicator)
     new.get_acls()
     return new
+
+
+@router.post("/{id}/context")
+@permission_on_target(roles.Permission.WRITE)
+def add_context(
+    httpreq: Request, id: str, request: context.AddContextRequest
+) -> IndicatorTypes:
+    """Adds context to an indicator."""
+    return context.add_context(Indicator, httpreq, id, request)
+
+
+@router.post("/{id}/context/replace")
+@permission_on_target(roles.Permission.WRITE)
+def replace_context(
+    httpreq: Request, id: str, request: context.ReplaceContextRequest
+) -> IndicatorTypes:
+    """Replaces context in an indicator."""
+    return context.replace_context(Indicator, httpreq, id, request)
+
+
+@router.post("/{id}/context/delete")
+@permission_on_target(roles.Permission.WRITE)
+def delete_context(
+    httpreq: Request, id, request: context.DeleteContextRequest
+) -> IndicatorTypes:
+    """Removes context to an indicator."""
+    return context.delete_context(Indicator, httpreq, id, request)
 
 
 @router.get("/{id}")

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -12,7 +12,6 @@ from core.schemas.indicator import (
     IndicatorTypes,
     Yara,
 )
-from core.schemas.rbac import global_permission, permission_on_ids, permission_on_target
 from core.schemas.tag import MAX_TAGS_REQUEST
 
 from . import context
@@ -85,7 +84,7 @@ router = APIRouter()
 
 
 @router.post("/")
-@global_permission(roles.Permission.WRITE)
+@rbac.global_permission(roles.Permission.WRITE)
 def new(httpreq: Request, request: NewIndicatorRequest) -> IndicatorTypes:
     """Creates a new indicator in the database."""
     try:
@@ -101,7 +100,7 @@ def new(httpreq: Request, request: NewIndicatorRequest) -> IndicatorTypes:
 
 
 @router.patch("/{id}")
-@permission_on_target(roles.Permission.WRITE)
+@rbac.permission_on_target(roles.Permission.WRITE)
 def patch(httpreq: Request, request: PatchIndicatorRequest, id: str) -> IndicatorTypes:
     """Modifies an indicator in the database."""
     db_indicator: IndicatorTypes = Indicator.get(id)
@@ -126,7 +125,7 @@ def patch(httpreq: Request, request: PatchIndicatorRequest, id: str) -> Indicato
 
 
 @router.post("/{id}/context")
-@permission_on_target(roles.Permission.WRITE)
+@rbac.permission_on_target(roles.Permission.WRITE)
 def add_context(
     httpreq: Request, id: str, request: context.AddContextRequest
 ) -> IndicatorTypes:
@@ -134,8 +133,8 @@ def add_context(
     return context.add_context(Indicator, httpreq, id, request)
 
 
-@router.post("/{id}/context/replace")
-@permission_on_target(roles.Permission.WRITE)
+@router.put("/{id}/context")
+@rbac.permission_on_target(roles.Permission.WRITE)
 def replace_context(
     httpreq: Request, id: str, request: context.ReplaceContextRequest
 ) -> IndicatorTypes:
@@ -144,7 +143,7 @@ def replace_context(
 
 
 @router.post("/{id}/context/delete")
-@permission_on_target(roles.Permission.WRITE)
+@rbac.permission_on_target(roles.Permission.WRITE)
 def delete_context(
     httpreq: Request, id, request: context.DeleteContextRequest
 ) -> IndicatorTypes:
@@ -153,7 +152,7 @@ def delete_context(
 
 
 @router.get("/{id}")
-@permission_on_target(roles.Permission.READ)
+@rbac.permission_on_target(roles.Permission.READ)
 def details(httpreq: Request, id: str) -> IndicatorTypes:
     """Returns details about an indicator."""
     db_indicator: IndicatorTypes = Indicator.get(id)  # type: ignore
@@ -165,7 +164,7 @@ def details(httpreq: Request, id: str) -> IndicatorTypes:
 
 
 @router.delete("/{id}")
-@permission_on_target(roles.Permission.DELETE)
+@rbac.permission_on_target(roles.Permission.DELETE)
 def delete(httpreq: Request, id: str) -> None:
     """Deletes an indicator."""
     db_indicator = Indicator.get(id)
@@ -198,7 +197,7 @@ def search(
 
 
 @router.post("/tag")
-@permission_on_ids(roles.Permission.WRITE)
+@rbac.permission_on_ids(roles.Permission.WRITE)
 def tag(httpreq: Request, request: IndicatorTagRequest) -> IndicatorTagResponse:
     """Tags entities."""
     indicators = []

--- a/core/web/apiv2/observables.py
+++ b/core/web/apiv2/observables.py
@@ -240,7 +240,7 @@ def add_context(
     return context.add_context(Observable, httpreq, id, request)
 
 
-@router.post("/{id}/context/replace")
+@router.put("/{id}/context")
 @permission_on_target(roles.Permission.WRITE)
 def replace_context(
     httpreq: Request, id: str, request: context.ReplaceContextRequest

--- a/tests/apiv2/entities.py
+++ b/tests/apiv2/entities.py
@@ -48,6 +48,35 @@ class EntityTest(unittest.TestCase):
         self.assertEqual(data["name"], "ta2")
         self.assertEqual(data["type"], "threat-actor")
 
+    def test_add_context(self):
+        response = client.post(
+            f"/api/v2/entities/{self.entity1.id}/context",
+            json={"source": "testSource", "context": {"test": "test"}},
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(data["context"], [{"test": "test", "source": "testSource"}])
+
+    def test_replace_context(self):
+        self.entity1.add_context("testSource", {"test": "test"})
+        response = client.put(
+            f"/api/v2/entities/{self.entity1.id}/context",
+            json={"context": [{"test2": "test2", "source": "blahSource"}]},
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(data["context"], [{"test2": "test2", "source": "blahSource"}])
+
+    def test_delete_context(self):
+        self.entity1.add_context("testSource", {"test": "test"})
+        response = client.post(
+            f"/api/v2/entities/{self.entity1.id}/context/delete",
+            json={"source": "testSource", "context": {"test": "test"}},
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(data["context"], [])
+
     def test_get_entity(self):
         response = client.get(f"/api/v2/entities/{self.entity1.id}")
         self.assertEqual(response.status_code, 200)

--- a/tests/apiv2/indicators.py
+++ b/tests/apiv2/indicators.py
@@ -61,6 +61,35 @@ class IndicatorTest(unittest.TestCase):
         self.assertEqual(data["name"], "otherRegex")
         self.assertEqual(data["type"], "regex")
 
+    def test_add_context(self):
+        response = client.post(
+            f"/api/v2/indicators/{self.indicator1.id}/context",
+            json={"source": "testSource", "context": {"test": "test"}},
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(data["context"], [{"test": "test", "source": "testSource"}])
+
+    def test_replace_context(self):
+        self.indicator1.add_context("testSource", {"test": "test"})
+        response = client.put(
+            f"/api/v2/indicators/{self.indicator1.id}/context",
+            json={"context": [{"test2": "test2", "source": "blahSource"}]},
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(data["context"], [{"test2": "test2", "source": "blahSource"}])
+
+    def test_delete_context(self):
+        self.indicator1.add_context("testSource", {"test": "test"})
+        response = client.post(
+            f"/api/v2/indicators/{self.indicator1.id}/context/delete",
+            json={"source": "testSource", "context": {"test": "test"}},
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(data["context"], [])
+
     def test_get_indicator(self):
         response = client.get(f"/api/v2/indicators/{self.indicator1.id}")
         data = response.json()

--- a/tests/apiv2/observables.py
+++ b/tests/apiv2/observables.py
@@ -489,6 +489,16 @@ class ObservableContextTest(unittest.TestCase):
         data = response.json()
         self.assertEqual(data["context"], [{"key": "value", "source": "test_source"}])
 
+    def test_replace_context(self) -> None:
+        self.observable.add_context("test_source", {"key": "value"})
+        response = client.put(
+            f"/api/v2/observables/{self.observable.id}/context",
+            json={"context": [{"key": "value2", "source": "blahSource"}]},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["context"], [{"key": "value2", "source": "blahSource"}])
+
     def test_search_context(self) -> None:
         """Tests that we can filter observables based on context subfields."""
         time.sleep(1)

--- a/tests/schemas/entity.py
+++ b/tests/schemas/entity.py
@@ -81,6 +81,18 @@ class EntityTest(unittest.TestCase):
         self.assertEqual(tool_entities[0], self.tool1)
         self.assertEqual(malware_entities[0], self.malware1)
 
+    def test_add_context(self) -> None:
+        entity_obj = ThreatActor(name="APT123").save()
+        entity_obj.add_context("test_source", {"abc": 123, "def": 456})
+        entity_obj.add_context("test_source2", {"abc": 123, "def": 456})
+
+        entity_obj = ThreatActor.get(entity_obj.id)
+        self.assertEqual(len(entity_obj.context), 2)
+        self.assertEqual(entity_obj.context[0]["source"], "test_source")
+        self.assertEqual(entity_obj.context[1]["source"], "test_source2")
+        self.assertEqual(entity_obj.context[0]["abc"], 123)
+        self.assertEqual(entity_obj.context[1]["abc"], 123)
+
     def test_filter_entities(self):
         time.sleep(0.5)  # wait for views to catch up
         entities, total = Entity.filter({"name": "APT123"})

--- a/tests/schemas/indicator.py
+++ b/tests/schemas/indicator.py
@@ -52,6 +52,20 @@ class IndicatorTest(unittest.TestCase):
         self.assertIsInstance(indicator_obj.diamond, DiamondModel)
         self.assertEqual(indicator_obj.diamond, DiamondModel.capability)
 
+    def test_add_context(self) -> None:
+        indicator_obj = indicator.save(
+            name="regex1", type="regex", pattern="asd", diamond="capability"
+        )
+        indicator_obj.add_context("test_source", {"abc": 123, "def": 456})
+        indicator_obj.add_context("test_source2", {"abc": 123, "def": 456})
+
+        indicator_obj = Regex.get(indicator_obj.id)
+        self.assertEqual(len(indicator_obj.context), 2)
+        self.assertEqual(indicator_obj.context[0]["source"], "test_source")
+        self.assertEqual(indicator_obj.context[1]["source"], "test_source2")
+        self.assertEqual(indicator_obj.context[0]["abc"], 123)
+        self.assertEqual(indicator_obj.context[1]["abc"], 123)
+
     def test_filter_entities_different_types(self) -> None:
         regex = Regex(
             name="regex1",


### PR DESCRIPTION
* Extracts the context attribute to its own mixin so it can be reused by other types than just observables
* Add API endpoints for full context replacement (useful when we will be sending the whole context through the UI)