### PR TITLE
ratchet(types): promote not-subscriptable to error

### DIFF
--- a/core/common/misp_to_yeti.py
+++ b/core/common/misp_to_yeti.py
@@ -39,7 +39,8 @@ class MispToYeti:
     ) -> dict:
         context = {}
         event_id = attribute_misp.get("event_id")
-        context["Org"] = event.get("Org")["name"]
+        org = event.get("Org")
+        context["Org"] = org["name"] if org else None
         context["event_id"] = event_id
         if attribute_misp.get("comment"):
             context["comment"] = attribute_misp.get("comment")

--- a/core/schemas/user.py
+++ b/core/schemas/user.py
@@ -113,6 +113,7 @@ class User(YetiModel, database_arango.ArangoYetiConnector):
 
     def delete_api_key(self, api_key_name) -> None:
         api_keys = self.api_keys
+        assert api_keys is not None
         del api_keys[api_key_name]
         self.api_keys = None
         self.save()

--- a/core/web/apiv2/auth.py
+++ b/core/web/apiv2/auth.py
@@ -310,6 +310,8 @@ def login_api(x_yeti_api_key_token: str = Security(api_key_header)) -> dict[str,
         data={"sub": user.username, "enabled": user.enabled},
         expires_delta=ACCESS_TOKEN_EXPIRE_DELTA,
     )
+    # validate_api_key_payload above guarantees the key exists in api_keys.
+    assert user.api_keys is not None
     user.api_keys[payload["name"]].last_used = datetime.datetime.now(
         tz=datetime.timezone.utc
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ include = ["core"]
 # from the initial rollout against ty 0.0.59.
 unresolved-attribute = "warn"       # 138 — ArangoYetiConnector mixin + union attr access
 invalid-argument-type = "warn"      # 35
-not-subscriptable = "warn"          # 16
+not-subscriptable = "error"         # 0 — api_keys/None asserts + MISP Org guard
 unsupported-operator = "error"      # 0 — fixed `in ("users")` typo + api_keys/None guards
 invalid-assignment = "warn"         # 14
 invalid-attribute-override = "warn"  # 12


### PR DESCRIPTION
## What

Promotes the `not-subscriptable` ty rule from `warn` to `error` (0 remaining). Three `None`-subscript sites — two are the same `api_keys: dict | None` family fixed in #1296, one is a MISP edge case.

| Site | Fix |
|------|-----|
| `core/schemas/user.py:116` — `del api_keys[name]` in `delete_api_key` | `assert api_keys is not None` (callers already guarantee a dict; `reset_api_key` asserts `isinstance` before calling) |
| `core/web/apiv2/auth.py:313` — `user.api_keys[payload["name"]]` in the API-key login flow | `assert user.api_keys is not None` — the preceding `validate_api_key_payload` guarantees the key exists |
| `core/common/misp_to_yeti.py:42` — `event.get("Org")["name"]` | would raise `TypeError` if a MISP event had no `Org`; guard with `org["name"] if org else None` |

The two asserts are defensive narrowing on paths where the value is already guaranteed non-None; the MISP change makes a missing `Org` degrade to `None` instead of crashing.

## Verification (dev container, Python 3.13)
- `uv run ty check --exit-zero-on-warning` → exit 0, `not-subscriptable` count 0 (192 warnings remain)
- `uv run ruff check` → clean
- unittest — `tests/schemas` (185), `tests/apiv2` (197), `tests/core_tests` (29) → all OK (`delete_api_key` path already covered by `test_delete_api_key`)

Part of the Phase 2 rule-promotion ratchet (follows #1291–#1296).