### PR TITLE
ratchet(types): make YetiPackage collection fields non-optional

### DIFF
--- a/core/schemas/package.py
+++ b/core/schemas/package.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 from typing_extensions import Self
@@ -34,11 +34,11 @@ class YetiPackage(BaseModel):
 
     timestamp: datetime = datetime.now()
     source: str = Field(min_length=3)
-    tags: Optional[Dict[str, List[str]]] = {}
-    observables: Optional[List[observable.ObservableTypes]] = []
-    entities: Optional[List[entity.EntityTypes]] = []
-    indicators: Optional[List[indicator.IndicatorTypes]] = []
-    relationships: Optional[Dict[str, List[YetiPackageRelationship]]] = {}
+    tags: Dict[str, List[str]] = {}
+    observables: List[observable.ObservableTypes] = []
+    entities: List[entity.EntityTypes] = []
+    indicators: List[indicator.IndicatorTypes] = []
+    relationships: Dict[str, List[YetiPackageRelationship]] = {}
 
     _root_type: Literal["package"] = "package"
 


### PR DESCRIPTION
Third ty ratchet PR — a frontend-safe root-cause fix that clears a large cascade.

## What

`YetiPackage` declared its collection fields as `Optional`:

```python
tags: Optional[Dict[str, List[str]]] = {}
observables: Optional[List[observable.ObservableTypes]] = []
entities: Optional[List[entity.EntityTypes]] = []
indicators: Optional[List[indicator.IndicatorTypes]] = []
relationships: Optional[Dict[str, List[YetiPackageRelationship]]] = {}
```

…but the code always treats them as collections — `__init__` and the model validators iterate, subscript, and membership-test them directly. Passing `None` would crash at runtime, so the `Optional` was both **wrong** and the root cause of ~33 ty warnings in this file (`not-iterable` / `not-subscriptable` / `unsupported-operator`, all cascading from the possibly-`None` type).

Dropped the `Optional` (and the now-unused import).

## Frontend-safe

`YetiPackage` is internal — referenced only by `package.py` and its tests, **not** an API request/response model, **not** in the OpenAPI schema. (The `Package-Input/Output` schemas in OpenAPI are the unrelated *observable* `package` type.) Omitting a field still uses its empty default; only an explicit `None` is now rejected — which would have crashed anyway.

## Effect

- `core/schemas/package.py`: **38 → 5** ty diagnostics.
- Overall `core/` warnings: 268 → **220**.
- `not-subscriptable` 16→4, `not-iterable` 11→5, `unsupported-operator` 15→7 (no rule fully cleared yet, so no flip this round).
- All three unittest suites pass (incl. `tests/schemas/package.py`); ruff clean; ty exits 0.