### PR TITLE
fix: add authentication to audit router (GHSA-34r4-95hx-gxqr)

### DIFF
--- a/core/web/webapp.py
+++ b/core/web/webapp.py
@@ -40,7 +40,12 @@ api_router = APIRouter()
 
 api_router.include_router(auth.router, prefix="/auth", tags=["auth"])
 
-api_router.include_router(audit.router, prefix="/audit", tags=["audit"])
+api_router.include_router(
+    audit.router,
+    prefix="/audit",
+    tags=["audit"],
+    dependencies=[Depends(auth.get_current_active_user)],
+)
 
 api_router.include_router(
     agents.router,


### PR DESCRIPTION
## Why

The `/api/v2/audit/timeline/{id}` endpoint was reachable by any unauthenticated network attacker (GHSA-34r4-95hx-gxqr, CVSS 7.5 High). The audit router was the only router in the application registered without an auth dependency, allowing anyone with network access to retrieve the complete audit trail -- actor usernames, object values (IPs, domains, URLs, hashes), and the full before/after details of every create/update/delete action ever performed on Yeti objects.

## What changed

`core/web/webapp.py`: added `dependencies=[Depends(auth.get_current_active_user)]` to the `audit.router` registration, consistent with every other router in the application (agents, observables, entities, indicators, etc.).

```python
# before
api_router.include_router(audit.router, prefix="/audit", tags=["audit"])

# after
api_router.include_router(
    audit.router,
    prefix="/audit",
    tags=["audit"],
    dependencies=[Depends(auth.get_current_active_user)],
)
```

One-line fix, zero behaviour change for authenticated users.