### PR TITLE
ratchet(types): promote unresolved-attribute + deprecated (plugins)

### DIFF
--- a/plugins/analytics/public/dockerhub.py
+++ b/plugins/analytics/public/dockerhub.py
@@ -2,12 +2,14 @@ import datetime
 import logging
 import re
 from collections.abc import Iterator
+from typing import cast
 
 import requests
 
 from core import taskmanager
 from core.schemas import observable, task
 from core.schemas.observable import Observable, ObservableType
+from core.schemas.observables.container_image import ContainerImage
 
 
 class DockerHubApi:
@@ -183,7 +185,7 @@ class DockerHubImageAnalytics(task.OneShotTask):
             observable_obj.type == "docker_image"
             or (
                 observable_obj.type == "container_image"
-                and observable_obj.registry == "docker.io"
+                and cast("ContainerImage", observable_obj).registry == "docker.io"
             )
         ):
             self.logger.info(

--- a/plugins/events/hostname_extract.py
+++ b/plugins/events/hostname_extract.py
@@ -1,7 +1,8 @@
+from typing import cast
 from urllib.parse import urlparse
 
 from core import taskmanager
-from core.events.message import EventMessage
+from core.events.message import EventMessage, ObjectEvent
 from core.schemas import observable, task
 
 
@@ -13,7 +14,9 @@ class HostnameExtract(task.EventTask):
     }
 
     def run(self, message: EventMessage) -> None:
-        url = message.event.yeti_object
+        event = message.event
+        assert isinstance(event, ObjectEvent)
+        url = cast("observable.Url", event.yeti_object)
         self.logger.info(f"Extracting hostname from: {url.value}")
         o = urlparse(url.value)
         if not o.hostname:

--- a/plugins/events/public/dockerhub.py
+++ b/plugins/events/public/dockerhub.py
@@ -1,7 +1,9 @@
+from typing import cast
+
 from core import taskmanager
-from core.events.message import EventMessage
+from core.events.message import EventMessage, ObjectEvent
 from core.schemas import task
-from core.schemas.observable import Observable
+from core.schemas.observables.container_image import ContainerImage
 from plugins.analytics.public.dockerhub import (
     DockerHubApi,
     get_image_context,
@@ -30,7 +32,9 @@ class DockerHubImageEvent(task.EventTask):
     }
 
     def run(self, message: EventMessage) -> None:
-        container_image = message.event.yeti_object
+        event = message.event
+        assert isinstance(event, ObjectEvent)
+        container_image = cast("ContainerImage", event.yeti_object)
         self.logger.info(f"Analysing container image {container_image.value}")
         if not (
             container_image.type == "docker_image"

--- a/plugins/feeds/public/abusech_malwarebazaar.py
+++ b/plugins/feeds/public/abusech_malwarebazaar.py
@@ -1,7 +1,7 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from io import StringIO
-from typing import ClassVar
+from typing import ClassVar, cast
 
 import pandas as pd
 
@@ -82,7 +82,7 @@ class AbuseCHMalwareBazaaar(task.FeedTask):
         context["sha256"] = block["sha256_hash"]
         context["imphash"] = block["imphash"]
         context["ssdeep"] = block["ssdeep"]
-        context["date_added"] = datetime.utcnow()
+        context["date_added"] = datetime.now(timezone.utc)
         context["tlsh"] = block["tlsh"]
         if block["reporter"]:
             context["reporter"] = block["reporter"]
@@ -93,7 +93,7 @@ class AbuseCHMalwareBazaaar(task.FeedTask):
 
         file_value = "FILE:{}".format(block["sha256_hash"])
 
-        malware_file = file.File(value=file_value).save()
+        malware_file = cast("file.File", file.File(value=file_value).save())
         logging.debug(
             f"Malware file: {malware_file} source: {self.name} context: {context}"
         )

--- a/plugins/feeds/public/abuseipdb.py
+++ b/plugins/feeds/public/abuseipdb.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import ClassVar
 
 from core import taskmanager
@@ -37,7 +37,7 @@ class AbuseIPDB(task.FeedTask):
 
         ip_value = line
 
-        context = {"source": self.name, "date_added": datetime.utcnow()}
+        context = {"source": self.name, "date_added": datetime.now(timezone.utc)}
         ipv4_obs = ipv4.IPv4(value=ip_value).save()
 
         logging.debug(f"Adding context to {ip_value}")

--- a/plugins/feeds/public/azorult-tracker.py
+++ b/plugins/feeds/public/azorult-tracker.py
@@ -1,7 +1,7 @@
 """Azorult Tracker feeds"""
 
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import ClassVar
 
 import numpy as np
@@ -38,7 +38,7 @@ class AzorultTracker(task.FeedTask):
                 self.analyze(item)
 
     def analyze(self, item):
-        context = {"source": self.name, "date_added": datetime.utcnow()}
+        context = {"source": self.name, "date_added": datetime.now(timezone.utc)}
 
         _id = item["_id"]
         domain = item["domain"]
@@ -64,7 +64,7 @@ class AzorultTracker(task.FeedTask):
         context["_id"] = _id
         context["panel_version"] = panel_version
         context["panel_path"] = panel_path
-        context["date_added"] = datetime.utcnow()
+        context["date_added"] = datetime.now(timezone.utc)
 
         try:
             hostname_obs = None

--- a/plugins/feeds/public/botvrij_filename.py
+++ b/plugins/feeds/public/botvrij_filename.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from core import taskmanager
 from core.schemas import task
@@ -29,7 +29,7 @@ class BotvrijFilename(task.FeedTask):
             "description": descr,
         }
 
