### PR TITLE
ratchet(types): promote invalid-argument-type (plugins)

### DIFF
--- a/core/schemas/task.py
+++ b/core/schemas/task.py
@@ -154,7 +154,7 @@ class FeedTask(Task):
         url: str,
         method: str = "get",
         headers: dict = {},
-        auth: tuple = (),
+        auth: tuple | None = (),
         params: dict = {},
         data: dict = {},
         json_data: dict = {},

--- a/plugins/analytics/public/ioc_extractor.py
+++ b/plugins/analytics/public/ioc_extractor.py
@@ -63,7 +63,7 @@ class IOCExtractor(task.AnalyticsTask):
             logging.exception(f"Error processing URL {url_obs.value} with Agent")
             logging.debug(last_response)
 
-    def process_report(self, report, source: observable.Url):
+    def process_report(self, report, source: observable.Observable):
         report_entity = investigation.Investigation(
             name=report["title"],
             description=report["summary"],

--- a/plugins/analytics/public/virustotal_api.py
+++ b/plugins/analytics/public/virustotal_api.py
@@ -47,7 +47,7 @@ class VirustotalApi(object):
             raise RuntimeError(msg)
 
     @staticmethod
-    def process_domain(domain: hostname.Hostname, attributes):
+    def process_domain(domain: Observable, attributes):
         context_key = "VirusTotalDomainInfo"
         context = {"source": context_key}
         logging.debug(attributes)

--- a/plugins/events/hostname_extract.py
+++ b/plugins/events/hostname_extract.py
@@ -16,6 +16,8 @@ class HostnameExtract(task.EventTask):
         url = message.event.yeti_object
         self.logger.info(f"Extracting hostname from: {url.value}")
         o = urlparse(url.value)
+        if not o.hostname:
+            return
         if observable.IPv4.validator(o.hostname):
             extracted_obs = observable.IPv4(value=o.hostname).save()
         else:

--- a/plugins/feeds/public/cisa_kev.py
+++ b/plugins/feeds/public/cisa_kev.py
@@ -160,7 +160,7 @@ class CisaKEV(task.FeedTask):
             base_score=base_score,
             severity=severity,
         ).save()
-        vulnerability.tag({entry.get("cveID"), "cisa-kev"})
+        vulnerability.tag({entry.get("cveID", ""), "cisa-kev"})
 
 
 taskmanager.TaskManager.register_task(CisaKEV)

--- a/plugins/feeds/public/dataplane_dnsrd.py
+++ b/plugins/feeds/public/dataplane_dnsrd.py
@@ -31,7 +31,9 @@ class DataplaneDNSRecursive(task.FeedTask):
         response = self._make_request(self._SOURCE, sort=False)
         if response:
             lines = response.content.decode("utf-8").split("\n")[64:-5]
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df["lastseen"] = pd.to_datetime(df["lastseen"])
             df.ffill(inplace=True)

--- a/plugins/feeds/public/dataplane_dnsrdany.py
+++ b/plugins/feeds/public/dataplane_dnsrdany.py
@@ -26,7 +26,9 @@ class DataplaneDNSAny(task.FeedTask):
         if response:
             lines = response.content.decode("utf-8").split("\n")[64:-5]
 
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df = df.dropna()
             df["lastseen"] = pd.to_datetime(df["lastseen"])

--- a/plugins/feeds/public/dataplane_dnsversion.py
+++ b/plugins/feeds/public/dataplane_dnsversion.py
@@ -31,7 +31,9 @@ class DataplaneDNSVersion(task.FeedTask):
         if response:
             lines = response.content.decode("utf-8").split("\n")[66:-5]
 
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
 
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df.ffill(inplace=True)

--- a/plugins/feeds/public/dataplane_proto41.py
+++ b/plugins/feeds/public/dataplane_proto41.py
@@ -30,7 +30,9 @@ class DataplaneProto41(task.FeedTask):
         if response:
             lines = response.content.decode("utf-8").split("\n")[64:-5]
 
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAME)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAME)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df["lastseen"] = pd.to_datetime(df["lastseen"])
             df.ffill(inplace=True)

--- a/plugins/feeds/public/dataplane_sipinvite.py
+++ b/plugins/feeds/public/dataplane_sipinvite.py
@@ -29,7 +29,9 @@ class DataplaneSIPInvite(task.FeedTask):
         response = self._make_request(self._SOURCE, sort=False)
         if response:
             lines = response.content.decode("utf-8").split("\n")[66:-5]
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df["lastseen"] = pd.to_datetime(df["lastseen"])
             df.ffill(inplace=True)

