### PR TITLE
ratchet(types): type connector surface on model mixins + fix tag None-safety

### DIFF
--- a/core/schemas/model.py
+++ b/core/schemas/model.py
@@ -2,7 +2,7 @@ import datetime
 import re
 import unicodedata
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 from pydantic import BaseModel, computed_field
 
@@ -28,6 +28,21 @@ class YetiBaseModel(BaseModel):
     @property
     def id(self):
         return self.__id
+
+    if TYPE_CHECKING:
+        # These are provided at runtime by database_arango.ArangoYetiConnector,
+        # which every persisted schema type mixes in. They are declared here
+        # (type-check time only) so type checkers can resolve the calls the
+        # model mixins below make on `self`. Non-persisted models such as
+        # YetiTagInstance never call them.
+        def save(self, *args: Any, **kwargs: Any) -> Self: ...
+
+        def delete(self, *args: Any, **kwargs: Any) -> None: ...
+
+        def neighbors(self, *args: Any, **kwargs: Any) -> Any: ...
+
+        @property
+        def extended_id(self) -> str: ...
 
 
 class YetiContextModel(YetiBaseModel):
@@ -254,6 +269,8 @@ class YetiTagModel(YetiBaseModel):
         if clear:
             for tag_name in removed_tags:
                 removed_tag = tag.Tag.find(name=tag_name)
+                if not removed_tag:
+                    continue
                 removed_tag.count -= 1
                 removed_tag.save()
 
@@ -300,6 +317,8 @@ class YetiTagModel(YetiBaseModel):
 
         for obj_tag in self.tags:
             db_tag = tag.Tag.find(name=obj_tag.name)
+            if not db_tag:
+                continue
             db_tag.count -= 1
             db_tag.save()
         self.tags = []


### PR DESCRIPTION
First ty ratchet PR (follows #1286).

## What

The `YetiTagModel` / `YetiContextModel` / `YetiAclModel` mixins call `self.save()`, `self.neighbors()`, `self.extended_id` — provided at runtime by `ArangoYetiConnector` (mixed into every persisted subclass), but invisible to the type checker *within the mixins themselves*. This is the single biggest source of ty's `unresolved-attribute` warnings.

`YetiBaseModel` can't actually inherit `AbstractYetiConnector` — that would make non-persisted models like `YetiTagInstance` abstract/uninstantiable. So the fix is `TYPE_CHECKING`-only stubs on `YetiBaseModel`. **Runtime is completely unchanged** — frontend-safe, no wire/OpenAPI impact.

## Bug fixed

ty surfaced a real latent crash: `Tag.find()` returns `Tag | None`, but the tag-removal (`clear=True`) and `clear_tags()` paths dereferenced it (`.count`/`.save`) with no None check — a crash if the tag row is ever missing. Now skips when absent.

## Effect

- `core/schemas/model.py`: 13 ty diagnostics → **0**.
- Total ty warnings across `core/`: 296 → **268**; `unresolved-attribute`: 138 → 119.
- ty exits 0 (no new error-level diagnostics); all three unittest suites pass; ruff clean.

Not flipping any rule to `error` yet — `unresolved-attribute` still has ~119 instances (union-attribute access + other Optional cases) that later ratchet PRs will chip away at.