### PR TITLE
ratchet(types): promote unresolved-attribute to error — Phase 2 complete

### DIFF
--- a/core/common/misp_to_yeti.py
+++ b/core/common/misp_to_yeti.py
@@ -52,7 +52,8 @@ class MispToYeti:
         links = []
         for attr in object_misp.get("Attribute") or []:
             obs_yeti = self.attr_misp_to_yeti(attr)
-            links.append(obs_yeti)
+            if obs_yeti is not None:
+                links.append(obs_yeti)
         obs_yeti = links.pop()
         for obj_to_link in links:
             obs_yeti.link_to(obj_to_link, f"linked_by_misp_{objs_type}", "misp")

--- a/core/common/utils.py
+++ b/core/common/utils.py
@@ -12,13 +12,12 @@ tzinfos = {"CEST": gettz("Europe/Amsterdam"), "CST": gettz("Europe/Amsterdam")}
 
 tld_extract_dict = {"extra_suffixes": list(), "suffix_list_urls": None}
 
-if hasattr(yeti_config, "tldextract"):
-    if yeti_config.tldextract.extra_suffixes:
-        tld_extract_dict["extra_suffixes"] = (
-            yeti_config.tldextract.extra_suffixes.split(",")
-        )
-    if yeti_config.tldextract.suffix_list_urls:
-        tld_extract_dict["suffix_list_urls"] = yeti_config.tldextract.suffix_list_urls
+_extra_suffixes = yeti_config.get("tldextract", "extra_suffixes", None)
+if _extra_suffixes:
+    tld_extract_dict["extra_suffixes"] = _extra_suffixes.split(",")
+_suffix_list_urls = yeti_config.get("tldextract", "suffix_list_urls", None)
+if _suffix_list_urls:
+    tld_extract_dict["suffix_list_urls"] = _suffix_list_urls
 
 
 def tldextract_parser(url):

--- a/core/events/consumers.py
+++ b/core/events/consumers.py
@@ -70,6 +70,10 @@ class Consumer(ConsumerMixin):
             self._logger.addHandler(handler)
         return self._logger
 
