### PR TITLE
ratchet(types): promote unknown-argument to error

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -1336,7 +1336,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
         key = cls._text_indexes[0]["fields"][0]
         for document in collection.find_by_text(key, query):
             document["__id"] = document.pop("_key")
-            yeti_objects.append(cls.load(document, strict=True))
+            yeti_objects.append(cls.load(document))
         return yeti_objects
 
     def _delete_vertex_refs_in_graphs(self, vertex_id):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ invalid-type-form = "warn"          # 5 — pydantic conlist() in annotations
 unresolved-import = "warn"          # 3 — optional deps not present in lint env
 no-matching-overload = "warn"       # 1
 missing-argument = "warn"           # 1
-unknown-argument = "warn"           # 1
+unknown-argument = "error"          # 0 — fixed a stray strict= kwarg on cls.load
 
 [tool.uv.sources]
 artifacts = { git = "https://github.com/forensicartifacts/artifacts.git", rev = "main" }


### PR DESCRIPTION
Next step of the backend `ty` ratchet — promotes `unknown-argument` from warn → error after fixing its one instance, which turned out to be a real latent bug.

## The bug
`fulltext_filter()` in `core/database_arango.py` called `cls.load(document, strict=True)`, but **no `load()` implementation accepts a `strict` kwarg** — it would raise `TypeError` if the method were ever invoked. `fulltext_filter` has **no callers anywhere in the repo** (dead code), so the bug never surfaced. Fixed by dropping the stray kwarg to match the sibling `cls.load(doc)` call in `filter()`.

## Change
- `core/database_arango.py`: `cls.load(document, strict=True)` → `cls.load(document)`
- `pyproject.toml`: `unknown-argument = "error"`

## Test plan
- [x] `uv run ty check --exit-zero-on-warning` — exit 0 (`unknown-argument` at 0 instances)
- [x] `uv run ruff check` — clean
- [x] `tests/schemas` (184), `tests/apiv2` (197), `tests/core_tests` (29) — all pass