### PR TITLE
ratchet(types): resolve connector mixin self-type (cluster 2/4)

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -491,6 +491,27 @@ class ArangoYetiConnector(AbstractYetiConnector):
     _db = db
     _collection_name: ClassVar[str | None] = None
 
+    if TYPE_CHECKING:
+        # Persisted schema types always mix this connector into a pydantic
+        # YetiModel (see core.schemas.model), so at runtime `self`/`cls` carry
+        # the model surface below. It is declared here (type-check time only) as
+        # the mirror of the TYPE_CHECKING block in YetiBaseModel, which declares
+        # the connector methods for the model side. `id` is declared as a
+        # property (not a bare annotation) so it is not mistaken for a required
+        # pydantic field. `type` is deliberately not declared here: it is a
+        # per-subclass Literal field, and a generic `str` would break the
+        # Literal-keyed lookups elsewhere.
+        _type_filter: ClassVar[str]
+        _text_indexes: ClassVar[list[dict[str, Any]]]
+        _exclude_overwrite: list[str]
+
+        @property
+        def id(self) -> str | None: ...
+
+        def model_dump(self, *args: Any, **kwargs: Any) -> dict[str, Any]: ...
+
+        def model_dump_json(self, *args: Any, **kwargs: Any) -> str: ...
+
     def __init__(self):
         self._arango_id = None
 


### PR DESCRIPTION
Second PR in the **`unresolved-attribute`** series (cluster 2 of 4).

## The mixin self-type problem
Every persisted schema type mixes `ArangoYetiConnector` into a pydantic
`YetiModel` — `class Observable(YetiModel, ArangoYetiConnector)` — so at runtime
the connector's `self`/`cls` always carry the full model surface. But the
connector is only typed as `AbstractYetiConnector` and doesn't declare that
surface, so its own methods (`save`, `extended_id`, `swap_link`, `delete`,
`list`, `find`, `fulltext_filter`) tripped `unresolved-attribute` on
`model_dump`, `model_dump_json`, `_exclude_overwrite`, `id`, `_type_filter`,
`_text_indexes`.

## Fix — declare the surface under `TYPE_CHECKING`
This is the **mirror** of the existing block in `YetiBaseModel` (model.py:32-45),
which already declares the *connector* methods (`save`/`delete`/`neighbors`/
`extended_id`) for the *model* side. Here we declare the *model* surface for the
*connector* side. The block is type-check-time only — **zero runtime change**.

Two deliberate choices:
- **`id` is a property, not a bare annotation.** A bare `id: str | None` in the
  class body is read as a required pydantic field, which makes every model
  construction report `missing-argument` (22 spurious errors). A property is not
  a field.
- **`type` is intentionally left out.** It's a per-subclass `Literal` field; a
  generic `str` here breaks `Literal`-keyed lookups (e.g.
  `_TYPE_TO_DUMP_DIR[obj.type]`). Those `.type` sites belong to the upcoming
  DFIQ-narrowing cluster.

## Verification
- `unresolved-attribute` **79 → 63** (rule stays `warn`)
- ty (0.0.60) in CI's env (`uv sync --group dev`): **exit 0, 0 errors**
- `ruff check` + `ruff format --check`: clean
- No runtime code path changes (`TYPE_CHECKING` block); no field changes → OpenAPI byte-stable
