### PR TITLE
ratchet(types): fix invalid-parameter-default + enforce the rule

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -72,11 +72,11 @@ class ArangoDatabase:
 
     def connect(
         self,
-        host: str = None,
-        port: int = None,
-        username: str = None,
-        password: str = None,
-        database: str = None,
+        host: str | None = None,
+        port: int | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        database: str | None = None,
         check_db_sync: bool = False,
     ):
         host = host or yeti_config.get("arangodb", "host")
@@ -1037,7 +1037,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
         graph_queries: List[tuple[str, str, str, str]] = [],
         links_count: bool = False,
         wildcard: bool = True,
-        user: "user.User" = None,
+        user: "user.User | None" = None,
     ) -> tuple[List[TYetiObject], int]:
         """Search in an ArangoDb collection.
 

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -107,7 +107,7 @@ class AbstractYetiConnector(ABC):
         offset: int = 0,
         count: int = 0,
         sorting: List[tuple[str, bool]] = [],
-        user: "user.User" = None,
+        user: "user.User | None" = None,
         include_tags: bool = True,
     ) -> tuple[
         dict[

--- a/core/schemas/entity.py
+++ b/core/schemas/entity.py
@@ -69,7 +69,7 @@ def create(*, name: str, type: str, **kwargs) -> "EntityTypes":
     return TYPE_MAPPING[type](name=name, **kwargs)
 
 
-def save(*, name: str, type: str, tags: List[str] = None, **kwargs):
+def save(*, name: str, type: str, tags: List[str] | None = None, **kwargs):
     indicator_obj = create(name=name, type=type, **kwargs).save()
     if tags:
         indicator_obj.tag(tags)

--- a/core/schemas/indicator.py
+++ b/core/schemas/indicator.py
@@ -115,7 +115,7 @@ def save(
     type: str,
     pattern: str,
     diamond: DiamondModel,
-    tags: List[str] = None,
+    tags: List[str] | None = None,
     **kwargs,
 ):
     indicator_obj = create(

--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -101,7 +101,7 @@ def save(
     *,
     value: str,
     type: str | None = None,
-    tags: List[str] = None,
+    tags: List[str] | None = None,
     overwrite=False,
     **kwargs,
 ) -> ObservableTypes:
@@ -129,7 +129,7 @@ def save(
     return observable_obj
 
 
-def find(value: str, type: str = None) -> ObservableTypes:
+def find(value: str, type: str | None = None) -> ObservableTypes:
     if type:
         obs = Observable.find(value=refang(value), type=type)
     else:
@@ -158,7 +158,7 @@ def create_from_text(text: str) -> Tuple[List["ObservableTypes"], List[str]]:
 
 
 def save_from_text(
-    text: str, tags: List[str] = None
+    text: str, tags: List[str] | None = None
 ) -> Tuple[List["ObservableTypes"], List[str]]:
     """
     Save a list of observables from a block of text.
@@ -208,7 +208,7 @@ def create_from_file(file: FileLikeObject) -> Tuple[List["ObservableTypes"], Lis
 
 
 def save_from_file(
-    file: FileLikeObject, tags: List[str] = None
+    file: FileLikeObject, tags: List[str] | None = None
 ) -> Tuple[List["ObservableTypes"], List[str]]:
     """
     Save a list of observables from a block of text.
@@ -238,7 +238,7 @@ def create_from_url(url: str) -> Tuple[List["ObservableTypes"], List[str]]:
 
 
 def save_from_url(
-    url: str, tags: List[str] = None
+    url: str, tags: List[str] | None = None
 ) -> Tuple[List["ObservableTypes"], List[str]]:
     """
     Save a list of observables from a URL.

--- a/core/taskscheduler.py
+++ b/core/taskscheduler.py
@@ -15,7 +15,7 @@ from core.taskmanager import TaskManager
 logger = get_task_logger(__name__)
 
 
-def get_plugins_list(task_class: Task = Task) -> set[str]:
+def get_plugins_list(task_class: type[Task] = Task) -> set[str]:
     plugins_list = set()
     plugins_path = pathlib.Path(yeti_config.get("system", "plugins_path"))
     if not plugins_path.exists():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ unresolved-attribute = "warn"       # 138 — ArangoYetiConnector mixin + union 
 invalid-argument-type = "warn"      # 35
 not-subscriptable = "warn"          # 16
 unsupported-operator = "warn"       # 15 — includes real `x not in None` bugs
-invalid-parameter-default = "warn"  # 15 — `arg: list = None` defaults
 invalid-assignment = "warn"         # 14
 invalid-attribute-override = "warn"  # 12
 not-iterable = "warn"               # 11


### PR DESCRIPTION
Second ty ratchet PR — the first that **flips a rule to `error`**.

## What

All 15 `invalid-parameter-default` diagnostics were internal function signatures with a `None` default on a non-optional annotation:
- `tags: List[str] = None` → `tags: List[str] | None = None` (the observable/entity/indicator `save`/`create`/`find` helpers)
- `host/port/username/password/database: str|int = None` in `ArangoYetiConnector.connect`
- `user: "user.User" = None` in `connect`/`filter`/the interface
- `get_plugins_list(task_class: Task = Task)` → `type[Task]` (the param is a class, used in `issubclass`)

None are request/response models or FastAPI endpoint parameters, so these are **annotation-only** — no runtime behavior, no OpenAPI/wire change (frontend-safe).

## Ratchet

With the rule at zero, `invalid-parameter-default` moves from `warn` to `error` in `[tool.ty.rules]`. It's now enforced — a future `arg: list = None` fails CI.

## Verification

- ty: `invalid-parameter-default` 15 → 0, rule enforced at error, `ty check --exit-zero-on-warning` exits 0.
- All three unittest suites pass; ruff clean.