### PR TITLE
ratchet(types): resolve DFIQ union attribute access (cluster 4/4)

### DIFF
--- a/core/schemas/dfiq.py
+++ b/core/schemas/dfiq.py
@@ -5,7 +5,7 @@ import re
 import uuid
 from dataclasses import dataclass
 from enum import Enum
-from typing import Annotated, Any, ClassVar, Literal, Type, Union, cast
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal, Type, Union, cast
 
 import yaml
 from packaging.version import Version
@@ -160,6 +160,16 @@ class DFIQBase(YetiModel, YetiAclModel, database_arango.ArangoYetiConnector):
         "dfiq_yaml"
     }
 
+    if TYPE_CHECKING:
+        # Every concrete DFIQ subclass declares `type` as its own
+        # Literal[DFIQType.*] field. Declared here as a property (type-check
+        # time only, so it is not treated as a required field) so code holding a
+        # DFIQBase can resolve `.type`. parent_ids/approaches are deliberately
+        # NOT declared here: they only exist on some subclasses and must stay
+        # narrowed per-site.
+        @property
+        def type(self) -> DFIQType: ...
+
     name: str = Field(min_length=1)
     uuid: str | None = None
     dfiq_id: str | None = None
@@ -295,7 +305,7 @@ class DFIQBase(YetiModel, YetiAclModel, database_arango.ArangoYetiConnector):
                 if (source.dfiq_id and source.uuid) not in intended_parent_ids:
                     rel.delete()
 
-        for parent in intended_parents:
+        for parent in cast("list[DFIQBase]", intended_parents):
             parent.link_to(self, self.type.value, f"Uses DFIQ {self.type.value}")
 
 

--- a/core/web/apiv2/dfiq.py
+++ b/core/web/apiv2/dfiq.py
@@ -131,7 +131,10 @@ def from_archive(httpreq: Request, archive: UploadFile) -> dict[str, int]:
 def new_from_yaml(httpreq: Request, request: NewDFIQRequest) -> dfiq.DFIQTypes:
     """Creates a new DFIQ object in the database."""
     try:
-        new = dfiq.TYPE_MAPPING[request.dfiq_type].from_yaml(request.dfiq_yaml)
+        new = cast(
+            "dfiq.DFIQTypes",
+            dfiq.TYPE_MAPPING[request.dfiq_type].from_yaml(request.dfiq_yaml),
+        )
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error))
 
@@ -161,7 +164,7 @@ def new_from_yaml(httpreq: Request, request: NewDFIQRequest) -> dfiq.DFIQTypes:
     if not all(intended_parents):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Missing parent(s), provided {new.parent_ids}",
+            detail=f"Missing parent(s), provided {parent_ids}",
         )
 
     new = new.save()
@@ -208,7 +211,7 @@ def to_archive(httpreq: Request, request: DFIQSearchRequest) -> FileResponse:
     with tempfile.TemporaryDirectory() as tempdir:
         public_objs = []
         internal_objs = []
-        for obj in dfiq_objects:
+        for obj in cast("list[dfiq.DFIQTypes]", dfiq_objects):
             if obj.dfiq_tags and "internal" in obj.dfiq_tags:
                 internal_objs.append(obj)
             else:
@@ -419,7 +422,7 @@ def delete(httpreq: Request, id: str) -> None:
         )
         if children:
             all_children.extend(children)
-    for child in all_children:
+    for child in cast("list[dfiq.DFIQFacet | dfiq.DFIQQuestion]", all_children):
         if db_dfiq.dfiq_id in child.parent_ids:
             child.parent_ids.remove(db_dfiq.dfiq_id)
         if db_dfiq.uuid in child.parent_ids:


### PR DESCRIPTION
Fourth PR in the **`unresolved-attribute`** series (cluster 4 of 4). After this,
only the promotion PR remains.

## DFIQ is a heterogeneous union
`DFIQBase` has neither `type` (a per-subclass `Literal`) nor
`parent_ids`/`approaches` (which exist only on *some* subclasses), yet endpoints
and helpers hold `DFIQBase`-typed values (from `get()`/`filter()`/`from_yaml`)
and reach for those attributes under runtime type guards.

## Fix
- **`type`** — declared on `DFIQBase` under `if TYPE_CHECKING:` as a **property**
  (every concrete subclass genuinely has it; a property isn't treated as a
  required field). Clears all the `.type` accesses at once.
- **`parent_ids` / `approaches`** — deliberately **not** declared universally:
  they exist only on some subclasses, so a blanket declaration would mask real
  errors (e.g. `scenario.parent_ids`). Instead the `DFIQBase` sources are
  narrowed to the `DFIQTypes` union (or the parent-bearing subclasses) at the
  call site, letting the existing `if type == ...` guards do the narrowing —
  matching the existing `cast("dfiq.DFIQTypes", ...)` usages in this file.
- **`update_parents`** — narrow the `all()`-verified parents list to
  `list[DFIQBase]` so `.link_to` no longer sees the `| None` arm.

Runtime behaviour is unchanged: casts are no-ops, the property is
type-check-time only, and the one error-message swap (`new.parent_ids` → the
already-narrowed local `parent_ids`) is equivalent on the only reachable path.

## Verification
- `unresolved-attribute` **53 → 33** (rule stays `warn`; the final PR flips it)
- ty (0.0.60) in CI's env (`uv sync --group dev`): **exit 0, 0 errors**
- `ruff check` + `ruff format --check`: clean
- unittest schemas / apiv2 / core_tests: **186 / 197 / 29**, all pass
- **OpenAPI spec diffed byte-for-byte identical** vs main