-        obs = file.File(value=filen).save()
+        obs = cast("file.File", file.File(value=filen).save())
         obs.name = filen
         obs.add_context(self.name, context)
         obs.tag(["botvrij"])

--- a/plugins/feeds/public/cisco_umbrella_top_domains.py
+++ b/plugins/feeds/public/cisco_umbrella_top_domains.py
@@ -21,6 +21,8 @@ class CiscoUmbrellaTopDomains(task.FeedTask):
     def run(self):
         top_domains = yeti_config.get("umbrella", "top_domains", 10000)
         response = self._make_request(self._SOURCE, sort=False)
+        if not response:
+            return
         data = self._unzip_content(response.content)
         context = {
             "name": self.name,

--- a/plugins/feeds/public/hybrid_analysis.py
+++ b/plugins/feeds/public/hybrid_analysis.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import timedelta
 from io import StringIO
-from typing import ClassVar
+from typing import ClassVar, cast
 
 import pandas as pd
 
@@ -41,7 +41,7 @@ class HybridAnalysis(task.FeedTask):
 
         try:
             sha256_obs = sha256.SHA256(value=item["sha256"]).save()
-            f_hyb = file.File(value=f"FILE:{item['sha256']}").save()
+            f_hyb = cast("file.File", file.File(value=f"FILE:{item['sha256']}").save())
         except Exception:
             logging.exception(f"HybridAnalysis: Failed to save file: {item['sha256']}")
             return

--- a/plugins/feeds/public/lolbas.py
+++ b/plugins/feeds/public/lolbas.py
@@ -115,7 +115,9 @@ class LoLBAS(task.FeedTask):
             "blob/", ""
         )
         try:
-            sigma_yaml = self._make_request(url).text
+            response = self._make_request(url)
+            assert response is not None
+            sigma_yaml = response.text
             sigma_data = yaml.safe_load(sigma_yaml)
         except yaml.YAMLError as e:
             logging.error("Error parsing Sigma rule at %s: %s", url, e)

--- a/plugins/feeds/public/malpedia.py
+++ b/plugins/feeds/public/malpedia.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import timedelta
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from core import taskmanager
 from core.schemas import entity, task
@@ -44,7 +44,7 @@ class MalpediaMalware(task.FeedTask):
             "external_references": "\n* " + "\n* ".join(refs),
         }
         m.family = entry.get("type", "")
-        m = m.save()
+        m = cast("entity.Malware", m.save())
         m.add_context(context["source"], context)
         attributions = entry.get("attribution", [])
         for attribution in attributions:
@@ -96,7 +96,7 @@ class MalpediaActors(task.FeedTask):
         if synonyms:
             intrusion_set.aliases = synonyms
 
-        intrusion_set = intrusion_set.save()
+        intrusion_set = cast("entity.IntrusionSet", intrusion_set.save())
         intrusion_set.add_context(context["source"], context)
         tags = []
 

