### PR TITLE
ratchet(types): promote missing-argument/invalid-assignment/unresolved-import (plugins)

### DIFF
--- a/plugins/analytics/public/passive_total.py
+++ b/plugins/analytics/public/passive_total.py
@@ -59,7 +59,7 @@ def whois_links(observable_obj: Observable, whois):
                     ns_obs = hostname.Hostname(value=ns).save()
                     observable_obj.link_to(ns_obs, "NS record", "PassiveTotal")
                 except Exception as e:
-                    logging.error(e.with_traceback())
+                    logging.error(e)
 
 
 class PassiveTotalApi(object):
@@ -184,7 +184,7 @@ class PassiveTotalWhois(task.OneShotTask, PassiveTotalApi):
         data = PassiveTotalApi.get("/whois", params)
 
         context = {"source": "PassiveTotal Whois", "raw": data}
-        observable_obj.add_context(context)
+        observable_obj.add_context(context["source"], context)
 
         whois_links(observable_obj, data)
 

--- a/plugins/events/public/datadog_metrics.py
+++ b/plugins/events/public/datadog_metrics.py
@@ -98,7 +98,7 @@ class DatadogMetrics(task.EventTask):
         "acts_on": "(new|update|delete)",
     }
 
-    _metrics_flusher: ClassVar[MetricsFlusher] = None
+    _metrics_flusher: ClassVar[MetricsFlusher | None] = None
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/plugins/feeds/public/otx_alienvault.py
+++ b/plugins/feeds/public/otx_alienvault.py
@@ -2,9 +2,10 @@ import json
 import logging
 from datetime import datetime, timedelta
 from io import StringIO
+from typing import Any
 
 import pandas as pd
-import yara
+import yara  # ty: ignore[unresolved-import]  # yara-python is a C extension with no type stubs
 from OTXv2 import OTXv2
 
 from core import taskmanager
@@ -63,7 +64,7 @@ class OTXAlienvault(task.FeedTask):
             self.analyze(row)
 
     def analyze(self, item):
-        context = dict(source=self.name)
+        context: dict[str, Any] = dict(source=self.name)
         context["references"] = "\r\n".join(item["references"])
         context["description"] = item["description"]
         context["link"] = "https://otx.alienvault.com/pulse/%s" % item["id"]

--- a/plugins/feeds/public/yaraify.py
+++ b/plugins/feeds/public/yaraify.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from typing import ClassVar
 from zipfile import ZipFile
 
-import yara
+import yara  # ty: ignore[unresolved-import]  # yara-python is a C extension with no type stubs
 
 from core import taskmanager
 from core.schemas import indicator, task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,10 +117,10 @@ unresolved-attribute = "warn"       # 32
 invalid-method-override = "warn"    # 12
 invalid-return-type = "warn"        # 7
 deprecated = "warn"                 # 5
-missing-argument = "warn"           # 4
-invalid-assignment = "warn"         # 3
-unused-ignore-comment = "warn"      # 2
-unresolved-import = "warn"          # 2 — no-stub deps (yara C-ext, …)
+# unused-ignore-comment stays warn: the only instances are the boto3/tldextract
+# import ignores in core (s3.py/utils.py) — used by the dev-only main job but
+# unused in this all-deps plugins job, so they can't be cleanly removed.
+unused-ignore-comment = "warn"      # 2 (core-only, env-dependent)
 
 [tool.uv.sources]
 artifacts = { git = "https://github.com/forensicartifacts/artifacts.git", rev = "main" }


### PR DESCRIPTION
Second plugins ratchet batch. Fixes instances and drops three rules from the
`[[tool.ty.overrides]]` block.

- **missing-argument** (`passive_total.py`) — two real latent bugs:
  `e.with_traceback()` with no arg → `logging.error(e)`; and `add_context(context)`
  called with one arg → `add_context(context["source"], context)`.
- **invalid-assignment** — `datadog_metrics` `_metrics_flusher` typed
  `ClassVar[MetricsFlusher | None]`; `otx_alienvault` `context` typed
  `dict[str, Any]` so the datetime `context["created"]` assignment fits.
- **unresolved-import** — `import yara` in `otx_alienvault`/`yaraify` gets a
  per-line `# ty: ignore[unresolved-import]` (yara-python is a stub-less C ext).

`unused-ignore-comment` stays at `warn`: its only instances are the
boto3/tldextract import ignores in **core** — used by the dev-only main job but
unused in this all-deps plugins job, so they can't be cleanly removed.

## Verification
- **Plugins job:** 0 errors (96 → 89 warnings)
- **Main typecheck job:** unchanged
- `ruff check .` + `ruff format . --check`: clean
- unittest schemas / apiv2 / core_tests: 186 / 197 / 29, all pass
