### PR TITLE
ratchet(types): roll out plugins/ type-checking (Phase 3, warn)

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -24,3 +24,30 @@ jobs:
       # but non-blocking; any error-level diagnostic fails the job.
       - name: Run ty
         run: uv run ty check --exit-zero-on-warning
+
+  typecheck-plugins:
+    name: Type check plugins using ty
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - run:
+          sudo apt-get update && sudo apt-get install -y python3-pip && sudo pip3 install uv
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      # plugins/ imports optional third-party deps (pymisp, otxv2, censys, …), so
+      # this job installs every dependency group. It is kept separate from the
+      # main typecheck job above so that job stays lean (dev group only).
+      - name: Install dependencies
+        run: uv sync --all-groups
+      # Scope the check to plugins/ (core imports still resolve for type info but
+      # core is not itself re-checked here). deprecated/ dirs and the one dead-API
+      # analytic are excluded. Plugin rules are held at warn via
+      # [[tool.ty.overrides]] in pyproject.toml until the Phase 3 ratchet clears
+      # them.
+      - name: Run ty on plugins
+        run: |
+          uv run ty check \
+            -c 'src.include=["plugins"]' \
+            -c 'src.exclude=["plugins/**/deprecated/**", "plugins/analytics/public/random_analytics.py"]' \
+            --exit-zero-on-warning

--- a/core/clients/file_storage/classes/s3.py
+++ b/core/clients/file_storage/classes/s3.py
@@ -1,12 +1,13 @@
 import logging
 import os
+from typing import Any
 
 from core.clients.file_storage.classes.interface import FileStorageClient
 
+boto3: Any = None
 try:
     import boto3  # ty: ignore[unresolved-import]  # optional dep (s3 group)
 except ImportError:
-    boto3 = None
     logging.warning(
         "boto3 is not imported, if you wish to use s3 file storage please install with `uv sync --group s3`"
     )

--- a/core/common/utils.py
+++ b/core/common/utils.py
@@ -1,5 +1,6 @@
 # DEPRECATED
 import logging
+from typing import Any
 
 from dateutil import parser
 from dateutil.tz import UTC, gettz
@@ -10,7 +11,7 @@ from core.config.config import yeti_config
 tzinfos = {"CEST": gettz("Europe/Amsterdam"), "CST": gettz("Europe/Amsterdam")}
 
 
-tld_extract_dict = {"extra_suffixes": list(), "suffix_list_urls": None}
+tld_extract_dict: dict[str, Any] = {"extra_suffixes": list(), "suffix_list_urls": None}
 
 _extra_suffixes = yeti_config.get("tldextract", "extra_suffixes", None)
 if _extra_suffixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,5 +102,30 @@ unknown-argument = "error"          # 0 — fixed a stray strict= kwarg on cls.l
 possibly-missing-submodule = "error"
 unused-type-ignore-comment = "error"
 
+# Phase 3 — plugins ratchet. plugins/ is type-checked by the separate
+# `typecheck-plugins` CI job (it installs all dependency groups and scopes
+# src.include to ["plugins"]); the main typecheck job never checks plugins, so
+# this override is inert there. These rules currently fire across plugins/ and
+# are held at warn until fixed — promote one by DELETING it from this block
+# (then it inherits the error level above). Counts are the initial rollout.
+[[tool.ty.overrides]]
+include = ["plugins"]
+
+[tool.ty.overrides.rules]
+invalid-argument-type = "warn"      # 41
+unresolved-attribute = "warn"       # 32
+invalid-method-override = "warn"    # 12
+invalid-return-type = "warn"        # 7
+deprecated = "warn"                 # 5
+missing-argument = "warn"           # 4
+invalid-assignment = "warn"         # 3
+unused-ignore-comment = "warn"      # 2
+unresolved-import = "warn"          # 2 — no-stub deps (yara C-ext, …)
+invalid-type-form = "warn"          # 2
+unsupported-operator = "warn"       # 1
+not-subscriptable = "warn"          # 1
+invalid-parameter-default = "warn"  # 1
+call-non-callable = "warn"          # 1
+
 [tool.uv.sources]
 artifacts = { git = "https://github.com/forensicartifacts/artifacts.git", rev = "main" }


### PR DESCRIPTION
Foundation PR for Phase 3 — bringing `plugins/` under ty. Adds a **separate**
`typecheck-plugins` CI job so the main typecheck job stays lean (dev group only),
and holds all firing plugin rules at `warn` for an incremental ratchet.

## The new CI job
Installs every dependency group and scopes the check to `plugins/`:
```
ty check -c 'src.include=["plugins"]'
         -c 'src.exclude=["plugins/**/deprecated/**",
                          "plugins/analytics/public/random_analytics.py"]'
         --exit-zero-on-warning
```
Core imports still resolve for type info, but core isn't re-checked here; heavy /
git-based plugin deps are isolated to this job.

## What the scoping found
- **~135 of the 249 naive diagnostics were dead code** — pre-ArangoDB plugins
  under `*/deprecated/*` importing `core.observables` / `core.analytics` /
  `mongoengine`, which no longer exist. Excluding them leaves **114 real
  diagnostics** on the 95 live plugins, the same rule mix as the core ratchet
  (invalid-argument-type 41, unresolved-attribute 32, invalid-method-override 12, …).
- Plugin rules are held at `warn` via a new `[[tool.ty.overrides]]`
  (`include = ["plugins"]`) block — promote one by deleting it. Inert for the
  main job.

## Core fixes (surface only with optional deps installed)
The plugins job imports these core modules, so two long-hidden errors appear:
- `s3.py` — `boto3` typed `Any` for the optional-import fallback (was
  `= None`, flagged once boto3 resolves).
- `utils.py` — `tld_extract_dict` typed `dict[str, Any]` so `TLDExtract(**...)`
  type-checks. Both inert in the dev-only env, so the main job is unchanged.

## Verification
- **Main typecheck job:** unchanged — 0 errors, 0 warnings.
- **New plugins job:** 0 errors, 107 warnings (the ratcheted plugin rules).
- `ruff check .` + `ruff format . --check`: clean
- unittest schemas / apiv2 / core_tests: 186 / 197 / 29, all pass

Next: ratchet the plugin rules one at a time (delete each from the overrides as
its instances are fixed), per `plans/plugins-ty-widening.md`.