+    def on_message(self, body, received_message):
+        """Handles an incoming message. Implemented by subclasses."""
+        raise NotImplementedError
+
     def get_consumers(self, Consumer, channel):
         return [
             Consumer(queues=self.queues, callbacks=[self.on_message], accept=["json"])

--- a/core/migrations/arangodb.py
+++ b/core/migrations/arangodb.py
@@ -125,6 +125,7 @@ def migration_3():
             if not legacy_tag:
                 legacy_tag = tag.Tag.get(tagrel["target"].split("/")[1])
                 resolved[tagrel["target"]] = legacy_tag
+            assert legacy_tag is not None
             tagrel["name"] = legacy_tag.name
             legacy_types_per_source[tagrel["source"]].append(tagrel)
             pbar.update(1)

--- a/core/migrations/migration.py
+++ b/core/migrations/migration.py
@@ -3,6 +3,7 @@ from typing import Callable
 
 class MigrationManager:
     MIGRATIONS: list[Callable] = []
+    db_version: int
 
     def __init__(self):
         self.connect_to_db()

--- a/core/schemas/audit.py
+++ b/core/schemas/audit.py
@@ -91,7 +91,7 @@ def log_timeline(
 
 
 def log_timeline_tags(actor: str, obj: "AllObjectTypes", old_tags: list[str]):
-    new_tags = {tag.name for tag in obj.tags}
+    new_tags = {tag.name for tag in getattr(obj, "tags", [])}
     details = {
         "removed": set(old_tags) - new_tags,
         "added": new_tags - set(old_tags),

--- a/core/schemas/entity.py
+++ b/core/schemas/entity.py
@@ -137,7 +137,8 @@ _private_entity_classes = load_private_types("core.schemas.entities", Entity)
 
 TYPE_MAPPING = {"entity": Entity, "entities": Entity}
 for _cls in (*_ENTITY_CLASSES, *_private_entity_classes):
-    TYPE_MAPPING[str(_cls.model_fields["type"].default)] = cast("type[Entity]", _cls)
+    _cls = cast("type[Entity]", _cls)
+    TYPE_MAPPING[str(_cls.model_fields["type"].default)] = _cls
 
 EntityTypes = Union[
     AttackPattern,

--- a/core/schemas/indicator.py
+++ b/core/schemas/indicator.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import datetime
 import logging
 from enum import Enum
-from typing import Any, ClassVar, Generator, List, Literal, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Generator,
+    List,
+    Literal,
+    Union,
+    cast,
+)
 
 from pydantic import ConfigDict, Field, computed_field
 
@@ -40,6 +49,14 @@ class Indicator(
     _collection_name: ClassVar[str] = "indicators"
     _type_filter: ClassVar[str] = ""
     _root_type: Literal["indicator"] = "indicator"
+
+    if TYPE_CHECKING:
+        # Each concrete indicator subclass declares `type` as its own
+        # Literal[IndicatorType.*] field. Declared here as a property
+        # (type-check time only, so not a required field) so code holding a base
+        # Indicator can resolve `.type`.
+        @property
+        def type(self) -> "IndicatorType": ...
 
     name: str
     description: str = ""
@@ -164,7 +181,8 @@ _private_indicator_classes = load_private_types("core.schemas.indicators", Indic
 
 TYPE_MAPPING = {"indicator": Indicator, "indicators": Indicator}
 for _cls in (*_INDICATOR_CLASSES, *_private_indicator_classes):
-    TYPE_MAPPING[str(_cls.model_fields["type"].default)] = cast("type[Indicator]", _cls)
+    _cls = cast("type[Indicator]", _cls)
+    TYPE_MAPPING[str(_cls.model_fields["type"].default)] = _cls
 
 IndicatorTypes = Union[
     ForensicArtifact,

--- a/core/schemas/indicators/forensicartifact.py
+++ b/core/schemas/indicators/forensicartifact.py
@@ -42,7 +42,7 @@ class ForensicArtifact(indicator.Indicator):
         artifact_reader = reader.YamlArtifactsReader()
         artifact_writer = writer.YamlArtifactsWriter()
 
-        artifacts_dict = {}
+        artifacts_dict: dict[str, "ForensicArtifact"] = {}
 
         for definition in artifact_reader.ReadFileObject(io.StringIO(yaml_string)):
             definition_dict = definition.AsDict()
@@ -56,14 +56,14 @@ class ForensicArtifact(indicator.Indicator):
             definition_dict["location"] = "host"
             definition_dict["diamond"] = indicator.DiamondModel.victim
             definition_dict["relevant_tags"] = [definition_dict["name"]]
-            forensic_indicator = cls(**definition_dict).save()
+            forensic_indicator = cast("ForensicArtifact", cls(**definition_dict).save())
             artifacts_dict[definition.name] = forensic_indicator
 
         if update_parents:
             for artifact in artifacts_dict.values():
                 artifact.update_parents(artifacts_dict)
 
-        return cast("list[ForensicArtifact]", list(artifacts_dict.values()))
+        return list(artifacts_dict.values())
 
     def update_yaml(self):
         artifact_reader = reader.YamlArtifactsReader()

--- a/core/schemas/indicators/yara.py
+++ b/core/schemas/indicators/yara.py
@@ -1,5 +1,5 @@
 import logging
-from typing import ClassVar, Literal
+from typing import ClassVar, Literal, cast
 
 import plyara
 import plyara.exceptions
@@ -164,7 +164,9 @@ class Yara(indicator.Indicator):
                 meta={"missing_dependencies": missing_deps},
             )
 
-        self = super().save(exclude_overwrite=exclude_overwrite)
+        # super().save() is typed through the connector as the base Indicator;
+        # narrow back to Yara to reach the Yara-specific `dependencies`.
+        self = cast("Yara", super().save(exclude_overwrite=exclude_overwrite))
         nodes, relationships, _ = self.neighbors(
             link_types=["depends"], direction="outbound", max_hops=1
         )

--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -5,7 +5,17 @@ import io
 import os
 import tempfile
 from enum import Enum
-from typing import IO, Callable, ClassVar, List, Literal, Tuple, Union, cast
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Callable,
+    ClassVar,
+    List,
+    Literal,
+    Tuple,
+    Union,
+    cast,
+)
 
 import requests
 from bs4 import BeautifulSoup
@@ -30,6 +40,14 @@ class Observable(
     _collection_name: ClassVar[str] = "observables"
     _type_filter: ClassVar[str | None] = None
     _root_type: Literal["observable"] = "observable"
+
+    if TYPE_CHECKING:
+        # Each concrete observable subclass declares `type` as its own
+        # Literal[ObservableType.*] field. Declared here as a property
+        # (type-check time only, so not a required field) so code holding a base
+        # Observable can resolve `.type`.
+        @property
+        def type(self) -> "ObservableType": ...
 
     value: str = Field(min_length=1)
     last_analysis: dict[str, datetime.datetime] = {}
@@ -384,9 +402,8 @@ _private_observable_classes = load_private_types("core.schemas.observables", Obs
 
 TYPE_MAPPING = {"observable": Observable, "observables": Observable}
 for _cls in (*_OBSERVABLE_CLASSES, *_private_observable_classes):
-    TYPE_MAPPING[str(_cls.model_fields["type"].default)] = cast(
-        "type[Observable]", _cls
-    )
+    _cls = cast("type[Observable]", _cls)
+    TYPE_MAPPING[str(_cls.model_fields["type"].default)] = _cls
 
 # Static union for type checkers and OpenAPI. Discriminator is applied by the
 # request/response models that use this alias (as before), so the generated

--- a/core/schemas/rbac.py
+++ b/core/schemas/rbac.py
@@ -68,7 +68,9 @@ def permission_on_ids(permission: roles.Permission):
             if not RBAC_ENABLED or httpreq.state.user.admin:
                 return func(*args, httpreq=httpreq, **kwargs)
 
-            prefix = re.search(r"/api/v2/(\w+)", httpreq.scope["path"]).group(1)
+            prefix_match = re.search(r"/api/v2/(\w+)", httpreq.scope["path"])
+            assert prefix_match is not None
+            prefix = prefix_match.group(1)
             for id in ids:
                 extended_id = f"{prefix}/{id}"
                 if not httpreq.state.user.has_permissions(extended_id, permission):

--- a/core/schemas/task.py
+++ b/core/schemas/task.py
@@ -60,6 +60,14 @@ class Task(YetiModel, database_arango.ArangoYetiConnector):
     _root_type: Literal["task"] = "task"
     _logger = None
 
+    if TYPE_CHECKING:
+        # Each concrete task subclass declares `type` as its own
+        # Literal[TaskType.*] field. Declared here as a property (type-check time
+        # only, so not a required field) so code holding a base Task can resolve
+        # `.type`.
+        @property
+        def type(self) -> "TaskType": ...
+
     # id: str | None = None
     name: str
     enabled: bool = False
@@ -318,7 +326,7 @@ class ExportTask(Task):
 
         FILE_STORAGE_CLIENT.put_file(
             self.file_name,
-            template.render(export_data, None).encode(),
+            (template.render(export_data, None) or "").encode(),
         )
 
     @property

--- a/core/taskscheduler.py
+++ b/core/taskscheduler.py
@@ -43,7 +43,7 @@ app = Celery(
 )
 
 
-@app.on_after_configure.connect
+@app.on_after_configure.connect  # ty: ignore[unresolved-attribute]
 def setup_periodic_tasks(sender, **kwargs):
     """Registers periodic tasks."""
     for task in Task.list():

--- a/core/web/apiv2/context.py
+++ b/core/web/apiv2/context.py
@@ -28,7 +28,7 @@ def replace_context(
     base_type: Type[T], httpreq: Request, id: str, request: ReplaceContextRequest
 ) -> T:
     """Replaces context in an arbitrary Yeti Object."""
-    obj = base_type.get(id)
+    obj = base_type.get(id)  # ty: ignore[unresolved-attribute]
     if not obj:
         raise HTTPException(
             status_code=404, detail=f"{base_type.__name__} {id} not found"
@@ -52,7 +52,7 @@ def add_context(
     base_type: Type[T], httpreq: Request, id: str, request: AddContextRequest
 ) -> T:
     """Adds context to an arbitrary Yeti Object."""
-    obj = base_type.get(id)
+    obj = base_type.get(id)  # ty: ignore[unresolved-attribute]
     if not obj:
         raise HTTPException(
             status_code=404, detail=f"{base_type.__name__} {id} not found"
@@ -71,7 +71,7 @@ def delete_context(
     base_type: Type[T], httpreq: Request, id: str, request: DeleteContextRequest
 ) -> T:
     """Deletes context from an arbitrary Yeti Object."""
-    obj = base_type.get(id)
+    obj = base_type.get(id)  # ty: ignore[unresolved-attribute]
     if not obj:
         raise HTTPException(
             status_code=404, detail=f"{base_type.__name__} {id} not found"

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -136,7 +136,7 @@ def patch(httpreq: Request, request: PatchIndicatorRequest, id: str) -> Indicato
     db_indicator.get_tags()
     update_data = request.indicator.model_dump(exclude_unset=True)
     updated_indicator = db_indicator.model_copy(update=update_data)
-    new = updated_indicator.save()
+    new = cast("IndicatorTypes", updated_indicator.save())
 
     if new.type == IndicatorType.forensicartifact:
         new.update_yaml()

--- a/core/web/apiv2/rbac.py
+++ b/core/web/apiv2/rbac.py
@@ -1,7 +1,10 @@
+from typing import cast
+
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict
 
 from core.schemas import dfiq, entity, graph, indicator, observable, rbac, roles, user
+from core.schemas.model import YetiAclModel
 
 router = APIRouter()
 
@@ -62,7 +65,7 @@ def get_acl_details(httpreq: Request, type: str, id: str):
     if not db_entity:
         raise HTTPException(status_code=404, detail=f"{type} {id} not found")
 
-    db_entity.get_acls(direct=True)
+    cast(YetiAclModel, db_entity).get_acls(direct=True)
     return db_entity
 
 

--- a/core/web/apiv2/templates.py
+++ b/core/web/apiv2/templates.py
@@ -101,7 +101,7 @@ def render(request: RenderTemplateRequest) -> StreamingResponse:
                 continue
             observables.append(db_obs)
 
-    data = template.render(observables, None)
+    data = template.render(observables, None) or ""
 
     def _stream():
         for d in data.split("\n"):

--- a/core/web/webapp.py
+++ b/core/web/webapp.py
@@ -169,7 +169,7 @@ async def log_requests(request: Request, call_next):
             "username": "anonymous",
             # When behind a proxy, we should start uvicorn with --proxy-headers
             # and use request.headers.get('x-forwarded-for') instead.
-            "client": request.client.host,
+            "client": request.client.host if request.client else None,
             "status_code": response.status_code,
             "content-type": request.headers.get("content-type", ""),
             "body": b"",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,13 +76,11 @@ python-version = "3.13"
 include = ["core"]
 
 [tool.ty.rules]
-# Phase 2 ratchet. These rules currently fire across the (previously
-# un-type-checked) code, so they are downgraded to non-blocking warnings while
-# every *other* ty rule is enforced at error level. CI runs with
-# --exit-zero-on-warning: warnings are visible but green, errors fail. Flip
-# these back to "error" (fixing the instances) one rule at a time. Counts are
-# from the initial rollout against ty 0.0.59.
-unresolved-attribute = "warn"       # 138 — ArangoYetiConnector mixin + union attr access
+# Phase 2 ratchet — COMPLETE. Every ty rule is now enforced at error level; the
+# warn-level backlog has been worked down to zero one rule at a time. CI runs
+# with --exit-zero-on-warning, so any rule that regresses to a warning stays
+# visible; keep them all at "error" so regressions fail the build instead.
+unresolved-attribute = "error"      # 0 — DB-connection property, connector/DFIQ/Task/Observable/Indicator TYPE_CHECKING surfaces, arango-job helper, per-site narrowing
 invalid-argument-type = "error"     # 0 — type[...] annotations, casts, dict-key narrowing, api_keys/None
 not-subscriptable = "error"         # 0 — api_keys/None asserts + MISP Org guard
 unsupported-operator = "error"      # 0 — fixed `in ("users")` typo + api_keys/None guards


### PR DESCRIPTION
**Final PR of the `unresolved-attribute` series — and of the whole Phase 2 ty
ratchet.** Clears the long tail of ~33 scattered warnings and flips the last
warn-level rule to `error`. **Every ty rule is now enforced at error level; ty
reports 0 errors and 0 warnings.**

## Structural fixes (clear multiple sites)
- **`Task` / `Observable` / `Indicator`** each gain a `TYPE_CHECKING` `type`
  property — the mirror of the `DFIQBase` one from the previous PR. Every
  concrete subclass declares `type` as its own `Literal`, so code holding a base
  can resolve `.type`. Declared as a **property** so it isn't treated as a
  required pydantic field.
- The **entity/indicator/observable registry loops** cast the loop variable
  `_cls` once so `_cls.model_fields` resolves.
- **`consumers.Consumer`** gains an abstract `on_message` (implemented by the
  Event/Log subclasses) so the base `get_consumers` callback resolves.
- **`migration.MigrationManager`** declares `db_version` (set by the arango subclass).

## Per-site narrowing / guards (behaviour-preserving unless noted)
- **None guards:** webapp client host; `templates`/`task` `template.render() or ""`;
  `misp_to_yeti` now skips `None` observables (previously would crash on
  `link_to`); the arango migration and rbac decorator assert their lookups are
  non-None.
- **Casts** for generic/mixin returns: `yara.save -> Yara`, indicators patch
  `-> IndicatorTypes`, `forensicartifact` dict typed as `ForensicArtifact`, rbac
  `get_acls` via `YetiAclModel`.
- `audit.log_timeline_tags` reads `tags` via `getattr` (DFIQ types have none).
- `utils.py` reads the tldextract config through the typed `yeti_config.get()`
  API instead of dynamic attribute access.
- `context.py` generic helpers `ty: ignore` the `base_type.get` classmethod call
  (the `TypeVar` can't express "connector + context model"); `taskscheduler`
  `ty: ignore`s the celery signal decorator.

## Verification
- `unresolved-attribute` **33 → 0**; rule flipped `warn` → `error`
- ty (0.0.60) in CI's env (`uv sync --group dev`): **0 errors, 0 warnings, all checks passed**
- `ruff check .` + `ruff format . --check`: clean
- unittest schemas / apiv2 / core_tests: **186 / 197 / 29**, all pass
- OpenAPI spec unchanged (the `type` properties are `TYPE_CHECKING`-only)

### Ratchet complete 🎉
Across #1291–#1309 + this PR, all Phase 2 ty rules — 18 of them plus
`unresolved-attribute` — are now enforced at error.
