### PR TITLE
ratchet(types): promote invalid-method-override + invalid-return-type (plugins)

### DIFF
--- a/core/schemas/task.py
+++ b/core/schemas/task.py
@@ -246,7 +246,7 @@ class AnalyticsTask(Task):
         observable.last_analysis[self.name] = now()
         observable.save()
 
-    def each(self, observable: Observable) -> Observable:
+    def each(self, observable: Observable, /) -> Observable:
         """Analyzes a single observable.
 
         Args:
@@ -280,7 +280,7 @@ class OneShotTask(Task):
             return
         self.each(results[0])
 
-    def each(self, observable: Observable) -> None:
+    def each(self, observable: Observable, /) -> None:
         """Analyzes a single observable.
 
         Args:

--- a/plugins/analytics/public/circl_passive_ssl.py
+++ b/plugins/analytics/public/circl_passive_ssl.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import requests
 from OpenSSL.crypto import (
     FILETYPE_ASN1,
@@ -9,7 +11,7 @@ from OpenSSL.crypto import (
 from core import taskmanager
 from core.config.config import yeti_config
 from core.schemas import task
-from core.schemas.observable import ObservableType
+from core.schemas.observable import Observable, ObservableType
 from core.schemas.observables import certificate, ipv4
 
 
@@ -68,7 +70,8 @@ class CirclPassiveSSLSearchIP(task.AnalyticsTask, CirclPassiveSSLApi):
 
     acts_on: list[ObservableType] = [ObservableType.ipv4]
 
-    def each(self, ip: ipv4.IPv4):
+    def each(self, observable: Observable):
+        ip = cast("ipv4.IPv4", observable)
         ip_search = CirclPassiveSSLApi.search_ip(ip)
         if ip_search:
             for ip_addr, ip_details in ip_search.items():

--- a/plugins/analytics/public/dockerhub.py
+++ b/plugins/analytics/public/dockerhub.py
@@ -21,7 +21,7 @@ class DockerHubApi:
         return {}
 
     @staticmethod
-    def _iter_endpoint_pages(endpoint) -> dict:
+    def _iter_endpoint_pages(endpoint) -> Iterator:
         data = DockerHubApi._make_request(endpoint)
         while data:
             for result in data.get("results", []):

--- a/plugins/analytics/public/macaddress_io.py
+++ b/plugins/analytics/public/macaddress_io.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import json
 from datetime import datetime
+from typing import cast
 
 from maclookup import ApiClient
 from maclookup import exceptions as maclookup_exceptions
@@ -10,7 +11,7 @@ from core import taskmanager
 from core.config.config import yeti_config
 from core.schemas import task
 from core.schemas.entity import Company
-from core.schemas.observable import ObservableType
+from core.schemas.observable import Observable, ObservableType
 from core.schemas.observables.mac_address import MacAddress
 
 
@@ -62,7 +63,8 @@ class MacAddressIo(task.AnalyticsTask, MacAddressIoApi):
 
     acts_on: list[ObservableType] = [ObservableType.mac_address]
 
-    def each(self, mac_address: MacAddress):
+    def each(self, observable: Observable):
+        mac_address = cast("MacAddress", observable)
         lookup_results = MacAddressIoApi.get(mac_address.value)
 
         vendor = None

--- a/plugins/analytics/public/network_whois.py
+++ b/plugins/analytics/public/network_whois.py
@@ -1,9 +1,11 @@
+from typing import cast
+
 from ipwhois import IPWhois
 
 from core import taskmanager
 from core.schemas import task
 from core.schemas.entity import Company
-from core.schemas.observable import ObservableType
+from core.schemas.observable import Observable, ObservableType
 from core.schemas.observables import email, ipv4
 
 
@@ -16,7 +18,8 @@ class NetworkWhois(task.AnalyticsTask):
 
     acts_on: list[ObservableType] = [ObservableType.ipv4]
 
-    def each(self, ip: ipv4.IPv4):
+    def each(self, observable: Observable):
+        ip = cast("ipv4.IPv4", observable)
         r = IPWhois(ip.value)
         result = r.lookup_whois()
 

--- a/plugins/analytics/public/shodan_api.py
+++ b/plugins/analytics/public/shodan_api.py
@@ -1,4 +1,5 @@
 import logging
+from typing import cast
 
 import shodan
 
@@ -36,7 +37,8 @@ class ShodanQuery(task.OneShotTask, ShodanApi):
 
     acts_on: list[ObservableType] = [ObservableType.ipv4]
 
-    def each(self, ip: ipv4.IPv4) -> Observable:
+    def each(self, observable: Observable) -> None:
+        ip = cast("ipv4.IPv4", observable)
         result = ShodanApi.fetch(ip)
         logging.debug(result)
 
@@ -60,7 +62,7 @@ class ShodanQuery(task.OneShotTask, ShodanApi):
             logging.debug(result["isp"])
             o_isp = Company(name=result["isp"]).save()
             ip.link_to(o_isp, "hosting", "Shodan Query")
-        return ip
+        return
 
 
 taskmanager.TaskManager.register_task(ShodanQuery)

--- a/plugins/feeds/public/et_open.py
+++ b/plugins/feeds/public/et_open.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 from datetime import timedelta, timezone
 from io import StringIO
+from typing import cast
 
 from idstools import rule
 
@@ -68,7 +69,7 @@ class ETOpen(task.FeedTask):
         ind_cve = entity.Vulnerability.find(name=cve)
         if not ind_cve:
             ind_cve = entity.Vulnerability(name=cve).save()
-        return ind_cve
+        return cast("entity.Vulnerability", ind_cve)
 
     def _extract_malware_family(self, meta: str):
         _, malware_family = meta.split(" ")
@@ -92,7 +93,7 @@ class ETOpen(task.FeedTask):
             aliases=[("text", mitre_id)],
         )
         if nb_ent != 0:
-            return ind_mitre_attack[0]
+            return cast("entity.AttackPattern", ind_mitre_attack[0])
 
     def _filter_rule(self, metadata: list[str]):
         """

--- a/plugins/feeds/public/miningpoolstats.py
+++ b/plugins/feeds/public/miningpoolstats.py
@@ -83,7 +83,7 @@ class MiningPoolStats(task.FeedTask):
             yield data
         return
 
-    def _get_coin_names(self) -> list:
+    def _get_coin_names(self) -> set | None:
         """
         Return available coin names in two steps. At first, fetch the main page to extract the
         timestamped endpoint. Then, add to a set the coin name from the page key.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,6 @@ include = ["plugins"]
 [tool.ty.overrides.rules]
 invalid-argument-type = "warn"      # 41
 unresolved-attribute = "warn"       # 32
-invalid-method-override = "warn"    # 12
-invalid-return-type = "warn"        # 7
 deprecated = "warn"                 # 5
 # unused-ignore-comment stays warn: the only instances are the boto3/tldextract
 # import ignores in core (s3.py/utils.py) — used by the dev-only main job but


### PR DESCRIPTION
Third plugins ratchet batch; drops both rules from the `[[tool.ty.overrides]]`
block.

## invalid-method-override (12) — all analytics `each` overrides
- **8 were pure parameter-name mismatches** (`observable_obj` vs base
  `observable`). Made the base `AnalyticsTask.each` / `OneShotTask.each`
  parameter **positional-only** (`observable, /`) in `core/schemas/task.py` —
  the framework only ever calls `each()` positionally, so the callback's
  parameter name is an implementation detail. Clears all 8 at once.
- **4 narrowed the parameter** to a concrete observable type (`IPv4`/`MacAddress`)
  — an LSP violation. They now take `observable: Observable` and `cast` to the
  concrete type on the first line. `shodan` also returned the observable from a
  `OneShotTask.each` (`-> None`); dropped the stray return.

## invalid-return-type (7)
- `dockerhub._iter_endpoint_pages` is a generator → `-> Iterator` (was `-> dict`).
- `et_open._extract_cve`/`_extract_mitre_attack` cast the connector's
  Entity-typed `save()`/`filter()` results back to `Vulnerability`/`AttackPattern`.
- `miningpoolstats._get_coin_names` → `-> set | None` (returns a set or None).

## Verification
- **Plugins job:** 0 errors (89 → 70 warnings)
- **Main typecheck job:** unchanged (0/0)
- `ruff check .` + `ruff format . --check`: clean
- unittest schemas / apiv2 / core_tests: 186 / 197 / 29, all pass
