### PR TITLE
ratchet(types): promote possibly-missing-submodule + unused-type-ignore-comment to error

### DIFF
--- a/core/schemas/indicators/forensicartifact.py
+++ b/core/schemas/indicators/forensicartifact.py
@@ -4,6 +4,7 @@ import re
 from typing import ClassVar, Literal
 
 import yaml
+import yaml.scanner
 from artifacts import definitions, reader, writer
 from artifacts import errors as artifacts_errors
 from pydantic import field_validator

--- a/core/web/apiv2/entities.py
+++ b/core/web/apiv2/entities.py
@@ -164,7 +164,7 @@ def get(
 @rbac.permission_on_target(roles.Permission.READ)
 def details(httpreq: Request, id: str) -> EntityTypes:
     """Returns details about an observable."""
-    db_entity: EntityTypes = Entity.get(id)  # type: ignore
+    db_entity: EntityTypes = Entity.get(id)
     if not db_entity:
         raise HTTPException(status_code=404, detail=f"Entity {id} not found")
     db_entity.get_tags()

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -210,7 +210,7 @@ def get(
 @rbac.permission_on_target(roles.Permission.READ)
 def details(httpreq: Request, id: str) -> IndicatorTypes:
     """Returns details about an indicator."""
-    db_indicator: IndicatorTypes = Indicator.get(id)  # type: ignore
+    db_indicator: IndicatorTypes = Indicator.get(id)
     if not db_indicator:
         raise HTTPException(status_code=404, detail="indicator not found")
     db_indicator.get_tags()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,5 +98,9 @@ no-matching-overload = "warn"       # 1
 missing-argument = "warn"           # 1
 unknown-argument = "warn"           # 1
 
+# Promoted to error (instances fixed; kept enforced so they can't regress).
+possibly-missing-submodule = "error"
+unused-type-ignore-comment = "error"
+
 [tool.uv.sources]
 artifacts = { git = "https://github.com/forensicartifacts/artifacts.git", rev = "main" }


### PR DESCRIPTION
Resumes the backend `ty` type-check ratchet (Phase 2). Promotes two single-instance rules from warn → error after fixing their instances, so they stay enforced.

## Changes
- **possibly-missing-submodule** — `import yaml.scanner` in `forensicartifact.py`. The `except (…, yaml.scanner.ScannerError)` referenced a submodule PyYAML doesn't eagerly import, so ty couldn't resolve it. (Runtime behavior unchanged — it happened to work when the submodule was already loaded elsewhere; the explicit import makes it correct.)
- **unused-type-ignore-comment** — drop the now-redundant `# type: ignore` on `Entity.get(id)` / `Indicator.get(id)` in the entities/indicators `details` routes. The static type registry (#1285) made those annotations resolve without the override.
- Add both rules as `"error"` in `[tool.ty.rules]`.

## Test plan
- [x] `uv run ty check --exit-zero-on-warning` — exit 0 (both promoted rules at 0 instances; total diagnostics 220 → 217)
- [x] `uv run ruff check` — clean
- [x] `tests/schemas` (184), `tests/apiv2` (197), `tests/core_tests` (29) — all pass