### PR TITLE
ratchet(types): promote unresolved-import to error

### DIFF
--- a/core/clients/file_storage/classes/s3.py
+++ b/core/clients/file_storage/classes/s3.py
@@ -4,7 +4,7 @@ import os
 from core.clients.file_storage.classes.interface import FileStorageClient
 
 try:
-    import boto3
+    import boto3  # ty: ignore[unresolved-import]  # optional dep (s3 group)
 except ImportError:
     boto3 = None
     logging.warning(

--- a/core/common/utils.py
+++ b/core/common/utils.py
@@ -3,7 +3,7 @@ import logging
 
 from dateutil import parser
 from dateutil.tz import UTC, gettz
-from tldextract import TLDExtract
+from tldextract import TLDExtract  # ty: ignore[unresolved-import]
 
 from core.config.config import yeti_config
 

--- a/core/schemas/indicators/yara.py
+++ b/core/schemas/indicators/yara.py
@@ -4,7 +4,7 @@ from typing import ClassVar, Literal
 import plyara
 import plyara.exceptions
 import plyara.utils
-import yara
+import yara  # ty: ignore[unresolved-import]  # yara-python is a C extension with no type stubs
 from pydantic import BaseModel, PrivateAttr, model_validator
 
 from core import errors

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ invalid-return-type = "warn"        # 11
 invalid-method-override = "warn"    # 8
 call-non-callable = "warn"          # 7
 invalid-type-form = "error"         # 0 — conlist() → Annotated[list[str], Field(...)]
-unresolved-import = "warn"          # 3 — optional deps not present in lint env
+unresolved-import = "error"         # 0 — optional/C-ext deps suppressed per-line
 no-matching-overload = "error"      # 0 — cast the isinstance-narrowed path for open()
 missing-argument = "warn"           # 1
 unknown-argument = "error"          # 0 — fixed a stray strict= kwarg on cls.load


### PR DESCRIPTION
## What

Promotes the `unresolved-import` ty rule from `warn` to `error` (0 remaining instances).

Three imports that ty can't resolve — all genuinely absent under CI's `uv sync --group dev`, which installs **neither** the `plugins` nor `s3` dependency group:

| Import | File | Why unresolved |
|--------|------|----------------|
| `boto3` | `core/clients/file_storage/classes/s3.py` | optional `s3` group; already `try/except ImportError`-guarded |
| `tldextract` | `core/common/utils.py` | transitive dep of `shodan` (`plugins` group); module is `# DEPRECATED` |
| `yara` | `core/schemas/indicators/yara.py` | `yara-python` is a hard dep but a **C extension with no type stubs**, so ty can't resolve it even when installed |

Each is suppressed with `# ty: ignore[unresolved-import]`. Because all three are unresolved in the CI lint env, the ignore comments are always *used* — `unused-ignore-comment` stays clean (verified locally).

## Verification (dev container, Python 3.13)
- `uv run ty check --exit-zero-on-warning` → exit 0, `unresolved-import` count 0, no `unused-ignore` diagnostics
- `uv run ruff check` → clean
- unittest — `tests/schemas` (184), `tests/apiv2` (197), `tests/core_tests` (29) → all OK

Part of the Phase 2 rule-promotion ratchet (follows #1291–#1294).