### PR TITLE
fix: correct template_dir config key, add example export templates

### DIFF
--- a/extras/templates/csv_export.jinja2
+++ b/extras/templates/csv_export.jinja2
@@ -1,0 +1,10 @@
+{#
+  Example export template: a simple CSV of observable value, type and tags.
+
+  See json_export.jinja2 in this directory for a full rundown of the
+  fields available on each `row` in `data`.
+#}
+value,type,tags
+{% for row in data -%}
+{{ row.value }},{{ row.type }},"{{ row.tags|map(attribute="name")|join(";") }}"
+{% endfor -%}

--- a/extras/templates/json_export.jinja2
+++ b/extras/templates/json_export.jinja2
@@ -1,0 +1,24 @@
+{#
+  Example export template: one JSON object per line (JSONL).
+
+  `data` is the only variable available to export templates: a list of
+  Observable objects (see core/schemas/observable.py and
+  core/schemas/observables/*.py for the full list of types and their
+  type-specific fields, e.g. Hostname, IPv4, Url, ...).
+
+  Common fields available on every observable:
+    row.value      - the observable's value, e.g. "1.2.3.4"
+    row.type       - the observable type, e.g. "ipv4", "hostname", "url"
+    row.tags       - list of tag objects, each with a .name and .fresh
+    row.created    - creation timestamp
+    row.modified   - last modification timestamp
+    row.context    - list of context dicts attached to the observable
+
+  Note: {{ row|tojson }} on the whole object does NOT produce clean JSON,
+  because minijinja serializes the underlying Python object as a list of
+  (key, value) pairs rather than a dict. Build the object you want to
+  export explicitly instead, as shown below.
+#}
+{% for row in data -%}
+{"value": {{ row.value|tojson }}, "type": {{ row.type|tojson }}, "tags": {{ row.tags|map(attribute="name")|list|tojson }}, "created": {{ row.created|tojson }}}
+{% endfor -%}

--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -9,7 +9,11 @@ export_path = /opt/yeti/exports
 logging = /var/log/yeti_user_activity.log
 plugins_path = ./plugins
 audit_logfile = /var/log/yeti_audit.log
-templates_dir = /opt/yeti/templates
+
+# Directory holding export templates (*.jinja2 files, see
+# extras/templates/README.md). Both the api and tasks (worker) services read
+# from this directory, so it must be mounted/shared on both.
+template_dir = /opt/yeti/templates
 
 # Public scheme + hostname + port for Yeti. Use it if you want to specify an
 # OIDC callback


### PR DESCRIPTION
## Summary
Addresses #1256 ("No doc for or example export templates exist"):

- `yeti.conf.sample` defined `templates_dir`, but the code
  (`core/schemas/template.py`, `core/web/apiv2/templates.py`) reads
  `template_dir` (singular) via `yeti_config.get("system", "template_dir", ...)`.
  A user setting `templates_dir` per the sample config had it silently
  ignored, always falling back to the default `/opt/yeti/templates`.
  Renamed the key and added a comment on the required api/tasks volume
  sharing.
- Added `extras/templates/json_export.jinja2` and
  `extras/templates/csv_export.jinja2` as annotated starting points,
  documenting the only context variable available to export templates
  (`data`, a list of `Observable` objects) and its common fields.
- The write-up of the `data` context and getting-started guide for the
  docs site is tracked separately against yeti-platform.github.io.

## Test plan
- [x] Rendered both example templates locally against a mock `Observable`
      with tags; output validated as well-formed JSON/CSV.
- [ ] CI: ruff lint + unit tests