### PR TITLE
ci: run ruff from the version pinned in uv.lock

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -16,9 +16,9 @@ jobs:
       - run:
           sudo apt-get update && sudo apt-get install -y python3-pip && sudo pip3 install uv
       - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
-      - name: Install ruff
-        run: uv tool install ruff
+      - name: Install ruff (pinned via uv.lock)
+        run: uv sync --only-group dev
       - name: Run ruff lint check
-        run: ruff check .
+        run: uv run --no-sync ruff check .
       - name: Run ruff format check
-        run: ruff format . --check
+        run: uv run --no-sync ruff format . --check


### PR DESCRIPTION
The Lint workflow installed ruff with an unpinned `uv tool install ruff`, which floated to whatever was latest on PyPI (0.15.x) while the project pinned ruff in its dev dependency group. The two disagreed on isort grouping, so CI could fail on code that passed locally (and vice versa).

Install the dev dependency group (`uv sync --only-group dev`) and run ruff via `uv run --no-sync ruff`, so CI uses exactly the ruff version locked in uv.lock. `--only-group dev` pulls just the lightweight tooling (ruff, mypy, pylint, pytest), not the project's runtime deps, so the job stays fast. Bumping ruff is now a deliberate uv.lock change reviewed like any other dependency, and CI and local always agree.