### PR TITLE
fix: use correct Pydantic discriminator field name in observable endpoints

### DIFF
--- a/core/web/apiv2/observables.py
+++ b/core/web/apiv2/observables.py
@@ -42,13 +42,13 @@ class NewObservableRequest(TagRequestMixin):
 class NewExtendedObservableRequest(TagRequestMixin):
     model_config = ConfigDict(extra="forbid")
 
-    observable: ObservableTypes = Field(discriminant="type")
+    observable: ObservableTypes = Field(discriminator="type")
 
 
 class PatchObservableRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    observable: ObservableTypes = Field(discriminant="type")
+    observable: ObservableTypes = Field(discriminator="type")
 
 
 class NewBulkObservableAddRequest(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "httpx>=0.23.3",
     "ruff>=0.9.0",
     "httpx>=0.28.1",
+    "pytest>=9.1.1",
 ]
 plugins = [
     "pymisp>=2.4.176",

--- a/tests/apiv2/observables.py
+++ b/tests/apiv2/observables.py
@@ -343,6 +343,17 @@ class ObservableTest(unittest.TestCase):
         self.assertEqual(data["tags"][0]["fresh"], True)
         self.assertEqual(data["tags"][1]["fresh"], True)
 
+    def test_create_extended_observable_missing_type_raises_error(self):
+        response = client.post(
+            "/api/v2/observables/extended",
+            json={
+                "observable": {
+                    "value": "1.2.3.4",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 422)
+
     def test_bulk_add(self):
         request = {
             "observables": [

--- a/uv.lock
+++ b/uv.lock
@@ -639,6 +639,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "ipwhois"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -995,6 +1004,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "plyara"
 version = "2.2.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1210,6 +1228,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/26/e25b4a374b4639e0c235527bbe31c0524f26eda701d79456a7e1877f4cc5/pyopenssl-25.0.0.tar.gz", hash = "sha256:cd2cef799efa3936bb08e8ccb9433a575722b9dd986023f1cabc4ae64e9dac16", size = 179573, upload-time = "2025-01-12T17:22:48.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/d7/eb76863d2060dcbe7c7e6cccfd95ac02ea0b9acc37745a0d99ff6457aefb/pyOpenSSL-25.0.0-py3-none-any.whl", hash = "sha256:424c247065e46e76a37411b9ab1782541c23bb658bf003772c3405fbaa128e90", size = 56453, upload-time = "2025-01-12T17:22:43.44Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -1846,6 +1882,7 @@ dev = [
     { name = "httpx" },
     { name = "mypy" },
     { name = "pylint" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 plugins = [
@@ -1899,6 +1936,7 @@ dev = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "pylint", specifier = ">=2.16.1" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.9.0" },
 ]
 plugins = [


### PR DESCRIPTION
## Problem

`Field(discriminant="type")` was used in `NewExtendedObservableRequest` and `PatchObservableRequest`. `discriminant` is not a valid Pydantic v2 parameter -- Pydantic silently ignores unknown keyword arguments on `Field()`, so the discriminated union was never set up.

As a result, when a client omits the `type` field on `POST /api/v2/observables/extended` or `PATCH /api/v2/observables/{id}`, Pydantic would try each union member in order and silently accept the first one that validated, misclassifying the observable without returning any error.

## Fix

Replace `discriminant` with the correct `discriminator` (two occurrences in `core/web/apiv2/observables.py`). With the correct spelling, Pydantic enforces that `type` must be present and must match a known literal value; a missing or unknown `type` now returns HTTP 422.

A regression test (`test_create_extended_observable_missing_type_raises_error`) has been added to cover this case.

Closes #1273