### PR TITLE
fix: prevent AQL injection via sorting and filter_aliases parameters

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -1156,6 +1156,8 @@ class ArangoYetiConnector(AbstractYetiConnector):
                     key_conditions = [f"REGEX_TEST(o.@arg{i}_key, @arg{i}_value, true)"]
 
                 for alias, alias_type in aliases:
+                    if alias != "tags":
+                        _validate_sort_field(alias)
                     if alias == "tags":
                         if using_view:
                             key_conditions.append(

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -54,6 +54,7 @@ def _validate_sort_field(field: str) -> str:
         )
     return field
 
+
 TYetiObject = TypeVar("TYetiObject", bound="ArangoYetiConnector")
 
 

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 import logging
+import re
 import sys
 import time
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Type, TypeVar
@@ -40,6 +41,18 @@ TESTING = "unittest" in sys.modules.keys()
 ASYNC_JOB_WAIT_TIME = 0.01
 
 RBAC_ENABLED = yeti_config.get("rbac", "enabled", default=False)
+
+_SAFE_FIELD_RE = re.compile(r"^[a-zA-Z0-9_.]+$")
+
+
+def _validate_sort_field(field: str) -> str:
+    """Raise ValueError if *field* contains characters that could inject AQL."""
+    if not _SAFE_FIELD_RE.match(field):
+        raise ValueError(
+            f"Invalid sort field '{field}': only alphanumeric characters, "
+            "underscores and dots are allowed."
+        )
+    return field
 
 TYetiObject = TypeVar("TYetiObject", bound="ArangoYetiConnector")
 
@@ -854,6 +867,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
         }
         sorts = []
         for field, asc in sorting:
+            _validate_sort_field(field)
             sorts.append(f"p.edges[0].{field} {'ASC' if asc else 'DESC'}")
         sorting_aql = f"SORT {', '.join(sorts)}" if sorts else ""
 
@@ -1080,6 +1094,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
             if field == "total_links" and links_count:
                 sorts.append(f"total_links {'ASC' if asc else 'DESC'}")
             else:
+                _validate_sort_field(field)
                 sorts.append(f"o.{field} {'ASC' if asc else 'DESC'}")
 
         aql_args: dict[str, str | int | list] = {}

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -45,7 +45,7 @@ RBAC_ENABLED = yeti_config.get("rbac", "enabled", default=False)
 _SAFE_FIELD_RE = re.compile(r"^[a-zA-Z0-9_.]+$")
 
 
-def _validate_sort_field(field: str) -> str:
+def _validate_safe_field_name(field: str) -> str:
     """Raise ValueError if *field* contains characters that could inject AQL."""
     if not _SAFE_FIELD_RE.match(field):
         raise ValueError(
@@ -868,7 +868,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
         }
         sorts = []
         for field, asc in sorting:
-            _validate_sort_field(field)
+            _validate_safe_field_name(field)
             sorts.append(f"p.edges[0].{field} {'ASC' if asc else 'DESC'}")
         sorting_aql = f"SORT {', '.join(sorts)}" if sorts else ""
 
@@ -1095,7 +1095,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
             if field == "total_links" and links_count:
                 sorts.append(f"total_links {'ASC' if asc else 'DESC'}")
             else:
-                _validate_sort_field(field)
+                _validate_safe_field_name(field)
                 sorts.append(f"o.{field} {'ASC' if asc else 'DESC'}")
 
         aql_args: dict[str, str | int | list] = {}
@@ -1158,7 +1158,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
 
                 for alias, alias_type in aliases:
                     if alias != "tags":
-                        _validate_sort_field(alias)
+                        _validate_safe_field_name(alias)
                     if alias == "tags":
                         if using_view:
                             key_conditions.append(


### PR DESCRIPTION
## Why

Three AQL injection vectors existed in `core/database_arango.py` where user-supplied strings were interpolated directly into AQL query text. ArangoDB bind variables only protect `@`-prefixed values -- they cannot bind attribute identifiers. Any authenticated (non-admin) user could exploit these endpoints to inject arbitrary AQL expressions, including cross-collection reads of sensitive data such as the `users` collection (password hashes, admin flags).

Tracked in security advisories GHSA-xgwm-74g7-wfmq, GHSA-w697-5f26-qx88, and GHSA-vw33-fwfx-6m9p (canonical). CVSS 3.1: `AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:L` (7.1 High).

## What changed

Added a `_validate_sort_field()` helper that rejects any field/alias name containing characters outside `[a-zA-Z0-9_.]`, raising `ValueError` before the value reaches the query string.

The three vulnerable interpolation sites patched:

| Location | Vulnerable pattern |
|---|---|
| `filter()` -- sorting | `f"o.{field} ASC\|DESC"` |
| `neighbors()` -- sorting | `f"p.edges[0].{field} ASC\|DESC"` |
| `filter()` -- filter_aliases | `f"ANALYZER(LIKE(o.{alias}, ...))"` and list variants |

Affected API endpoints (all search routes that accept `sorting` or `filter_aliases`):
- `POST /api/v2/observables/search`
- `POST /api/v2/entities/search`
- `POST /api/v2/indicators/search`
- `POST /api/v2/dfiq/search`
- `POST /api/v2/tasks/search`
- `POST /api/v2/search/`
- `POST /api/v2/graph/search`

## Notes

- Legitimate field names (`name`, `created`, `tags.name`, `root_type`, `total_links`, etc.) all pass the regex unchanged.
- The `tags` alias is hardcoded server-side and bypasses the check intentionally.
- No schema or API contract changes -- invalid field names now return an error instead of forwarding malformed AQL to ArangoDB.