### PR TITLE
ratchet(types): promote 5 single-instance plugin rules to error

### DIFF
--- a/plugins/analytics/public/dockerhub.py
+++ b/plugins/analytics/public/dockerhub.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import re
+from collections.abc import Iterator
 
 import requests
 
@@ -46,12 +47,12 @@ class DockerHubApi:
         return DockerHubApi._make_request(endpoint)
 
     @staticmethod
-    def user_images(user, page_size=50) -> iter:
+    def user_images(user, page_size=50) -> Iterator:
         endpoint = f"https://hub.docker.com/v2/repositories/{user}?page_size={page_size}&ordering=last_updated"
         yield from DockerHubApi._iter_endpoint_pages(endpoint)
 
     @staticmethod
-    def image_tags(image, page_size=100) -> iter:
+    def image_tags(image, page_size=100) -> Iterator:
         endpoint = f"https://hub.docker.com/v2/repositories/{image}/tags/?page_size={page_size}&page=1&name&ordering"
         yield from DockerHubApi._iter_endpoint_pages(endpoint)
 

--- a/plugins/analytics/public/passive_total.py
+++ b/plugins/analytics/public/passive_total.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from typing import Any
 
 import requests
 from dateutil import parser
@@ -13,7 +14,7 @@ from core.schemas.observables import email, hostname, sha256
 
 
 def whois_links(observable_obj: Observable, whois):
-    to_extract = [
+    to_extract: list[dict[str, Any]] = [
         {
             "field": "organization",
             "type": Company,

--- a/plugins/events/public/datadog_metrics.py
+++ b/plugins/events/public/datadog_metrics.py
@@ -2,7 +2,7 @@ import logging
 import threading
 import time
 from queue import Queue
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import requests
 
@@ -54,7 +54,7 @@ class MetricsFlusher(threading.Thread):
         self._logger.debug(
             f"Flushing metrics queue {metrics_queue} (size:{metrics_queue.qsize()})"
         )
-        timeseries = {}
+        timeseries: dict[str, dict[str, Any]] = {}
         for _ in range(self._flush_count):
             if not metrics_queue.empty():
                 key = hashlib.sha256()

--- a/plugins/feeds/public/cisa_kev.py
+++ b/plugins/feeds/public/cisa_kev.py
@@ -132,7 +132,7 @@ class CisaKEV(task.FeedTask):
         cve_id = entry["cveID"]
         reference = f"https://nvd.nist.gov/vuln/detail/{cve_id}"
         description = "#### Summary\n\n"
-        description = entry.get("shortDescription") + "\n\n"
+        description = entry.get("shortDescription", "") + "\n\n"
         description += f"* Added to KEV: {entry['dateAdded']}\n"
         description += f"* Vendor/Project: {entry.get('vendorProject', 'N/A')}\n"
         description += f"* Product: {entry.get('product', 'N/A')}\n"

--- a/plugins/feeds/public/misp.py
+++ b/plugins/feeds/public/misp.py
@@ -74,7 +74,7 @@ class MispFeed(task.FeedTask):
         for event in self.get_event(instance, from_date):
             self.analyze(event, instance)
 
-    def get_event(self, instance: dict, from_date: str, to_date: str = None):
+    def get_event(self, instance: dict, from_date: str, to_date: str | None = None):
         misp_client = PyMISP(
             url=instance["url"], key=instance["key"], ssl=instance["verifycert"]
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,11 +121,6 @@ missing-argument = "warn"           # 4
 invalid-assignment = "warn"         # 3
 unused-ignore-comment = "warn"      # 2
 unresolved-import = "warn"          # 2 — no-stub deps (yara C-ext, …)
-invalid-type-form = "warn"          # 2
-unsupported-operator = "warn"       # 1
-not-subscriptable = "warn"          # 1
-invalid-parameter-default = "warn"  # 1
-call-non-callable = "warn"          # 1
 
 [tool.uv.sources]
 artifacts = { git = "https://github.com/forensicartifacts/artifacts.git", rev = "main" }


### PR DESCRIPTION
First plugins ratchet PR (Phase 3). Fixes the trivial single/low-instance rules
and deletes them from the `[[tool.ty.overrides]]` block so they inherit `error`:

| rule | file | fix |
|------|------|-----|
| invalid-type-form | dockerhub.py | `-> iter` → `-> Iterator` on two generators |
| call-non-callable | passive_total.py | `to_extract: list[dict[str, Any]]` so `field["type"](...)` is callable |
| not-subscriptable | datadog_metrics.py | `timeseries: dict[str, dict[str, Any]]` |
| unsupported-operator | cisa_kev.py | `entry.get("shortDescription", "")` (str default, not `str \| None`) |
| invalid-parameter-default | misp.py | `to_date: str \| None = None` |

## Verification
- **Plugins job:** 0 errors (107 → 96 warnings)
- **Main typecheck job:** unchanged
- `ruff check .` + `ruff format . --check`: clean
- unittest schemas / apiv2 / core_tests: 186 / 197 / 29, all pass
