### PR TITLE
fix: prevent path traversal in ExportTask file name (GHSA-4q3w-w2g5-8wqq)

### DIFF
--- a/core/clients/file_storage/classes/local_storage.py
+++ b/core/clients/file_storage/classes/local_storage.py
@@ -18,7 +18,9 @@ class LocalStorageClient(FileStorageClient):
         base = self.path.resolve()
         target = (base / file_name).resolve()
         if target != base and base not in target.parents:
-            raise ValueError(f"Invalid file name: {file_name!r} escapes storage directory")
+            raise ValueError(
+                f"Invalid file name: {file_name!r} escapes storage directory"
+            )
         return target
 
     def file_path(self, file_name: str) -> str:

--- a/core/clients/file_storage/classes/local_storage.py
+++ b/core/clients/file_storage/classes/local_storage.py
@@ -15,7 +15,11 @@ class LocalStorageClient(FileStorageClient):
         logging.info(f"Initialized local storage client with path {self.path}")
 
     def _file_path(self, file_name: str) -> pathlib.Path:
-        return self.path.joinpath(file_name)
+        base = self.path.resolve()
+        target = (base / file_name).resolve()
+        if target != base and base not in target.parents:
+            raise ValueError(f"Invalid file name: {file_name!r} escapes storage directory")
+        return target
 
     def file_path(self, file_name: str) -> str:
         return str(self._file_path(file_name))

--- a/core/schemas/task.py
+++ b/core/schemas/task.py
@@ -295,7 +295,9 @@ class ExportTask(Task):
     @property
     def file_name(self) -> str:
         """Returns the output file for the export."""
-        safe_name = re.sub(r"[^A-Za-z0-9_.\-]", "_", self.name.replace(" ", "_").lower())
+        safe_name = re.sub(
+            r"[^A-Za-z0-9_.\-]", "_", self.name.replace(" ", "_").lower()
+        )
         return pathlib.Path(safe_name).name
 
     def run(self) -> None:

--- a/core/schemas/task.py
+++ b/core/schemas/task.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import pathlib
 import re
 from enum import Enum
 from io import BytesIO
@@ -294,7 +295,8 @@ class ExportTask(Task):
     @property
     def file_name(self) -> str:
         """Returns the output file for the export."""
-        return self.name.replace(" ", "_").lower()
+        safe_name = re.sub(r"[^A-Za-z0-9_.\-]", "_", self.name.replace(" ", "_").lower())
+        return pathlib.Path(safe_name).name
 
     def run(self) -> None:
         """Runs the export asynchronously."""

--- a/tests/core_tests/local_storage.py
+++ b/tests/core_tests/local_storage.py
@@ -1,0 +1,25 @@
+import pathlib
+import tempfile
+import unittest
+
+from core.clients.file_storage.classes.local_storage import LocalStorageClient
+
+
+class LocalStorageClientTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tmpdir_path = str(pathlib.Path(self.tmpdir.name).resolve())
+        self.client = LocalStorageClient(self.tmpdir.name)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_file_path_rejects_traversal(self):
+        """Tests that a path escaping the storage directory is rejected
+        (GHSA-4q3w-w2g5-8wqq)."""
+        with self.assertRaises(ValueError):
+            self.client.file_path("../../../../../../etc/passwd")
+
+    def test_file_path_allows_normal_names(self):
+        path = self.client.file_path("randomexport")
+        self.assertTrue(path.startswith(self.tmpdir_path))

--- a/tests/core_tests/tasks.py
+++ b/tests/core_tests/tasks.py
@@ -298,6 +298,18 @@ class ExportTaskTest(unittest.TestCase):
         self.assertEqual(filename, "randomexport")
         yeti_config.system.export_path = previous
 
+    def test_file_name_sanitizes_path_traversal(self):
+        """Tests that ExportTask.file_name neutralizes path traversal attempts
+        (GHSA-4q3w-w2g5-8wqq)."""
+        task = ExportTask(
+            name="../../../../../../etc/passwd",
+            acts_on=["hostname"],
+            template_name="RandomTemplate",
+        )
+        self.assertNotIn("/", task.file_name)
+        self.assertNotIn("\\", task.file_name)
+        self.assertEqual(task.file_name, ".._.._.._.._.._.._etc_passwd")
+
     def test_tag_filtering(self):
         """Tests that the tag filtering works as intended."""
         task = ExportTask.find(name="RandomExport")


### PR DESCRIPTION
## Summary
- Fixes [GHSA-4q3w-w2g5-8wqq](https://github.com/yeti-platform/yeti/security/advisories/GHSA-4q3w-w2g5-8wqq): `ExportTask.file_name` only replaced spaces in the user-controlled task `name`, so a name like `../../../../etc/passwd` could be used through `POST /api/v2/tasks/export/new` and `GET /api/v2/tasks/export/{export_id}/content` to read/write arbitrary files reachable by the YETI service account.
- `core/schemas/task.py`: `ExportTask.file_name` now strips everything outside `[A-Za-z0-9_.-]` and takes only the final path component, so no path separators or `..` traversal sequences can reach the storage backend.
- `core/clients/file_storage/classes/local_storage.py`: `_file_path` now resolves the target path and raises if it escapes the configured storage directory, as defense in depth in case a file name reaches this layer unsanitized from another caller.

## Test plan
- [x] Verified the sanitizer neutralizes `../../../../../../etc/passwd`, `..%2f..%2fetc%2fpasswd`, and normal names like `My Report 2026`.
- [x] Verified both edited files parse (`ast.parse`).
- [ ] Run the existing task/export test suite in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)