### PR TITLE
fix(graph): reject unknown graph names in /graph/search with a 400

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -32,10 +32,9 @@ from .interfaces import AbstractYetiConnector
 CODE_DB_VERSION = 2
 AQL_QUERY_MAX_TTL = 3600 * 12
 
-LINK_TYPE_TO_GRAPH = {
-    "tagged": "tags",
-    "stix": "stix",
-}
+# Edge collections that back the defined ArangoDB graphs (see create_graphs);
+# these are the only names neighbors() can traverse with `@@graph`.
+TRAVERSABLE_GRAPHS = {"links", "acls"}
 
 TESTING = "unittest" in sys.modules.keys()
 
@@ -862,6 +861,11 @@ class ArangoYetiConnector(AbstractYetiConnector):
             - the relationships (edges),
             - total neighbor (vertices) count
         """
+        if graph not in TRAVERSABLE_GRAPHS:
+            raise ValueError(
+                f"Cannot traverse graph '{graph}': expected one of "
+                f"{sorted(TRAVERSABLE_GRAPHS)}."
+            )
         query_filter = ""
         args = {
             "extended_id": self.extended_id,

--- a/core/web/apiv2/graph.py
+++ b/core/web/apiv2/graph.py
@@ -142,20 +142,23 @@ def search(httpreq: Request, request: GraphSearchRequest) -> GraphSearchResponse
         raise HTTPException(
             status_code=404, detail=f"Source object {request.source} not found"
         )
-    vertices, paths, total = yeti_object.neighbors(
-        link_types=request.link_types,
-        target_types=request.target_types,
-        direction=request.direction,
-        filter=request.filter,
-        include_original=request.include_original,
-        graph=request.graph,
-        min_hops=request.min_hops or request.hops,
-        max_hops=request.max_hops or request.hops,
-        count=request.count,
-        offset=request.page * request.count,
-        sorting=request.sorting,
-        user=httpreq.state.user,
-    )
+    try:
+        vertices, paths, total = yeti_object.neighbors(
+            link_types=request.link_types,
+            target_types=request.target_types,
+            direction=request.direction,
+            filter=request.filter,
+            include_original=request.include_original,
+            graph=request.graph,
+            min_hops=request.min_hops or request.hops,
+            max_hops=request.max_hops or request.hops,
+            count=request.count,
+            offset=request.page * request.count,
+            sorting=request.sorting,
+            user=httpreq.state.user,
+        )
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error))
     return GraphSearchResponse(vertices=vertices, paths=paths, total=total)
 
 

--- a/tests/apiv2/graph.py
+++ b/tests/apiv2/graph.py
@@ -68,6 +68,23 @@ class SimpleGraphTest(unittest.TestCase):
         self.assertEqual(edges[0][0]["target"], self.observable2.extended_id)
         self.assertEqual(edges[0][0]["type"], "resolves")
 
+    def test_get_neighbors_unknown_graph(self):
+        # An unknown graph name (e.g. the retired "tagged" graph) has no edge
+        # collection to traverse; the API must reject it cleanly, not 500.
+        response = client.post(
+            "/api/v2/graph/search",
+            json={
+                "source": self.observable1.extended_id,
+                "hops": 1,
+                "graph": "tagged",
+                "direction": "any",
+                "include_original": False,
+            },
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 400, data)
+        self.assertIn("Cannot traverse graph 'tagged'", data["detail"])
+
     def test_get_neighbors_bad_hops(self):
         response = client.post(
             "/api/v2/graph/search",


### PR DESCRIPTION
## Problem
`POST /graph/search` returns an unhandled **HTTP 500** when given an unknown `graph` name. The frontend's observable-details "Tagged" card requested `graph="tagged"`, which surfaced as an `AxiosError: Request failed with status code 500` (and an "Uncaught (in promise)" in the browser console).

## Root cause
`neighbors()` (`core/database_arango.py`) binds the requested graph name straight into an AQL graph traversal:
```
FOR v, e, p IN @min_hops..@max_hops {direction} @extended_id @@graph
```
`@@graph` must name an existing **edge collection**. `"tagged"` has none (tags are stored as an embedded list property on each object, not as edges — there is no `tagged`/`tags` edge collection), so ArangoDB raises `[ERR 1203] collection or view not found: name: tagged`, which propagates unhandled → 500.

There was also a vestigial `LINK_TYPE_TO_GRAPH = {"tagged": "tags", "stix": "stix"}` map — defined but referenced nowhere, a leftover of an abandoned tags-as-edges design.

## Change
- Validate `graph` in `neighbors()` against `TRAVERSABLE_GRAPHS = {"links", "acls"}` — the edge collections that actually back the defined graphs (`threat_graph`, `systemroles`) — and raise `ValueError` otherwise.
- `/graph/search` translates that `ValueError` into a clean **400**.
- Replace the dead `LINK_TYPE_TO_GRAPH` map with the meaningful `TRAVERSABLE_GRAPHS` set.

The frontend that requested `graph="tagged"` is being removed separately (yeti-feeds-frontend#290); this change makes the API robust against any unknown graph name regardless.

## Test plan
- [x] New `test_get_neighbors_unknown_graph` asserts `graph="tagged"` → 400 with a clear detail message
- [x] `tests/apiv2/graph.py` — 23 passed
- [x] `tests/schemas/{graph,observable,user}.py` — 91 passed (internal `neighbors(graph="acls"/"links")` callers unaffected)
- [x] `ruff check` + `ruff format --check` clean
- [x] Manually verified against the reporting observable: `graph="tagged"` now raises `ValueError`, `graph="links"` still returns results