### PR TITLE
fix(observable): rename Package.regitry_type typo to registry_type

### DIFF
--- a/core/schemas/observables/package.py
+++ b/core/schemas/observables/package.py
@@ -6,4 +6,4 @@ from core.schemas import observable
 class Package(observable.Observable):
     type: Literal["package"] = "package"
     version: str | None = None
-    regitry_type: str | None = None
+    registry_type: str | None = None


### PR DESCRIPTION
## What

Renames the misspelled `Package.regitry_type` field to `registry_type`.

## Safety
- The field is referenced **nowhere else** in the backend (nothing reads or writes it) — verified by grep across `core/`, `tests/`, etc.
- `Observable` does not use `model_config = ConfigDict(extra="forbid")`, so any old stored documents carrying the `regitry_type` key are silently ignored on load (no validation crash). The field is unused, so no data of value is lost — **no DB migration needed**.

## OpenAPI
This renames the field in the generated schema. I diffed the sorted `app.openapi()` before/after: the **only** change is `regitry_type` → `registry_type` (name + title) in the two `Package` schema contexts. The frontend `api-schema.d.ts` should be regenerated (it already needs a regen from #1300's nullable change).

## Verification (dev container, Python 3.13)
- `uv run ty check --exit-zero-on-warning` → exit 0
- `uv run ruff check .` and `uv run ruff format . --check` → both clean
- unittest — `tests/schemas` (186), `tests/apiv2` (197), `tests/core_tests` (29) → all OK