### PR TITLE
ratchet(types): promote invalid-argument-type to error

### DIFF
--- a/core/common/misp_to_yeti.py
+++ b/core/common/misp_to_yeti.py
@@ -28,9 +28,9 @@ class MispToYeti:
 
     def attr_misp_to_yeti(self, attribute: dict) -> observable.Observable | None:
         if attribute.get("type") in MISP_TYPES_TO_IMPORT:
-            obs_yeti = observable.TYPE_MAPPING[
-                MISP_TYPES_TO_IMPORT[attribute.get("type")]
-            ](value=attribute.get("value")).save()
+            obs_yeti = observable.TYPE_MAPPING[MISP_TYPES_TO_IMPORT[attribute["type"]]](
+                value=attribute["value"]
+            ).save()
             print(f"Attribute {attribute.get('value')} imported")
             return obs_yeti
 

--- a/core/events/consumers.py
+++ b/core/events/consumers.py
@@ -34,7 +34,13 @@ global DEBUG
 
 
 class Consumer(ConsumerMixin):
-    def __init__(self, task_class: EventTask | LogTask, stop_event, connection, queues):
+    def __init__(
+        self,
+        task_class: type[EventTask] | type[LogTask],
+        stop_event,
+        connection,
+        queues,
+    ):
         global DEBUG
         self.task_class = task_class
         self._stop_event = stop_event

--- a/core/schemas/audit.py
+++ b/core/schemas/audit.py
@@ -67,9 +67,9 @@ def log_timeline(
     action: str | None = None,
     details: dict | None = None,
 ):
+    if not action:
+        action = "update" if old else "create"
     if details is None:
-        if not action:
-            action = "update" if old else "create"
         if old:
             old_dump = old.model_dump(exclude=new._TIMELINE_IGNORE_FIELDS)
             new_dump = new.model_dump(exclude=new._TIMELINE_IGNORE_FIELDS)

--- a/core/web/apiv2/dfiq.py
+++ b/core/web/apiv2/dfiq.py
@@ -174,7 +174,9 @@ def new_from_yaml(httpreq: Request, request: NewDFIQRequest) -> dfiq.DFIQTypes:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error))
 
     if request.update_indicators and new.type == dfiq.DFIQType.question:
-        dfiq.extract_indicators(new, user=httpreq.state.user.username)
+        dfiq.extract_indicators(
+            cast("dfiq.DFIQQuestion", new), user=httpreq.state.user.username
+        )
 
     return cast("dfiq.DFIQTypes", new)
 
@@ -342,7 +344,7 @@ def patch(httpreq: Request, request: PatchDFIQRequest, id: str) -> dfiq.DFIQType
         )
     db_dfiq.get_acls()
     updated_dfiq = db_dfiq.model_copy(
-        update=update_data.model_dump(exclude=["created"])
+        update=update_data.model_dump(exclude={"created"})
     )
     new = updated_dfiq.save()
     new.get_acls()
@@ -350,7 +352,9 @@ def patch(httpreq: Request, request: PatchDFIQRequest, id: str) -> dfiq.DFIQType
     new.update_parents()
 
     if request.update_indicators and new.type == dfiq.DFIQType.question:
-        dfiq.extract_indicators(new, user=httpreq.state.user.username)
+        dfiq.extract_indicators(
+            cast("dfiq.DFIQQuestion", new), user=httpreq.state.user.username
+        )
 
     return cast("dfiq.DFIQTypes", new)
 

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
@@ -326,7 +326,7 @@ def get_yara_bundle(httpreq: Request, request: YaraBundleRequest) -> YaraBundleR
                 continue
             yaras.append(yara)
 
-    bundle = Yara.generate_yara_bundle(rules=yaras)
+    bundle = Yara.generate_yara_bundle(rules=cast("list[Yara]", yaras))
 
     if request.overlays:
         yara_map = {}

--- a/core/web/apiv2/search.py
+++ b/core/web/apiv2/search.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, ConfigDict
 
