### PR TITLE
Update OpenPhish feed URL to new GitHub location

### DIFF
--- a/plugins/feeds/public/openphish.py
+++ b/plugins/feeds/public/openphish.py
@@ -8,7 +8,7 @@ from core.schemas import observable, task
 
 class OpenPhish(task.FeedTask):
     # set default values for feed
-    _SOURCE: ClassVar["str"] = "https://openphish.com/feed.txt"
+    _SOURCE: ClassVar["str"] = "https://raw.githubusercontent.com/openphish/public_feed/refs/heads/main/feed.txt"
     _defaults = {
         "frequency": timedelta(hours=1),
         "name": "OpenPhish",


### PR DESCRIPTION
This PR updates the OpenPhish feed URL to point to their new GitHub-hosted location.

The original feed URL occasionally becomes unavailable, while the GitHub-based feed is now officially listed as a reliable alternative.

Switching to the GitHub feed ensures better reliability and availability of threat intelligence data.