--- a/plugins/feeds/public/dataplane_sipquery.py
+++ b/plugins/feeds/public/dataplane_sipquery.py
@@ -29,7 +29,9 @@ class DataplaneSIPQuery(task.FeedTask):
         if response:
             lines = response.content.decode("utf-8").split("\n")[66:-5]
             columns = ["ASN", "ASname", "ipaddr", "lastseen", "category"]
-            df = pd.DataFrame([line.split("|") for line in lines], columns=columns)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(columns)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df["lastseen"] = pd.to_datetime(df["lastseen"])
             df.ffill(inplace=True)

--- a/plugins/feeds/public/dataplane_sipregistr.py
+++ b/plugins/feeds/public/dataplane_sipregistr.py
@@ -31,7 +31,9 @@ class DataplaneSIPRegistr(task.FeedTask):
         if response:
             lines = response.content.decode("utf-8").split("\n")[66:-5]
 
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df["lastseen"] = pd.to_datetime(df["lastseen"])
             df.ffill(inplace=True)

--- a/plugins/feeds/public/dataplane_smtpdata.py
+++ b/plugins/feeds/public/dataplane_smtpdata.py
@@ -29,7 +29,9 @@ class DataplaneSMTPData(task.FeedTask):
         response = self._make_request(self._SOURCE, sort=False)
         if response:
             lines = response.content.decode("utf-8").split("\n")[68:-5]
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df = df.dropna()
             df["lastseen"] = pd.to_datetime(df["lastseen"])

--- a/plugins/feeds/public/dataplane_smtpgreet.py
+++ b/plugins/feeds/public/dataplane_smtpgreet.py
@@ -30,7 +30,9 @@ class DataplaneSMTPGreet(task.FeedTask):
         if response:
             lines = response.content.decode("utf-8").split("\n")[68:-5]
 
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df["lastseen"] = pd.to_datetime(df["lastseen"])
             df.ffill(inplace=True)

--- a/plugins/feeds/public/dataplane_sshclient.py
+++ b/plugins/feeds/public/dataplane_sshclient.py
@@ -29,7 +29,9 @@ class DataplaneSSHClient(task.FeedTask):
         response = self._make_request(self._SOURCE, sort=False)
         if response:
             lines = response.content.decode("utf-8").split("\n")[64:-5]
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df["lastseen"] = pd.to_datetime(df["lastseen"])
             df.ffill(inplace=True)

--- a/plugins/feeds/public/dataplane_sshpwauth.py
+++ b/plugins/feeds/public/dataplane_sshpwauth.py
@@ -29,7 +29,9 @@ class DataplaneSSHPwAuth(task.FeedTask):
         response = self._make_request(self._SOURCE, sort=False)
         if response:
             lines = response.content.decode("utf-8").split("\n")[68:-5]
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df = df.dropna()
 

--- a/plugins/feeds/public/dataplane_telnetlogin.py
+++ b/plugins/feeds/public/dataplane_telnetlogin.py
@@ -30,7 +30,9 @@ class DataplaneTelenetLogin(task.FeedTask):
         if response:
             lines = response.content.decode("utf-8").split("\n")[64:-5]
 
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df["lastseen"] = pd.to_datetime(df["lastseen"])
             df.ffill(inplace=True)

--- a/plugins/feeds/public/dataplane_vnc.py
+++ b/plugins/feeds/public/dataplane_vnc.py
@@ -30,7 +30,9 @@ class DataplaneVNC(task.FeedTask):
         if response:
             lines = response.content.decode("utf-8").split("\n")[68:-5]
 
-            df = pd.DataFrame([line.split("|") for line in lines], columns=self._NAMES)
+            df = pd.DataFrame(
+                [line.split("|") for line in lines], columns=pd.Index(self._NAMES)
+            )
             df = df.applymap(lambda x: x.strip() if isinstance(x, str) else x)
             df["lastseen"] = pd.to_datetime(df["lastseen"])
             df.ffill(inplace=True)

--- a/plugins/feeds/public/lolbas.py
+++ b/plugins/feeds/public/lolbas.py
@@ -74,7 +74,7 @@ class LoLBAS(task.FeedTask):
                         name=indicator_name,
                         type="regex",
                         pattern=fpath_pattern,
-                        diamond="capability",
+                        diamond=indicator.DiamondModel.capability,
                     )
                 except Exception:
                     logging.exception(f"Failed to save indicator: {indicator_name}")
@@ -106,7 +106,7 @@ class LoLBAS(task.FeedTask):
                         "Error processing sigma rule for %s: %s", entry["Name"], error
                     )
 