@@ -47,7 +49,7 @@ def search(httpreq: Request, request: SearchRequest) -> SearchResponse:
         links_count=True,
         user=httpreq.state.user,
     )
-    return SearchResponse(results=results, total=total)
+    return SearchResponse(results=cast("list[dict]", results), total=total)
 
 
 @router.post("/semantic")

--- a/core/web/apiv2/users.py
+++ b/core/web/apiv2/users.py
@@ -186,7 +186,9 @@ def new_api_key(
         request.name, scopes=request.scopes, expiration_delta=request.expiration
     )
     user.save()
-    return NewAPIKeyResponse(name=request.name, token=token, api_keys=user.api_keys)
+    return NewAPIKeyResponse(
+        name=request.name, token=token, api_keys=user.api_keys or {}
+    )
 
 
 @router.post("/toggle-api-key")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ include = ["core"]
 # these back to "error" (fixing the instances) one rule at a time. Counts are
 # from the initial rollout against ty 0.0.59.
 unresolved-attribute = "warn"       # 138 — ArangoYetiConnector mixin + union attr access
-invalid-argument-type = "warn"      # 35
+invalid-argument-type = "error"     # 0 — type[...] annotations, casts, dict-key narrowing, api_keys/None
 not-subscriptable = "error"         # 0 — api_keys/None asserts + MISP Org guard
 unsupported-operator = "error"      # 0 — fixed `in ("users")` typo + api_keys/None guards
 invalid-assignment = "error"        # 0 — field-default/enum/registry-cast/api_keys fixes


### PR DESCRIPTION
## What

Promotes the `invalid-argument-type` ty rule from `warn` to `error` (0 remaining). Twelve argument-type mismatches.

### Real fixes
- **`core/events/consumers.py`** — `Consumer.__init__`'s `task_class` receives a **class** (`EventTask`/`LogTask`) but was annotated as the instance type. Change to `type[EventTask] | type[LogTask]`. This single fix resolves 3 warnings (both `super().__init__(...)` calls at lines 75/121, and the `get_plugins_list(task_class)` call at 45, which wants `type[Task]`).
- **`core/schemas/audit.py`** — `action` was only defaulted inside `if details is None:`, so a caller that passes `details` but no `action` would build `TimelineLog(action=None)` and fail pydantic validation. Hoist the default so `action` is always a `str`.
- **`core/web/apiv2/dfiq.py`** — `model_dump(exclude=["created"])` — the `exclude` param wants a `set`, not a `list`.

### Narrowing casts / access fixes (no behavior change)
- **`core/common/misp_to_yeti.py`** — inside the `if attribute.get("type") in MISP_TYPES_TO_IMPORT:` guard, index the dict (`attribute["type"]`, `attribute["value"]`) instead of `.get(...)`, so the values aren't `... | None`.
- **`core/web/apiv2/dfiq.py`** — `extract_indicators()` wants `DFIQQuestion`; both calls are guarded by `new.type == question`, so `cast`.
- **`core/web/apiv2/indicators.py`** — `generate_yara_bundle` wants `list[Yara]`; the collected objects are Yaras typed as `Indicator`, so `cast`.
- **`core/web/apiv2/search.py`** — the base `filter()` results are dicts at runtime (the response field is `list[dict]`, and the sibling semantic-search endpoint `model_dump()`s them); `cast`.
- **`core/web/apiv2/users.py`** — `api_keys` is `dict | None`; pass `or {}`.

## Verification (dev container, Python 3.13)
- `uv run ty check --exit-zero-on-warning` → exit 0, `invalid-argument-type` count 0, no error-level diagnostics (124 warnings remain)
- `uv run ruff check .` **and** `uv run ruff format . --check` → both clean
- OpenAPI: sorted `app.openapi()` diffed before/after → **byte-identical**
- unittest — `tests/schemas` (186), `tests/apiv2` (197), `tests/core_tests` (29) → all OK

Part of the Phase 2 rule-promotion ratchet (follows #1291–#1303).