### PR TITLE
ratchet(types): bring yetictl/ into ty scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,10 @@ exclude = ["deprecated"]
 python-version = "3.13"
 
 [tool.ty.src]
-# Start with core/; widen (plugins/, yetictl/) in follow-ups.
-include = ["core"]
+# core/ and yetictl/ are fully enforced. plugins/ is deferred to a follow-up
+# (its third-party deps aren't installed by the typecheck CI job, and it needs
+# its own ratchet).
+include = ["core", "yetictl"]
 
 [tool.ty.rules]
 # Phase 2 ratchet — COMPLETE. Every ty rule is now enforced at error level; the

--- a/yetictl/cli.py
+++ b/yetictl/cli.py
@@ -27,18 +27,13 @@ def list_users():
 @click.argument("username")
 @click.argument("password")
 @click.option("--admin", is_flag=True, default=False)
-@click.option("--api_key")
-def create_user(
-    username: str, password: str, admin: bool = False, api_key: str | None = None
-) -> None:
+def create_user(username: str, password: str, admin: bool = False) -> None:
     """Creates a new user in the system."""
     user = UserSensitive.find(username=username)
     if user:
         raise RuntimeError(f"User with username {username} already exists")
     user = UserSensitive(username=username, admin=admin)
     user.set_password(password)
-    if api_key:
-        user.reset_api_key(api_key=api_key)
     user.save()
     token = user.create_api_key("default")
     click.echo(f"User {username} succesfully created! API key: {username}:{token}")
@@ -119,7 +114,7 @@ def list_tasks(task_type="") -> None:
 @cli.command()
 @click.argument("task_name")
 @click.argument("task_params", required=False)
-def run_task(task_name: str, task_params: dict | None = None) -> None:
+def run_task(task_name: str, task_params: str | None = None) -> None:
     """Runs a task."""
     # Load all tasks. Take into account new tasks that have not been registered
     logging.getLogger().setLevel(logging.INFO)
@@ -127,14 +122,15 @@ def run_task(task_name: str, task_params: dict | None = None) -> None:
     task = TaskManager.load_task(task_name)
     if not task:
         click.echo("Task {task_name} not found.")
+    parsed_params: TaskParams | None = None
     if task_params:
         try:
-            task_params = TaskParams(params=json.loads(task_params))
+            parsed_params = TaskParams(params=json.loads(task_params))
         except json.JSONDecodeError:
             click.echo("Could not parse task_params")
     try:
-        if task_params:
-            task.run(params=task_params.params)
+        if parsed_params:
+            task.run(params=parsed_params.params)
         else:
             task.run()
     except Exception as error:  # pylint: disable=broad-except


### PR DESCRIPTION
First widening of the ty scope beyond `core/`. Adds `yetictl/` to
`[tool.ty.src]`; `plugins/` is deferred (its third-party deps aren't installed
by the typecheck CI job, and it needs its own ratchet).

`yetictl` surfaced 4 errors, all in `yetictl/cli.py`:

- **`run_task`** — the `task_params` click argument is a raw CLI **string**, not a
  `dict`, so it's retyped `str | None`; the parsed value goes into a separate
  `TaskParams | None` variable instead of rebinding `task_params` through three
  different types. This also removes a **latent crash**: on a JSON parse error the
  old code left `task_params` as the raw string and then did `task_params.params`.
- **`create_user`** — dropped the `--api_key` option and its
  `user.reset_api_key(...)` call. `reset_api_key` **doesn't exist** on the user
  model (only `create_api_key`, which *generates* a token), so that flag always
  crashed. The `"default"` key is still created as before.

## Verification
- ty (0.0.60) in CI's env (`uv sync --group dev`): **0 errors, 0 warnings**
- `ruff check .` + `ruff format . --check`: clean
- unittest schemas / apiv2 / core_tests: **186 / 197 / 29**, all pass
