### PR TITLE
refactor(schemas): register observable/entity/indicator types statically

### DIFF
--- a/core/schemas/__init__.py
+++ b/core/schemas/__init__.py
@@ -1,13 +1,5 @@
-import importlib
-import inspect
-import logging
-import re
-from pathlib import Path
-
-import aenum
-
 from core.events import message
-from core.schemas import (
+from core.schemas import (  # noqa: F401  (imported for their side-effect registration)
     dfiq,
     entity,
     graph,
@@ -20,84 +12,8 @@ from core.schemas import (
     user,
 )
 
-logger = logging.getLogger(__name__)
-logging.getLogger().setLevel(logging.INFO)
-
-
-def register_module(module_name, base_module):
-    """
-    Register the classes for the schema implementation files
-
-    module_name: The module name to load
-    base_module: The base module to register the classes in (entity, indicator, observable)
-    """
-    module = importlib.import_module(module_name)
-    module_base_name = base_module.__name__.split(".")[-1]
-    schema_base_class = getattr(base_module, module_base_name.capitalize())
-    schema_type_mapping = getattr(base_module, "TYPE_MAPPING")
-    schema_types = getattr(base_module, f"{module_base_name.capitalize()}Types", None)
-    schema_enum = getattr(base_module, f"{module_base_name.capitalize()}Type")
-    for _, obj in inspect.getmembers(module, inspect.isclass):
-        if issubclass(obj, schema_base_class) and "type" in obj.model_fields:
-            obs_type = obj.model_fields["type"].default
-            logger.info(f"Registering class {obj.__name__} defining type <{obs_type}>")
-            aenum.extend_enum(schema_enum, obs_type, obs_type)
-            schema_type_mapping[obs_type] = obj
-            setattr(base_module, obj.__name__, obj)
-            if not schema_types:
-                schema_types = obj
-            else:
-                schema_types |= obj
-            setattr(base_module, f"{module_base_name.capitalize()}Types", schema_types)
-
-
-def register_classes(schema_root_type, base_module):
-    """
-    Register the classes for the schema root type
-
-    schema_root_type: The schema root type to work with (entities, indicators, observables)
-    base_module: The base module to register the classes in (entity, indicator, observable)
-    """
-    module_base_name = base_module.__name__.split(".")[-1]
-    logger.info(f"Registering {module_base_name} classes")
-    for schema_file in Path(__file__).parent.glob(f"{schema_root_type}/**/*.py"):
-        if schema_file.stem == "__init__":
-            continue
-        if schema_file.parent.stem == schema_root_type:
-            module_name = f"core.schemas.{schema_root_type}.{schema_file.stem}"
-        elif schema_file.parent.stem == "private":
-            module_name = f"core.schemas.{schema_root_type}.private.{schema_file.stem}"
-        try:
-            register_module(module_name, base_module)
-        except Exception:
-            logger.exception(f"Failed to register classes from {module_name}")
-
-
-def load_entities():
-    entity.TYPE_MAPPING = {"entity": entity.Entity, "entities": entity.Entity}
-    register_classes("entities", entity)
-
-
-def load_indicators():
-    indicator.TYPE_MAPPING = {
-        "indicator": indicator.Indicator,
-        "indicators": indicator.Indicator,
-    }
-    register_classes("indicators", indicator)
-
-
-def load_observables():
-    observable.TYPE_MAPPING = {
-        "observable": observable.Observable,
-        "observables": observable.Observable,
-    }
-    if "guess" not in observable.ObservableType.__members__:
-        aenum.extend_enum(observable.ObservableType, "guess", "guess")
-    register_classes("observables", observable)
-
-
-load_observables()
-load_entities()
-load_indicators()
-
+# Importing the schema modules above triggers their static type registration
+# (see the "Static type registry" sections in observable.py / entity.py /
+# indicator.py; dfiq.py registers its own types inline). Rebuild the event
+# message model now that every referenced schema type is importable.
 message.EventMessage.model_rebuild()

--- a/core/schemas/entity.py
+++ b/core/schemas/entity.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import datetime
 from enum import Enum
-from typing import ClassVar, List, Literal
+from typing import ClassVar, List, Literal, Union
 
 from pydantic import ConfigDict, Field, computed_field
 
@@ -8,14 +10,10 @@ from core import database_arango
 from core.helpers import now
 from core.schemas.model import YetiAclModel, YetiContextModel, YetiTagModel
 
-
-# Forward declarations
-# They are then populated by the load_entities function in __init__.py
-class EntityType(str, Enum): ...
-
-
-EntityTypes = ()
-TYPE_MAPPING = {}
+# EntityType, EntityTypes and TYPE_MAPPING are defined statically at the bottom
+# of this module (see "Static type registry"). TYPE_MAPPING must exist before
+# the functions below are *called*, which is always the case at runtime.
+TYPE_MAPPING: dict[str, type["Entity"]] = {}
 
 
 class Entity(
@@ -80,3 +78,81 @@ def save(*, name: str, type: str, tags: List[str] = None, **kwargs):
 
 def find(*, name: str, **kwargs) -> "EntityTypes":
     return Entity.find(name=name, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Static type registry (see observable.py for the rationale).
+# ---------------------------------------------------------------------------
+from core.schemas.entities.attack_pattern import AttackPattern  # noqa: E402
+from core.schemas.entities.campaign import Campaign  # noqa: E402
+from core.schemas.entities.company import Company  # noqa: E402
+from core.schemas.entities.course_of_action import CourseOfAction  # noqa: E402
+from core.schemas.entities.identity import Identity  # noqa: E402
+from core.schemas.entities.intrusion_set import IntrusionSet  # noqa: E402
+from core.schemas.entities.investigation import Investigation  # noqa: E402
+from core.schemas.entities.malware import Malware  # noqa: E402
+from core.schemas.entities.note import Note  # noqa: E402
+from core.schemas.entities.phone import Phone  # noqa: E402
+from core.schemas.entities.threat_actor import ThreatActor  # noqa: E402
+from core.schemas.entities.tool import Tool  # noqa: E402
+from core.schemas.entities.vulnerability import Vulnerability  # noqa: E402
+from core.schemas.loader import load_private_types  # noqa: E402
+
+
+class EntityType(str, Enum):
+    # Member names must be valid identifiers, so the four hyphenated types use
+    # underscores here; the *values* keep the wire-format hyphens.
+    attack_pattern = "attack-pattern"
+    campaign = "campaign"
+    company = "company"
+    course_of_action = "course-of-action"
+    identity = "identity"
+    intrusion_set = "intrusion-set"
+    investigation = "investigation"
+    malware = "malware"
+    note = "note"
+    phone = "phone"
+    threat_actor = "threat-actor"
+    tool = "tool"
+    vulnerability = "vulnerability"
+
+
+_ENTITY_CLASSES: list[type[Entity]] = [
+    AttackPattern,
+    Campaign,
+    Company,
+    CourseOfAction,
+    Identity,
+    IntrusionSet,
+    Investigation,
+    Malware,
+    Note,
+    Phone,
+    ThreatActor,
+    Tool,
+    Vulnerability,
+]
+
+_private_entity_classes = load_private_types("core.schemas.entities", Entity)
+
+TYPE_MAPPING = {"entity": Entity, "entities": Entity}
+for _cls in (*_ENTITY_CLASSES, *_private_entity_classes):
+    TYPE_MAPPING[str(_cls.model_fields["type"].default)] = _cls
+
+EntityTypes = Union[
+    AttackPattern,
+    Campaign,
+    Company,
+    CourseOfAction,
+    Identity,
+    IntrusionSet,
+    Investigation,
+    Malware,
+    Note,
+    Phone,
+    ThreatActor,
+    Tool,
+    Vulnerability,
+]
+if _private_entity_classes:
+    EntityTypes = Union[(EntityTypes, *_private_entity_classes)]

--- a/core/schemas/indicator.py
+++ b/core/schemas/indicator.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import datetime
 import logging
 from enum import Enum
-from typing import Any, ClassVar, Generator, List, Literal
+from typing import Any, ClassVar, Generator, List, Literal, Union
 
 from pydantic import ConfigDict, Field, computed_field
 
@@ -18,14 +20,10 @@ def future():
 
 DEFAULT_INDICATOR_VALIDITY_DAYS = 30
 
-
-# Forward declarations
-# They are then populated by the load_indicators function in __init__.py
-class IndicatorType(str, Enum): ...
-
-
-IndicatorTypes = ()
-TYPE_MAPPING = {}
+# IndicatorType, IndicatorTypes and TYPE_MAPPING are defined statically at the
+# bottom of this module (see "Static type registry"). TYPE_MAPPING must exist
+# before the functions below are *called*, which is always the case at runtime.
+TYPE_MAPPING: dict[str, type["Indicator"]] = {}
 
 
 class DiamondModel(Enum):
@@ -130,3 +128,51 @@ def save(
 
 def find(*, name: str, **kwargs) -> "IndicatorTypes":
     return Indicator.find(name=name, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Static type registry (see observable.py for the rationale).
+# ---------------------------------------------------------------------------
+from core.schemas.indicators.forensicartifact import ForensicArtifact  # noqa: E402
+from core.schemas.indicators.query import Query  # noqa: E402
+from core.schemas.indicators.regex import Regex  # noqa: E402
+from core.schemas.indicators.sigma import Sigma  # noqa: E402
+from core.schemas.indicators.suricata import Suricata  # noqa: E402
+from core.schemas.indicators.yara import Yara  # noqa: E402
+from core.schemas.loader import load_private_types  # noqa: E402
+
+
+class IndicatorType(str, Enum):
+    forensicartifact = "forensicartifact"
+    query = "query"
+    regex = "regex"
+    sigma = "sigma"
+    suricata = "suricata"
+    yara = "yara"
+
+
+_INDICATOR_CLASSES: list[type[Indicator]] = [
+    ForensicArtifact,
+    Query,
+    Regex,
+    Sigma,
+    Suricata,
+    Yara,
+]
+
+_private_indicator_classes = load_private_types("core.schemas.indicators", Indicator)
+
+TYPE_MAPPING = {"indicator": Indicator, "indicators": Indicator}
+for _cls in (*_INDICATOR_CLASSES, *_private_indicator_classes):
+    TYPE_MAPPING[str(_cls.model_fields["type"].default)] = _cls
+
+IndicatorTypes = Union[
+    ForensicArtifact,
+    Query,
+    Regex,
+    Sigma,
+    Suricata,
+    Yara,
+]
+if _private_indicator_classes:
+    IndicatorTypes = Union[(IndicatorTypes, *_private_indicator_classes)]

--- a/core/schemas/loader.py
+++ b/core/schemas/loader.py
@@ -1,0 +1,47 @@
+"""Helper to load user-supplied ("private") schema types.
+
+The observable/entity/indicator packages each expose a `private` subpackage
+where deployments can drop in their own subtypes. Unlike the public types,
+these are not known statically, so they are discovered at import time by
+globbing the `private` subpackage. This is the only remaining dynamic hook in
+the schema layer — public types are all registered explicitly.
+"""
+
+import importlib
+import inspect
+import logging
+import pkgutil
+
+logger = logging.getLogger(__name__)
+
+
+def load_private_types(package_name: str, base_class: type) -> list[type]:
+    """Return the schema subclasses defined in `<package_name>.private`.
+
+    Args:
+        package_name: e.g. "core.schemas.observables".
+        base_class: the family base class (Observable/Entity/Indicator);
+            only its subclasses that declare a `type` field are returned.
+    """
+    classes: list[type] = []
+    try:
+        private_pkg = importlib.import_module(f"{package_name}.private")
+    except ModuleNotFoundError:
+        return classes
+
+    for _, modname, _ in pkgutil.iter_modules(private_pkg.__path__):
+        full_name = f"{package_name}.private.{modname}"
+        try:
+            module = importlib.import_module(full_name)
+        except Exception:
+            logger.exception(f"Failed to import private schema module {full_name}")
+            continue
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if (
+                obj.__module__ == module.__name__
+                and issubclass(obj, base_class)
+                and "type" in getattr(obj, "model_fields", {})
+            ):
+                logger.info(f"Registering private type {obj.__name__} from {full_name}")
+                classes.append(obj)
+    return classes

--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -1,12 +1,11 @@
+from __future__ import annotations
+
 import datetime
 import io
 import os
 import tempfile
-
-# Data Schema
-# Dynamically register all observable types
 from enum import Enum
-from typing import IO, ClassVar, List, Literal, Tuple
+from typing import IO, ClassVar, List, Literal, Tuple, Union
 
 import requests
 from bs4 import BeautifulSoup
@@ -16,14 +15,11 @@ from core import database_arango
 from core.helpers import now, refang
 from core.schemas.model import YetiAclModel, YetiContextModel, YetiTagModel
 
-
-# Forward declarations
-# They are then populated by the load_observables function in __init__.py
-class ObservableType(str, Enum): ...
-
-
-ObservableTypes = ()
-TYPE_MAPPING = {}
+# The concrete observable types, the ObservableType enum, the ObservableTypes
+# union and TYPE_MAPPING are all defined statically at the bottom of this
+# module (see "Static type registry"). TYPE_MAPPING must exist before the
+# functions below are *called*, which is always the case at runtime.
+TYPE_MAPPING: dict[str, type["Observable"]] = {}
 FileLikeObject = str | os.PathLike | IO | tempfile.SpooledTemporaryFile
 
 
@@ -257,3 +253,176 @@ def save_from_url(
             obs.tag(tags)
         saved_observables.append(obs)
     return saved_observables, unknown
+
+
+# ---------------------------------------------------------------------------
+# Static type registry
+#
+# Every observable subtype is imported and registered explicitly below. This
+# replaces the previous import-time reflection (aenum + directory globbing), so
+# ObservableType / ObservableTypes / TYPE_MAPPING are visible to static type
+# checkers and to FastAPI's OpenAPI generation.
+#
+# To add a new observable type: create the module under observables/ and add it
+# both to the imports and to _OBSERVABLE_CLASSES below. tests/schemas/registry
+# fails if a subtype is defined but not registered here.
+# ---------------------------------------------------------------------------
+from core.schemas.loader import load_private_types  # noqa: E402
+from core.schemas.observables.asn import ASN  # noqa: E402
+from core.schemas.observables.auth_secret import AuthSecret  # noqa: E402
+from core.schemas.observables.bic import BIC  # noqa: E402
+from core.schemas.observables.certificate import Certificate  # noqa: E402
+from core.schemas.observables.cidr import CIDR  # noqa: E402
+from core.schemas.observables.command_line import CommandLine  # noqa: E402
+from core.schemas.observables.container_image import (  # noqa: E402
+    ContainerImage,
+    DockerImage,
+)
+from core.schemas.observables.email import Email  # noqa: E402
+from core.schemas.observables.file import File  # noqa: E402
+from core.schemas.observables.generic import Generic  # noqa: E402
+from core.schemas.observables.hostname import Hostname  # noqa: E402
+from core.schemas.observables.iban import IBAN  # noqa: E402
+from core.schemas.observables.imphash import Imphash  # noqa: E402
+from core.schemas.observables.ipv4 import IPv4  # noqa: E402
+from core.schemas.observables.ipv6 import IPv6  # noqa: E402
+from core.schemas.observables.ja3 import JA3  # noqa: E402
+from core.schemas.observables.jarm import JARM  # noqa: E402
+from core.schemas.observables.mac_address import MacAddress  # noqa: E402
+from core.schemas.observables.md5 import MD5  # noqa: E402
+from core.schemas.observables.mutex import Mutex  # noqa: E402
+from core.schemas.observables.named_pipe import NamedPipe  # noqa: E402
+from core.schemas.observables.package import Package  # noqa: E402
+from core.schemas.observables.path import Path  # noqa: E402
+from core.schemas.observables.registry_key import RegistryKey  # noqa: E402
+from core.schemas.observables.sha1 import SHA1  # noqa: E402
+from core.schemas.observables.sha256 import SHA256  # noqa: E402
+from core.schemas.observables.ssdeep import Ssdeep  # noqa: E402
+from core.schemas.observables.tlsh import TLSH  # noqa: E402
+from core.schemas.observables.url import Url  # noqa: E402
+from core.schemas.observables.user_account import UserAccount  # noqa: E402
+from core.schemas.observables.user_agent import UserAgent  # noqa: E402
+from core.schemas.observables.wallet import Wallet  # noqa: E402
+
+
+class ObservableType(str, Enum):
+    guess = "guess"
+    asn = "asn"
+    auth_secret = "auth_secret"
+    bic = "bic"
+    certificate = "certificate"
+    cidr = "cidr"
+    command_line = "command_line"
+    container_image = "container_image"
+    docker_image = "docker_image"
+    email = "email"
+    file = "file"
+    generic = "generic"
+    hostname = "hostname"
+    iban = "iban"
+    imphash = "imphash"
+    ipv4 = "ipv4"
+    ipv6 = "ipv6"
+    ja3 = "ja3"
+    jarm = "jarm"
+    mac_address = "mac_address"
+    md5 = "md5"
+    mutex = "mutex"
+    named_pipe = "named_pipe"
+    package = "package"
+    path = "path"
+    registry_key = "registry_key"
+    sha1 = "sha1"
+    sha256 = "sha256"
+    ssdeep = "ssdeep"
+    tlsh = "tlsh"
+    url = "url"
+    user_account = "user_account"
+    user_agent = "user_agent"
+    wallet = "wallet"
+
+
+_OBSERVABLE_CLASSES: list[type[Observable]] = [
+    ASN,
+    AuthSecret,
+    BIC,
+    Certificate,
+    CIDR,
+    CommandLine,
+    ContainerImage,
+    DockerImage,
+    Email,
+    File,
+    Generic,
+    Hostname,
+    IBAN,
+    Imphash,
+    IPv4,
+    IPv6,
+    JA3,
+    JARM,
+    MacAddress,
+    MD5,
+    Mutex,
+    NamedPipe,
+    Package,
+    Path,
+    RegistryKey,
+    SHA1,
+    SHA256,
+    Ssdeep,
+    TLSH,
+    Url,
+    UserAccount,
+    UserAgent,
+    Wallet,
+]
+
+_private_observable_classes = load_private_types("core.schemas.observables", Observable)
+
+TYPE_MAPPING = {"observable": Observable, "observables": Observable}
+for _cls in (*_OBSERVABLE_CLASSES, *_private_observable_classes):
+    TYPE_MAPPING[str(_cls.model_fields["type"].default)] = _cls
+
+# Static union for type checkers and OpenAPI. Discriminator is applied by the
+# request/response models that use this alias (as before), so the generated
+# schema is unchanged.
+ObservableTypes = Union[
+    ASN,
+    AuthSecret,
+    BIC,
+    Certificate,
+    CIDR,
+    CommandLine,
+    ContainerImage,
+    DockerImage,
+    Email,
+    File,
+    Generic,
+    Hostname,
+    IBAN,
+    Imphash,
+    IPv4,
+    IPv6,
+    JA3,
+    JARM,
+    MacAddress,
+    MD5,
+    Mutex,
+    NamedPipe,
+    Package,
+    Path,
+    RegistryKey,
+    SHA1,
+    SHA256,
+    Ssdeep,
+    TLSH,
+    Url,
+    UserAccount,
+    UserAgent,
+    Wallet,
+]
+# Deployments may drop extra subtypes into observables/private/; widen the
+# runtime union so API response models serialize them too.
+if _private_observable_classes:
+    ObservableTypes = Union[(ObservableTypes, *_private_observable_classes)]

--- a/core/schemas/task.py
+++ b/core/schemas/task.py
@@ -20,7 +20,7 @@ from core.config.config import yeti_config
 # if TYPE_CHECKING:
 from core.events.message import EventMessage, LogMessage
 from core.schemas.model import YetiModel
-from core.schemas.observable import Observable, ObservableTypes
+from core.schemas.observable import Observable
 from core.schemas.template import Template
 
 FILE_STORAGE_CLIENT = file_storage.get_client(
@@ -288,7 +288,7 @@ class ExportTask(Task):
     exclude_tags: list[str] = []
     ignore_tags: list[str] = []
     fresh_tags: bool = True
-    acts_on: list[ObservableTypes] = []
+    acts_on: list[str] = []  # observable type names to export, e.g. ["ipv4"]
     template_name: str
     sha256: str | None = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "parameterized>=0.9.0",
     "yara-python>=4.5.0",
     "idstools>=0.6.5",
-    "aenum>=3.1.15",
     "tqdm>=4.67.1",
     "plyara>=2.2",
     "minijinja>=2.9.0",

--- a/tests/schemas/registry.py
+++ b/tests/schemas/registry.py
@@ -1,0 +1,67 @@
+"""Guards the static type registries in observable.py / entity.py / indicator.py.
+
+Public schema types are registered by hand (explicit imports + TYPE_MAPPING +
+the *Types union). This test globs each family package and fails if a subtype
+is defined on disk but not wired into its registry — preserving the old
+"drop a file in and it works" ergonomics as "drop a file in and CI tells you
+to register it".
+"""
+
+import importlib
+import inspect
+import pathlib
+import typing
+import unittest
+
+from core.schemas import entity, indicator, observable
+
+
+class RegistryCompletenessTest(unittest.TestCase):
+    def _check(self, base_module, base_class, package: str):
+        pkg_path = pathlib.Path(base_module.__file__).parent / package
+        union = getattr(base_module, f"{base_class.__name__}Types")
+        union_args = set(typing.get_args(union))
+        type_mapping = base_module.TYPE_MAPPING
+
+        found_any = False
+        for pyfile in sorted(pkg_path.glob("*.py")):
+            if pyfile.stem == "__init__":
+                continue
+            module = importlib.import_module(f"core.schemas.{package}.{pyfile.stem}")
+            for _, cls in inspect.getmembers(module, inspect.isclass):
+                if cls.__module__ != module.__name__:
+                    continue
+                if not issubclass(cls, base_class) or cls is base_class:
+                    continue
+                if "type" not in cls.model_fields:
+                    continue
+                found_any = True
+                type_value = cls.model_fields["type"].default
+                with self.subTest(cls=cls.__name__):
+                    self.assertIn(
+                        type_value,
+                        type_mapping,
+                        f"{cls.__name__} ({type_value!r}) is missing from "
+                        f"{package} TYPE_MAPPING — register it in {base_module.__name__}",
+                    )
+                    self.assertIs(type_mapping[type_value], cls)
+                    self.assertIn(
+                        cls,
+                        union_args,
+                        f"{cls.__name__} is missing from {base_class.__name__}Types "
+                        f"— add it to the union in {base_module.__name__}",
+                    )
+        self.assertTrue(found_any, f"No subtypes discovered in {package}")
+
+    def test_observables_registered(self):
+        self._check(observable, observable.Observable, "observables")
+
+    def test_entities_registered(self):
+        self._check(entity, entity.Entity, "entities")
+
+    def test_indicators_registered(self):
+        self._check(indicator, indicator.Indicator, "indicators")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -8,15 +8,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "aenum"
-version = "3.1.15"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/f8/33e75863394f42e429bb553e05fda7c59763f0fd6848de847a25b3fbccf6/aenum-3.1.15.tar.gz", hash = "sha256:8cbd76cd18c4f870ff39b24284d3ea028fbe8731a58df3aa581e434c575b9559", size = 134730, upload-time = "2023-06-27T00:19:52.546Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/fa/ca0c66b388624ba9dbbf35aab3a9f326bfdf5e56a7237fe8f1b600da6864/aenum-3.1.15-py3-none-any.whl", hash = "sha256:e0dfaeea4c2bd362144b87377e2c61d91958c5ed0b4daf89cb6f45ae23af6288", size = 137633, upload-time = "2023-06-27T00:19:55.112Z" },
-]
-
-[[package]]
 name = "altair"
 version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2795,7 +2786,6 @@ name = "yeti"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "aenum" },
     { name = "artifacts" },
     { name = "authlib" },
     { name = "beautifulsoup4" },
@@ -2849,7 +2839,6 @@ s3 = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aenum", specifier = ">=3.1.15" },
     { name = "artifacts", git = "https://github.com/forensicartifacts/artifacts.git?rev=main" },
     { name = "authlib", specifier = ">=1.2.1" },
     { name = "beautifulsoup4", specifier = ">=4.13.4" },


### PR DESCRIPTION
## Summary

The observable/entity/indicator type registries were built at import time by reflection — empty forward declarations (`ObservableTypes = ()`, `class ObservableType(str, Enum): ...`, `TYPE_MAPPING = {}`) that `core/schemas/__init__.py` then populated by globbing the family directories, mutating the enums with `aenum`, and OR-ing the union together. The result was invisible to static type checkers and to FastAPI's OpenAPI generation: every `-> ObservableTypes` annotation was, statically, an empty tuple. That's why mypy could never run and the "strong typing" bought nothing.

This registers the public types explicitly instead.

## What changed

- Each base module (`observable.py` / `entity.py` / `indicator.py`) imports its subtypes and defines a real `Enum`, a real `Union` (`*Types`) and `TYPE_MAPPING` at the bottom of the module. `from __future__ import annotations` keeps the factory-function signatures happy. `dfiq.py` already did this; the three families now match it.
- The static registry lives at the bottom of the base modules (not the package `__init__`) so every existing `from core.schemas.observable import X` and `observable.save()` consumer keeps working with zero churn.
- Unions stay plain `Union[...]` (discriminator applied at the request-model sites, as before) so the generated OpenAPI is unchanged.
- The only remaining dynamic hook is `core/schemas/loader.py`, which globs each family's `private/` subpackage so deployments can still drop in their own subtypes; those extend `TYPE_MAPPING` and widen the runtime union.
- `core/schemas/__init__.py` loses `register_module`/`register_classes`/`load_*` and the `aenum` dependency (removed from pyproject/uv.lock). 104 lines → 19.
- `EntityType` members use underscore identifiers with hyphenated *values* (e.g. `threat_actor = "threat-actor"`) so the enum can be a static class; wire values are unchanged and no code referenced the old hyphenated member names.
- `tests/schemas/registry.py` guards completeness: it fails if a subtype is defined on disk but not wired into `TYPE_MAPPING` and the union — preserving the old "drop a file in and it works" ergonomics.

## Bug surfaced + fixed

`ExportTask.acts_on` was annotated `list[ObservableTypes]`, but because `task.py` is imported before the old dynamic registration ran, the union was the empty `()` tuple and the field rendered as an untyped `items: {}` in OpenAPI. It's a list of observable *type names* (passed straight into a `type__in` query, like every sibling task model), so it is now `list[str]`.

## Verification

- All three unittest suites pass (schemas / apiv2 / core_tests); ruff (pinned 0.15) clean.
- Generated OpenAPI diffed against a pre-refactor baseline: **byte-identical except** the one field above, which changes from `items: {}` to `items: {type: string}` on `ExportTask-Input`/`-Output`.

## Notes / deliberate deviations

- Kept `(str, Enum)` rather than switching to `StrEnum` (orthogonal; Phase 0's `.value` coercions already cover the f-string bug).
- Private types are no longer auto-added to the `*Type` **enum** (they were via `aenum`); they still work via `TYPE_MAPPING` and the `/extended` union endpoint. Private dirs are empty, so no impact today.