### PR TITLE
ratchet(types): promote no-matching-overload to error

### DIFF
--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -5,7 +5,7 @@ import io
 import os
 import tempfile
 from enum import Enum
-from typing import IO, ClassVar, List, Literal, Tuple, Union
+from typing import IO, ClassVar, List, Literal, Tuple, Union, cast
 
 import requests
 from bs4 import BeautifulSoup
@@ -183,7 +183,9 @@ def create_from_file(file: FileLikeObject) -> Tuple[List["ObservableTypes"], Lis
     """
     opened = False
     if isinstance(file, (str, bytes, os.PathLike)):
-        f = open(file, "r", encoding="utf-8")
+        # The isinstance guard narrows `file` to a path, but FileLikeObject's
+        # unparametrized os.PathLike doesn't match open()'s PathLike[str] overload.
+        f = open(cast("str | os.PathLike[str]", file), "r", encoding="utf-8")
         opened = True
     elif isinstance(file, (io.IOBase, tempfile.SpooledTemporaryFile)):
         f = file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ invalid-method-override = "warn"    # 8
 call-non-callable = "warn"          # 7
 invalid-type-form = "warn"          # 5 — pydantic conlist() in annotations
 unresolved-import = "warn"          # 3 — optional deps not present in lint env
-no-matching-overload = "warn"       # 1
+no-matching-overload = "error"      # 0 — cast the isinstance-narrowed path for open()
 missing-argument = "warn"           # 1
 unknown-argument = "error"          # 0 — fixed a stray strict= kwarg on cls.load
 


### PR DESCRIPTION
## What

Promotes the `no-matching-overload` ty rule from `warn` to `error` (0 remaining instances).

The single instance was in `create_from_file()` (`core/schemas/observable.py`): it passes a `FileLikeObject` to `open()` in text mode. The `isinstance(file, (str, bytes, os.PathLike))` guard narrows `file` to a path, but `FileLikeObject`'s **unparametrized** `os.PathLike` doesn't match `open()`'s `PathLike[str]` overload, so ty flagged it. Fixed with a narrow `cast("str | os.PathLike[str]", file)` on the already-guarded value — no runtime behavior change.

## Verification (in dev container, Python 3.13)
- `uv run ty check --exit-zero-on-warning` → exit 0, `no-matching-overload` count 0
- `uv run ruff check` → clean
- unittest discover — `tests/schemas` (184), `tests/apiv2` (197), `tests/core_tests` (29) → all OK

Part of the Phase 2 rule-promotion ratchet (follows #1291, #1292).