### PR TITLE
[ISSUE-1173] Add 'description' field to tags 

### DIFF
--- a/core/schemas/tag.py
+++ b/core/schemas/tag.py
@@ -32,6 +32,8 @@ class Tag(YetiModel, database_arango.ArangoYetiConnector):
     _type_filter: ClassVar[str | None] = None
 
     name: str = Field(max_length=MAX_TAG_LENGTH)
+    description: str | None = None
+
     count: int = 0
     created: datetime.datetime = Field(default_factory=now)
     default_expiration: datetime.timedelta = DEFAULT_EXPIRATION

--- a/core/web/apiv2/tag.py
+++ b/core/web/apiv2/tag.py
@@ -11,6 +11,7 @@ class NewRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str
+    description: str | None = None
     default_expiration: datetime.timedelta = DEFAULT_EXPIRATION
     produces: list[str] = []
     replaces: list[str] = []
@@ -63,6 +64,7 @@ def new(request: NewRequest) -> Tag:
     """Creates a new observable in the database."""
     tag = Tag(
         name=request.name,
+        description=request.description,
         default_expiration=request.default_expiration,
         created=datetime.datetime.now(datetime.timezone.utc),
         produces=request.produces,
@@ -89,6 +91,7 @@ def update(tag_id: str, request: UpdateRequest) -> Tag:
         raise HTTPException(status_code=404, detail="Item not found")
 
     tag.name = request.name
+    tag.description = request.description
     tag.produces = request.produces
     tag.replaces = request.replaces
     tag.default_expiration = request.default_expiration

--- a/tests/apiv2/tags.py
+++ b/tests/apiv2/tags.py
@@ -40,9 +40,11 @@ class tagTest(unittest.TestCase):
     def test_update_tag(self):
         response = client.put(
             f"/api/v2/tags/{self.tag.id}",
-            json={"name": "tag111",
-             "description": "krafta",
-             "default_expiration": "P10D"},
+            json={
+              "name": "tag111",
+              "description": "krafta",
+              "default_expiration": "P10D"
+            },
         )
         data = response.json()
         self.assertEqual(response.status_code, 200, data)

--- a/tests/apiv2/tags.py
+++ b/tests/apiv2/tags.py
@@ -41,9 +41,9 @@ class tagTest(unittest.TestCase):
         response = client.put(
             f"/api/v2/tags/{self.tag.id}",
             json={
-              "name": "tag111",
-              "description": "krafta",
-              "default_expiration": "P10D"
+                "name": "tag111",
+                "description": "krafta",
+                "default_expiration": "P10D",
             },
         )
         data = response.json()

--- a/tests/apiv2/tags.py
+++ b/tests/apiv2/tags.py
@@ -40,12 +40,15 @@ class tagTest(unittest.TestCase):
     def test_update_tag(self):
         response = client.put(
             f"/api/v2/tags/{self.tag.id}",
-            json={"name": "tag111", "default_expiration": "P10D"},
+            json={"name": "tag111",
+             "description": "krafta",
+             "default_expiration": "P10D"},
         )
         data = response.json()
         self.assertEqual(response.status_code, 200, data)
         self.assertEqual(self.tag.id, data["id"])
         self.assertEqual(data["name"], "tag111")
+        self.assertEqual(data["description"], "krafta")
         self.assertEqual(data["default_expiration"], "P10D")  # 10 daysin ISO 8601
 
     def test_tag_search(self):

--- a/tests/schemas/tag.py
+++ b/tests/schemas/tag.py
@@ -17,8 +17,9 @@ class TagTest(unittest.TestCase):
 
     def test_tag_create(self) -> None:
         """Test that a tag can be created"""
-        tag = Tag(name="test").save()
+        tag = Tag(name="test", description="test-desc").save()
         self.assertEqual(tag.name, "test")
+        self.assertEqual(tag.description, "test-desc")
         self.assertIsNotNone(tag.id)
 
     def test_tags_persist(self) -> None:


### PR DESCRIPTION
### Summary
Add a `description` field to `tags` and updated the associated tests. This addresses #1173 "Associate description to tags".

### Tests
Tests passed cleanly -- most of the time -- in the `api` container. `test_yara_bundle_with_overlays` in `indicators.py` appears to be flaky and _does not_ pass each time.