--- a/plugins/feeds/public/misp.py
+++ b/plugins/feeds/public/misp.py
@@ -1,6 +1,6 @@
 import logging
 import unicodedata
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import cast
 from urllib.parse import urljoin
 
@@ -106,7 +106,7 @@ class MispFeed(task.FeedTask):
         galaxies_to_context = []
 
         context = {}
-        context["date_added"] = datetime.utcnow()
+        context["date_added"] = datetime.now(timezone.utc)
         context["source"] = instance["name"]
         external_analysis = [
             attr["value"]

--- a/plugins/feeds/public/tranco_top_domains.py
+++ b/plugins/feeds/public/tranco_top_domains.py
@@ -28,6 +28,8 @@ class TrancoTopDomains(task.FeedTask):
             f"Importing {top_domains} Tranco top domains (include subdomains: {include_subdomains})"
         )
         response = self._make_request(endpoint, sort=False)
+        if not response:
+            return
         context = {
             "name": self.name,
         }

--- a/plugins/feeds/public/wiz_cloud_threat_landscape.py
+++ b/plugins/feeds/public/wiz_cloud_threat_landscape.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from datetime import timedelta
-from typing import ClassVar
+from typing import ClassVar, cast
 
 import requests
 
@@ -267,7 +267,10 @@ class WizCloudThreatLandscape(task.FeedTask):
             entity = AttackPattern.find(name=name)
             if not entity:
                 description = self._format_description(properties)
-                entity = AttackPattern(name=name, description=description).save()
+                entity = cast(
+                    "AttackPattern",
+                    AttackPattern(name=name, description=description).save(),
+                )
             kill_chain_phases = set(entity.kill_chain_phases)
             for mitre_technique in properties.get("mitre tactic", []):
                 m = re.search("(.*?(?=\())", mitre_technique)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,8 +112,6 @@ unused-type-ignore-comment = "error"
 include = ["plugins"]
 
 [tool.ty.overrides.rules]
-unresolved-attribute = "warn"       # 32
-deprecated = "warn"                 # 5
 # unused-ignore-comment stays warn: the only instances are the boto3/tldextract
 # import ignores in core (s3.py/utils.py) — used by the dev-only main job but
 # unused in this all-deps plugins job, so they can't be cleanly removed.


### PR DESCRIPTION
**Final plugins ratchet batch.** Drops `unresolved-attribute` and `deprecated`
from the overrides — the `[[tool.ty.overrides]]` block now holds only
`unused-ignore-comment` (the two core boto3/tldextract import ignores, which are
env-dependent: used by the dev-only main job, unused in the all-deps plugins job).

## unresolved-attribute (32)
- **Event handlers** (dockerhub, hostname_extract): `message.event` is an
  `ObjectEvent | LinkEvent | TagEvent` union and only `ObjectEvent` has
  `yeti_object`. Narrow with `assert isinstance(event, ObjectEvent)`, then `cast`
  `yeti_object` to the concrete observable (`ContainerImage` / `Url`).
- **save()/find() return the base** `Observable`/`Entity` through the connector,
  so plugins doing `x = SpecificType(...).save()` then `x.<subclass attr>` cast
  the result: File `.name`/`.size` (abusech, botvrij, hybrid), Malware/IntrusionSet
  `.aliases` (malpedia), AttackPattern `.kill_chain_phases` (wiz), ContainerImage
  `.registry` (dockerhub).
- **`Response | None` guards** for `_make_request(...).content/.text`
  (cisco_umbrella, tranco, lolbas).

## deprecated (5)
`datetime.utcnow()` → `datetime.now(timezone.utc)` (abusech, abuseipdb,
azorult-tracker, misp).

## Verification
- **Plugins job:** 0 errors, 2 warnings (the intentional `unused-ignore-comment`)
- **Main typecheck job:** unchanged (0/0)
- `ruff check .` + `ruff format . --check`: clean
- unittest schemas / apiv2 / core_tests: 186 / 197 / 29, all pass

### Plugins ratchet complete 🎉
114 diagnostics at rollout → 0 real diagnostics. `core`, `yetictl`, and
`plugins` are all now type-checked; only the env-dependent
`unused-ignore-comment` remains at `warn`.