-    def process_sigma_rule(self, tool: entity.Tool, detection: dict) -> None:
+    def process_sigma_rule(self, tool: entity.Entity, detection: dict) -> None:
         """Processes a Sigma rule as specified in the lolbas json."""
         url = detection["Sigma"]
         if not url:

--- a/plugins/feeds/public/misp.py
+++ b/plugins/feeds/public/misp.py
@@ -1,6 +1,7 @@
 import logging
 import unicodedata
 from datetime import date, datetime, timedelta
+from typing import cast
 from urllib.parse import urljoin
 
 from pymisp.api import PyMISP
@@ -45,7 +46,7 @@ class MispFeed(task.FeedTask):
             logging.error("Issue on misp client")
             return
 
-        orgs = misp_client.organisations(scope="all")
+        orgs = cast("list[dict]", misp_client.organisations(scope="all"))
         for org in orgs:
             org_id = org["Organisation"]["id"]
             org_name = org["Organisation"]["name"]
@@ -70,18 +71,21 @@ class MispFeed(task.FeedTask):
 
     def get_last_events(self, instance: dict):
         from_date = self.last_run
+        assert from_date is not None
         logging.debug(f"Getting events from {from_date} and {self.last_run}")
         for event in self.get_event(instance, from_date):
             self.analyze(event, instance)
 
-    def get_event(self, instance: dict, from_date: str, to_date: str | None = None):
+    def get_event(self, instance: dict, from_date: date, to_date: date | None = None):
         misp_client = PyMISP(
             url=instance["url"], key=instance["key"], ssl=instance["verifycert"]
         )
-        from_date = from_date.strftime("%Y-%m-%d")
-        if to_date:
-            to_date = to_date.strftime("%Y-%m-%d")
-        results = misp_client.search(date_from=from_date, date_to=to_date)
+        from_date_str = from_date.strftime("%Y-%m-%d")
+        to_date_str = to_date.strftime("%Y-%m-%d") if to_date else None
+        results = cast(
+            "list[dict]",
+            misp_client.search(date_from=from_date_str, date_to=to_date_str),
+        )
         logging.debug("Found {} events".format(len(results)))
         for r in results:
             if "Event" in r:
@@ -162,7 +166,7 @@ class MispFeed(task.FeedTask):
 
             obs.add_context(instance["name"], context)
 
-    def decompose_weeks(self, start_day: datetime, last_day: datetime):
+    def decompose_weeks(self, start_day: date, last_day: date):
         # Génère la liste de tuples
         weeks = []
         current_start = start_day

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ unused-type-ignore-comment = "error"
 include = ["plugins"]
 
 [tool.ty.overrides.rules]
-invalid-argument-type = "warn"      # 41
 unresolved-attribute = "warn"       # 32
 deprecated = "warn"                 # 5
 # unused-ignore-comment stays warn: the only instances are the boto3/tldextract


### PR DESCRIPTION
Fourth plugins ratchet batch; drops `invalid-argument-type` from the overrides.
41 instances, clustered:

- **DataFrame columns (13, all `dataplane_*` feeds):** `columns=self._NAMES` (a
  `list[str]`) is rejected by pandas-stubs' `columns` type on Python 3.13.
  Wrapped in `pd.Index(...)`, which the stub accepts. No behaviour change.
- **`_make_request` `auth=None` (4):** widened the core signature
  `auth: tuple` → `auth: tuple | None` (requests accepts `auth=None`).
- **misp.py (6):** `decompose_weeks`/`get_event` params retyped
  `datetime`/`str` → `date`; PyMISP `organisations()`/`search()` results cast to
  `list[dict]` (were inferred as `str`); `get_last_events` asserts `last_run`
  non-None; strftime results use new locals so the `date`-typed params aren't
  reassigned to `str`.
- **hostname_extract:** guard `o.hostname` (urlparse → `str | None`).
- **Widened callback params to what they actually receive:** virustotal
  `process_domain` (Hostname → Observable), ioc_extractor `process_report`
  (Url → Observable), lolbas `process_sigma_rule` (Tool → Entity, since
  `save()` returns the base Entity).
- cisa_kev tag uses `entry.get("cveID", "")`; lolbas `diamond` uses the
  `DiamondModel` enum instead of `"capability"`.

## Verification
- **Plugins job:** 0 errors (70 → 36 warnings)
- **Main typecheck job:** unchanged (0/0)
- `ruff check .` + `ruff format . --check`: clean
- unittest schemas / apiv2 / core_tests: 186 / 197 / 29, all pass
