### PR TITLE
types: split static/runtime *Types unions to fix the soundness gap (F2)

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -1031,7 +1031,20 @@ class ArangoYetiConnector(AbstractYetiConnector):
             self._build_vertices(vertices, path["vertices"])
         if not include_original:
             vertices.pop(self.extended_id, None)
-        return vertices, paths, total or 0
+        # _build_vertices can also populate Tag/User/Group/DFIQ instances (its
+        # type_mapping isn't limited to observable/entity/indicator), which the
+        # declared return type below doesn't enumerate -- a pre-existing gap,
+        # not something this cast newly introduces. Cast to the documented
+        # contract rather than widen it here; auditing every neighbors()
+        # caller for that gap is a separate, its own follow-up.
+        return (
+            cast(
+                "dict[str, observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag]",
+                vertices,
+            ),
+            paths,
+            total or 0,
+        )
 
     def _dedup_edges(self, edges):
         """Deduplicates edges with same STIX ID, keeping the most recent one.

--- a/core/events/message.py
+++ b/core/events/message.py
@@ -37,12 +37,12 @@ class EventType(str, Enum):
 
 
 ObservableObjectTypes = Annotated[
-    "observable.ObservableTypes", Field(discriminator="type")
+    "observable.ObservableTypesRuntime", Field(discriminator="type")
 ]
 TaskObjectTypes = Annotated["task.TaskTypes", Field(discriminator="type")]
-EntityObjectTypes = Annotated["entity.EntityTypes", Field(discriminator="type")]
+EntityObjectTypes = Annotated["entity.EntityTypesRuntime", Field(discriminator="type")]
 IndicatorObjectTypes = Annotated[
-    "indicator.IndicatorTypes", Field(discriminator="type")
+    "indicator.IndicatorTypesRuntime", Field(discriminator="type")
 ]
 UserTypes = Union["user.UserSensitive", "user.User"]
 

--- a/core/schemas/audit.py
+++ b/core/schemas/audit.py
@@ -1,18 +1,10 @@
 import datetime
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import ClassVar, Literal
 
 from pydantic import ConfigDict, computed_field
 
 from core import database_arango
 from core.schemas.model import YetiBaseModel, YetiModel
-
-if TYPE_CHECKING:
-    from core.schemas.dfiq import DFIQTypes
-    from core.schemas.entity import EntityTypes
-    from core.schemas.indicator import IndicatorTypes
-    from core.schemas.observable import ObservableTypes
-
-    AllObjectTypes = EntityTypes | ObservableTypes | IndicatorTypes | DFIQTypes
 
 
 class AuditLog(YetiModel, database_arango.ArangoYetiConnector):
@@ -62,8 +54,8 @@ class TimelineLog(YetiBaseModel, database_arango.ArangoYetiConnector):
 
 def log_timeline(
     username: str,
-    new: "AllObjectTypes",
-    old: "AllObjectTypes" = None,
+    new: "YetiBaseModel",
+    old: "YetiBaseModel | None" = None,
     action: str | None = None,
     details: dict | None = None,
 ):
@@ -90,7 +82,7 @@ def log_timeline(
         ).save()
 
 
-def log_timeline_tags(actor: str, obj: "AllObjectTypes", old_tags: list[str]):
+def log_timeline_tags(actor: str, obj: "YetiBaseModel", old_tags: list[str]):
     new_tags = {tag.name for tag in getattr(obj, "tags", [])}
     details = {
         "removed": set(old_tags) - new_tags,

--- a/core/schemas/entity.py
+++ b/core/schemas/entity.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 from enum import Enum
-from typing import ClassVar, List, Literal, Self, Union
+from typing import TYPE_CHECKING, ClassVar, List, Literal, Self, Union, cast
 
 from pydantic import ConfigDict, Field, computed_field
 
@@ -25,6 +25,14 @@ class Entity(
     _type_filter: ClassVar[str] = ""
     _root_type: Literal["entity"] = "entity"
 
+    if TYPE_CHECKING:
+        # Each concrete entity subclass declares `type` as its own
+        # Literal[EntityType.*] field. Declared here as a property
+        # (type-check time only, so not a required field) so code holding a
+        # base Entity can resolve `.type`.
+        @property
+        def type(self) -> "EntityType": ...
+
     name: str = Field(min_length=1)
     description: str = ""
     created: datetime.datetime = Field(default_factory=now)
@@ -43,7 +51,10 @@ class Entity(
             loader = TYPE_MAPPING[object["type"]]
         else:
             raise ValueError("Attempted to instantiate an undefined entity type.")
-        return loader(**object)
+        # loader is a TYPE_MAPPING value (type[Entity] statically); every
+        # concrete member is one of the enumerated EntityTypes (or a private/
+        # subtype covered by EntityTypesRuntime, not this static union).
+        return cast("EntityTypes", loader(**object))
 
     def save(self, *args, **kwargs) -> "Self":
         self.modified = now()
@@ -66,7 +77,7 @@ def create(*, name: str, type: str, **kwargs) -> "EntityTypes":
     """
     if type not in TYPE_MAPPING:
         raise ValueError(f"{type} is not a valid entity type")
-    return TYPE_MAPPING[type](name=name, **kwargs)
+    return cast("EntityTypes", TYPE_MAPPING[type](name=name, **kwargs))
 
 
 def save(*, name: str, type: str, tags: List[str] | None = None, **kwargs):
@@ -76,8 +87,8 @@ def save(*, name: str, type: str, tags: List[str] | None = None, **kwargs):
     return indicator_obj
 
 
-def find(*, name: str, **kwargs) -> "EntityTypes":
-    return Entity.find(name=name, **kwargs)
+def find(*, name: str, **kwargs) -> "EntityTypes | None":
+    return cast("EntityTypes | None", Entity.find(name=name, **kwargs))
 
 
 # ---------------------------------------------------------------------------
@@ -154,5 +165,10 @@ EntityTypes = Union[
     Tool,
     Vulnerability,
 ]
+# Separate runtime-widened symbol so type checkers keep full checking on the
+# static EntityTypes above (see observable.py for the rationale). Internal code
+# annotates EntityTypes; FastAPI request/response models annotate
+# EntityTypesRuntime.
+EntityTypesRuntime = EntityTypes
 if _private_entity_classes:
-    EntityTypes = Union[(EntityTypes, *_private_entity_classes)]
+    EntityTypesRuntime = Union[(EntityTypes, *_private_entity_classes)]

--- a/core/schemas/indicator.py
+++ b/core/schemas/indicator.py
@@ -12,6 +12,7 @@ from typing import (
     Literal,
     Self,
     Union,
+    cast,
 )
 
 from pydantic import ConfigDict, Field, computed_field
@@ -84,7 +85,11 @@ class Indicator(
             loader = TYPE_MAPPING[object["type"]]
         else:
             raise ValueError("Attempted to instantiate an undefined indicator type.")
-        return loader(**object)
+        # loader is a TYPE_MAPPING value (type[Indicator] statically); every
+        # concrete member is one of the enumerated IndicatorTypes (or a
+        # private/ subtype covered by IndicatorTypesRuntime, not this static
+        # union).
+        return cast("IndicatorTypes", loader(**object))
 
     def save(self, *args, **kwargs) -> "Self":
         self.modified = now()
@@ -123,7 +128,10 @@ def create(
     """
     if type not in TYPE_MAPPING:
         raise ValueError(f"{type} is not a valid indicator type")
-    return TYPE_MAPPING[type](name=name, pattern=pattern, diamond=diamond, **kwargs)
+    return cast(
+        "IndicatorTypes",
+        TYPE_MAPPING[type](name=name, pattern=pattern, diamond=diamond, **kwargs),
+    )
 
 
 def save(
@@ -143,8 +151,8 @@ def save(
     return indicator_obj
 
 
-def find(*, name: str, **kwargs) -> "IndicatorTypes":
-    return Indicator.find(name=name, **kwargs)
+def find(*, name: str, **kwargs) -> "IndicatorTypes | None":
+    return cast("IndicatorTypes | None", Indicator.find(name=name, **kwargs))
 
 
 # ---------------------------------------------------------------------------
@@ -191,5 +199,10 @@ IndicatorTypes = Union[
     Suricata,
     Yara,
 ]
+# Separate runtime-widened symbol so type checkers keep full checking on the
+# static IndicatorTypes above (see observable.py for the rationale). Internal
+# code annotates IndicatorTypes; FastAPI request/response models annotate
+# IndicatorTypesRuntime.
+IndicatorTypesRuntime = IndicatorTypes
 if _private_indicator_classes:
-    IndicatorTypes = Union[(IndicatorTypes, *_private_indicator_classes)]
+    IndicatorTypesRuntime = Union[(IndicatorTypes, *_private_indicator_classes)]

--- a/core/schemas/observable.py
+++ b/core/schemas/observable.py
@@ -64,7 +64,11 @@ class Observable(
     @classmethod
     def load(cls, object: dict) -> "ObservableTypes":  # noqa: F821
         if object["type"] in TYPE_MAPPING:
-            return TYPE_MAPPING[object["type"]](**object)
+            # TYPE_MAPPING is dict[str, type[Observable]] statically, but every
+            # value is actually one of the enumerated ObservableTypes members
+            # (or a private/ subtype covered by ObservableTypesRuntime, not the
+            # static union used here for the common/internal-facing case).
+            return cast("ObservableTypes", TYPE_MAPPING[object["type"]](**object))
         raise ValueError("Attempted to instantiate an undefined observable type.")
 
     def save(self, *args, **kwargs) -> "Self":
@@ -113,7 +117,7 @@ def create(*, value: str, type: str | None = None, **kwargs) -> ObservableTypes:
             raise ValueError(f"Invalid type for observable '{value}'")
     elif type not in TYPE_MAPPING:
         raise ValueError(f"{type} is not a valid observable type")
-    return TYPE_MAPPING[type](value=value, **kwargs)
+    return cast("ObservableTypes", TYPE_MAPPING[type](value=value, **kwargs))
 
 
 def save(
@@ -148,12 +152,12 @@ def save(
     return observable_obj
 
 
-def find(value: str, type: str | None = None) -> ObservableTypes:
+def find(value: str, type: str | None = None) -> ObservableTypes | None:
     if type:
         obs = Observable.find(value=refang(value), type=type)
     else:
         obs = Observable.find(value=refang(value))
-    return obs
+    return cast("ObservableTypes | None", obs)
 
 
 def create_from_text(text: str) -> Tuple[List["ObservableTypes"], List[str]]:
@@ -443,7 +447,13 @@ ObservableTypes = Union[
     UserAgent,
     Wallet,
 ]
-# Deployments may drop extra subtypes into observables/private/; widen the
-# runtime union so API response models serialize them too.
+# Deployments may drop extra subtypes into observables/private/. The runtime
+# union below widens to include them so API request/response models serialize
+# them; it is a SEPARATE symbol from the static ObservableTypes above so type
+# checkers keep full checking on the static alias — a starred re-assignment
+# onto ObservableTypes itself would make it gradual (effectively unchecked)
+# everywhere it is used. Internal code annotates ObservableTypes; FastAPI
+# request/response models annotate ObservableTypesRuntime.
+ObservableTypesRuntime = ObservableTypes
 if _private_observable_classes:
-    ObservableTypes = Union[(ObservableTypes, *_private_observable_classes)]
+    ObservableTypesRuntime = Union[(ObservableTypes, *_private_observable_classes)]

--- a/core/schemas/package.py
+++ b/core/schemas/package.py
@@ -114,7 +114,7 @@ class YetiPackage(BaseModel):
 
         kwargs["value"] = value
         instance = cls(**kwargs)
-        self.observables.append(instance)
+        self.observables.append(cast("ObservableTypes", instance))
         self._objects[value] = instance
         return self
 
@@ -126,7 +126,7 @@ class YetiPackage(BaseModel):
         cls = entity.TYPE_MAPPING[type]
         kwargs["name"] = name
         instance = cls(**kwargs)
-        self.entities.append(instance)
+        self.entities.append(cast("entity.EntityTypes", instance))
         self._objects[name] = instance
         return self
 
@@ -138,7 +138,7 @@ class YetiPackage(BaseModel):
         cls = indicator.TYPE_MAPPING[type]
         kwargs["name"] = name
         instance = cls(**kwargs)
-        self.indicators.append(instance)
+        self.indicators.append(cast("indicator.IndicatorTypes", instance))
         self._objects[name] = instance
         return self
 

--- a/core/web/apiv2/entities.py
+++ b/core/web/apiv2/entities.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from core.schemas import audit, model, rbac, roles
-from core.schemas.entity import Entity, EntityType, EntityTypes
+from core.schemas.entity import Entity, EntityType, EntityTypesRuntime
 from core.schemas.tag import MAX_TAGS_REQUEST
 
 from . import context
@@ -14,14 +14,14 @@ from . import context
 class NewEntityRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    entity: EntityTypes = Field(discriminator="type")
+    entity: EntityTypesRuntime = Field(discriminator="type")
     tags: Annotated[list[str], Field(max_length=MAX_TAGS_REQUEST)] = []
 
 
 class PatchEntityRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    entity: EntityTypes = Field(discriminator="type")
+    entity: EntityTypesRuntime = Field(discriminator="type")
 
 
 class EntitySearchRequest(BaseModel):
@@ -49,7 +49,7 @@ class EntityMultipleGetRequest(BaseModel):
 class EntitySearchResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    entities: list[EntityTypes]
+    entities: list[EntityTypesRuntime]
     total: int
 
 
@@ -74,7 +74,7 @@ router = APIRouter()
 
 @router.post("/")
 @rbac.global_permission(roles.Permission.WRITE)
-def new(httpreq: Request, request: NewEntityRequest) -> EntityTypes:
+def new(httpreq: Request, request: NewEntityRequest) -> EntityTypesRuntime:
     """Creates a new entity in the database."""
     new = request.entity.save()
     rbac.set_acls(new, user=httpreq.state.user)
@@ -86,9 +86,9 @@ def new(httpreq: Request, request: NewEntityRequest) -> EntityTypes:
 
 @router.patch("/{id}")
 @rbac.permission_on_target(roles.Permission.WRITE)
-def patch(httpreq: Request, request: PatchEntityRequest, id: str) -> EntityTypes:
+def patch(httpreq: Request, request: PatchEntityRequest, id: str) -> EntityTypesRuntime:
     """Modifies entity in the database."""
-    db_entity: EntityTypes = Entity.get(id)
+    db_entity = Entity.get(id)
     if not db_entity:
         raise HTTPException(status_code=404, detail=f"Entity {id} not found")
     if db_entity.type != request.entity.type:
@@ -108,7 +108,7 @@ def patch(httpreq: Request, request: PatchEntityRequest, id: str) -> EntityTypes
 @rbac.permission_on_target(roles.Permission.WRITE)
 def add_context(
     httpreq: Request, id: str, request: context.AddContextRequest
-) -> EntityTypes:
+) -> EntityTypesRuntime:
     """Adds context to an Entity."""
     return context.add_context(Entity, httpreq, id, request)
 
@@ -117,7 +117,7 @@ def add_context(
 @rbac.permission_on_target(roles.Permission.WRITE)
 def replace_context(
     httpreq: Request, id: str, request: context.ReplaceContextRequest
-) -> EntityTypes:
+) -> EntityTypesRuntime:
     """Replaces context in an Entity."""
     return context.replace_context(Entity, httpreq, id, request)
 
@@ -126,7 +126,7 @@ def replace_context(
 @rbac.permission_on_target(roles.Permission.WRITE)
 def delete_context(
     httpreq: Request, id, request: context.DeleteContextRequest
-) -> EntityTypes:
+) -> EntityTypesRuntime:
     """Removes context to an Entity."""
     return context.delete_context(Entity, httpreq, id, request)
 
@@ -136,7 +136,7 @@ def get(
     httpreq: Request,
     name: str,
     type: EntityType | None = None,
-) -> EntityTypes:
+) -> EntityTypesRuntime:
     """Gets an entity by name."""
 
     params = {"name": name}
@@ -164,9 +164,9 @@ def get(
 
 @router.get("/{id}")
 @rbac.permission_on_target(roles.Permission.READ)
-def details(httpreq: Request, id: str) -> EntityTypes:
+def details(httpreq: Request, id: str) -> EntityTypesRuntime:
     """Returns details about an observable."""
-    db_entity: EntityTypes = Entity.get(id)
+    db_entity = Entity.get(id)
     if not db_entity:
         raise HTTPException(status_code=404, detail=f"Entity {id} not found")
     db_entity.get_tags()

--- a/core/web/apiv2/graph.py
+++ b/core/web/apiv2/graph.py
@@ -115,9 +115,9 @@ class GraphSearchResponse(BaseModel):
 
     vertices: dict[
         str,
-        observable.ObservableTypes
-        | entity.EntityTypes
-        | indicator.IndicatorTypes
+        observable.ObservableTypesRuntime
+        | entity.EntityTypesRuntime
+        | indicator.IndicatorTypesRuntime
         | tag.Tag
         | dfiq.DFIQTypes,
     ]
@@ -240,10 +240,10 @@ class AnalysisRequest(BaseModel):
 
 
 class AnalysisResponse(BaseModel):
-    entities: list[tuple[graph.Relationship, entity.EntityTypes]]
-    observables: list[tuple[graph.Relationship, observable.ObservableTypes]]
-    known: list[observable.ObservableTypes]
-    matches: list[tuple[str, indicator.IndicatorTypes]]  # IndicatorMatch?
+    entities: list[tuple[graph.Relationship, entity.EntityTypesRuntime]]
+    observables: list[tuple[graph.Relationship, observable.ObservableTypesRuntime]]
+    known: list[observable.ObservableTypesRuntime]
+    matches: list[tuple[str, indicator.IndicatorTypesRuntime]]  # IndicatorMatch?
     unknown: set[str]
 
 

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -11,6 +11,7 @@ from core.schemas.indicator import (
     Indicator,
     IndicatorType,
     IndicatorTypes,
+    IndicatorTypesRuntime,
     Yara,
 )
 from core.schemas.tag import MAX_TAGS_REQUEST
@@ -24,13 +25,13 @@ logger = logging.getLogger(__name__)
 class NewIndicatorRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    indicator: IndicatorTypes = Field(discriminator="type")
+    indicator: IndicatorTypesRuntime = Field(discriminator="type")
 
 
 class PatchIndicatorRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    indicator: IndicatorTypes = Field(discriminator="type")
+    indicator: IndicatorTypesRuntime = Field(discriminator="type")
 
 
 class IndicatorSearchRequest(BaseModel):
@@ -58,7 +59,7 @@ class IndicatorMultipleGetRequest(BaseModel):
 class IndicatorSearchResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    indicators: list[IndicatorTypes]
+    indicators: list[IndicatorTypesRuntime]
     total: int
 
 
@@ -107,7 +108,7 @@ router = APIRouter()
 
 @router.post("/")
 @rbac.global_permission(roles.Permission.WRITE)
-def new(httpreq: Request, request: NewIndicatorRequest) -> IndicatorTypes:
+def new(httpreq: Request, request: NewIndicatorRequest) -> IndicatorTypesRuntime:
     """Creates a new indicator in the database."""
     try:
         new = request.indicator.save()
@@ -123,9 +124,11 @@ def new(httpreq: Request, request: NewIndicatorRequest) -> IndicatorTypes:
 
 @router.patch("/{id}")
 @rbac.permission_on_target(roles.Permission.WRITE)
-def patch(httpreq: Request, request: PatchIndicatorRequest, id: str) -> IndicatorTypes:
+def patch(
+    httpreq: Request, request: PatchIndicatorRequest, id: str
+) -> IndicatorTypesRuntime:
     """Modifies an indicator in the database."""
-    db_indicator: IndicatorTypes = Indicator.get(id)
+    db_indicator = Indicator.get(id)
     if not db_indicator:
         raise HTTPException(status_code=404, detail=f"Indicator {id} not found")
 
@@ -151,7 +154,7 @@ def patch(httpreq: Request, request: PatchIndicatorRequest, id: str) -> Indicato
 @rbac.permission_on_target(roles.Permission.WRITE)
 def add_context(
     httpreq: Request, id: str, request: context.AddContextRequest
-) -> IndicatorTypes:
+) -> IndicatorTypesRuntime:
     """Adds context to an indicator."""
     return context.add_context(Indicator, httpreq, id, request)
 
@@ -160,7 +163,7 @@ def add_context(
 @rbac.permission_on_target(roles.Permission.WRITE)
 def replace_context(
     httpreq: Request, id: str, request: context.ReplaceContextRequest
-) -> IndicatorTypes:
+) -> IndicatorTypesRuntime:
     """Replaces context in an indicator."""
     return context.replace_context(Indicator, httpreq, id, request)
 
@@ -169,7 +172,7 @@ def replace_context(
 @rbac.permission_on_target(roles.Permission.WRITE)
 def delete_context(
     httpreq: Request, id, request: context.DeleteContextRequest
-) -> IndicatorTypes:
+) -> IndicatorTypesRuntime:
     """Removes context to an indicator."""
     return context.delete_context(Indicator, httpreq, id, request)
 
@@ -179,7 +182,7 @@ def get(
     httpreq: Request,
     name: str,
     type: IndicatorType | None = None,
-) -> IndicatorTypes:
+) -> IndicatorTypesRuntime:
     """Gets an indicator by name."""
 
     params = {"name": name}
@@ -209,9 +212,9 @@ def get(
 
 @router.get("/{id}")
 @rbac.permission_on_target(roles.Permission.READ)
-def details(httpreq: Request, id: str) -> IndicatorTypes:
+def details(httpreq: Request, id: str) -> IndicatorTypesRuntime:
     """Returns details about an indicator."""
-    db_indicator: IndicatorTypes = Indicator.get(id)
+    db_indicator = Indicator.get(id)
     if not db_indicator:
         raise HTTPException(status_code=404, detail="indicator not found")
     db_indicator.get_tags()

--- a/core/web/apiv2/observables.py
+++ b/core/web/apiv2/observables.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from core.config.config import yeti_config
 from core.schemas import audit, model, observable, rbac, roles, tag
-from core.schemas.observable import Observable, ObservableType, ObservableTypes
+from core.schemas.observable import Observable, ObservableType, ObservableTypesRuntime
 from core.schemas.rbac import global_permission, permission_on_ids, permission_on_target
 
 from . import context
@@ -42,13 +42,13 @@ class NewObservableRequest(TagRequestMixin):
 class NewExtendedObservableRequest(TagRequestMixin):
     model_config = ConfigDict(extra="forbid")
 
-    observable: ObservableTypes = Field(discriminator="type")
+    observable: ObservableTypesRuntime = Field(discriminator="type")
 
 
 class PatchObservableRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    observable: ObservableTypes = Field(discriminator="type")
+    observable: ObservableTypesRuntime = Field(discriminator="type")
 
 
 class NewBulkObservableAddRequest(BaseModel):
@@ -60,7 +60,7 @@ class NewBulkObservableAddRequest(BaseModel):
 class BulkObservableAddResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    added: list[ObservableTypes] = []
+    added: list[ObservableTypesRuntime] = []
     failed: list[str] = []
 
 
@@ -92,7 +92,7 @@ class ObservableSearchRequest(BaseModel):
 class ObservableSearchResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    observables: list[ObservableTypes]
+    observables: list[ObservableTypesRuntime]
     total: int
 
 
@@ -116,7 +116,7 @@ router = APIRouter()
 
 @router.post("/")
 @global_permission(roles.Permission.WRITE)
-def new(httpreq: Request, request: NewObservableRequest) -> ObservableTypes:
+def new(httpreq: Request, request: NewObservableRequest) -> ObservableTypesRuntime:
     """Creates a new observable in the database.
 
     Raises:
@@ -144,7 +144,7 @@ def new(httpreq: Request, request: NewObservableRequest) -> ObservableTypes:
 @global_permission(roles.Permission.WRITE)
 def new_extended(
     httpreq: Request, request: NewExtendedObservableRequest
-) -> ObservableTypes:
+) -> ObservableTypesRuntime:
     """Creates a new observable in the database with extended properties.
 
     Raises:
@@ -171,7 +171,9 @@ def new_extended(
 
 @router.patch("/{id}")
 @permission_on_target(roles.Permission.WRITE)
-def patch(httpreq: Request, request: PatchObservableRequest, id) -> ObservableTypes:
+def patch(
+    httpreq: Request, request: PatchObservableRequest, id
+) -> ObservableTypesRuntime:
     """Modifies observable in the database."""
     db_observable = Observable.get(id)
     if not db_observable:
@@ -223,7 +225,7 @@ def get(
     httpreq: Request,
     value: str,
     type: ObservableType | None = None,
-) -> ObservableTypes:
+) -> ObservableTypesRuntime:
     """Gets an observable by value."""
 
     params = {"value": value}
@@ -252,7 +254,7 @@ def get(
 
 @router.get("/{id}")
 @permission_on_target(roles.Permission.READ)
-def details(httpreq: Request, id: str) -> ObservableTypes:
+def details(httpreq: Request, id: str) -> ObservableTypesRuntime:
     """Returns details about an observable."""
     observable_obj = Observable.get(id)
 
@@ -267,7 +269,7 @@ def details(httpreq: Request, id: str) -> ObservableTypes:
 @permission_on_target(roles.Permission.WRITE)
 def add_context(
     httpreq: Request, id: str, request: context.AddContextRequest
-) -> ObservableTypes:
+) -> ObservableTypesRuntime:
     """Adds context to an observable."""
     return context.add_context(Observable, httpreq, id, request)
 
@@ -276,7 +278,7 @@ def add_context(
 @permission_on_target(roles.Permission.WRITE)
 def replace_context(
     httpreq: Request, id: str, request: context.ReplaceContextRequest
-) -> ObservableTypes:
+) -> ObservableTypesRuntime:
     """Replaces context in an observable."""
     return context.replace_context(Observable, httpreq, id, request)
 
@@ -285,7 +287,7 @@ def replace_context(
 @permission_on_target(roles.Permission.WRITE)
 def delete_context(
     httpreq: Request, id, request: context.DeleteContextRequest
-) -> ObservableTypes:
+) -> ObservableTypesRuntime:
     """Removes context to an observable."""
     return context.delete_context(Observable, httpreq, id, request)
 
@@ -310,7 +312,7 @@ def search(
 
 @router.post("/add_text", deprecated=True)
 @global_permission(roles.Permission.WRITE)
-def add_text(httpreq: Request, request: AddTextRequest) -> ObservableTypes:
+def add_text(httpreq: Request, request: AddTextRequest) -> ObservableTypesRuntime:
     """Adds and returns an observable for a given string, attempting to guess
     its type."""
     try:


### PR DESCRIPTION
`ObservableTypes`/`EntityTypes`/`IndicatorTypes` were widened at runtime with a starred re-assignment (`Union[(XTypes, *private_classes)]`) to include deployment-supplied `private/` subtypes. ty can't evaluate that re-assignment, so it marked the whole alias **gradual — effectively unchecked** — everywhere it was used across ~80 call sites. Concrete symptom: `observable.find()` returned `ObservableTypes` but actually could return `None`, and nothing caught it.

### Fix
Each alias is now a pure static `Union`, never reassigned. The runtime widening moves to a new sibling symbol (`ObservableTypesRuntime`, `EntityTypesRuntime`, `IndicatorTypesRuntime`) — identical to the static alias when no private types exist (verified: OpenAPI spec is **byte-identical, md5-confirmed**) and widened only when they do. Internal code keeps the static alias; FastAPI request/response models **and** the event-message payloads (`core/events/message.py` — a second, non-FastAPI pydantic validation boundary that would otherwise have silently stopped accepting private types) use the Runtime one.

### Bugs this surfaced (fixed here)
- `observable`/`entity`/`indicator` module-level `find()` were missing `| None` on the return type — the exact bug class the ty ratchet's own review (F2) flagged as a risk. Verified their only callers are truthy-only checks, so no ripple.
- `audit.log_timeline()` / `log_timeline_tags()` were typed against the full 4-schema union but only ever touch `YetiBaseModel`-level surface (`model_dump`, `_TIMELINE_IGNORE_FIELDS`, `extended_id`) — retyped to that instead of casting all ~15 call sites. Also fixed `old: AllObjectTypes = None` (no `| None`), a latent bad-default invisible while the union was gradual.
- `Entity` never got the `TYPE_CHECKING`-declared `type` property that `Observable`/`Indicator`/`Task`/`DFIQBase` already have (an established codebase pattern) — it had been papered over by an incorrect local `db_entity: EntityTypes = Entity.get(id)` annotation in two apiv2 endpoints. Added the property, dropped the wrong annotations.
- `database_arango.py`'s `neighbors()` declared return type doesn't cover `Tag`/`User`/`Group`/`DFIQ`, which `_build_vertices` can also produce — a **pre-existing gap**, now documented and cast to the existing (incomplete) contract rather than widened, since widening would ripple into 5 untouched callers I haven't audited. Left as a follow-up, not expanded here.

Producer functions (`load`/`create`) that build via `TYPE_MAPPING` keep a documented `cast()` to the static union — `TYPE_MAPPING` is `dict[str, type[Base]]`, so ty can't see that every value is actually a concrete union member.

### Verification
- Both ty jobs: 0 errors, only the 2 known env-dependent `unused-ignore-comment` warnings
- `ruff check` + `ruff format --check`: clean
- `tests/schemas` 186/186, `tests/core_tests` 29/29, `tests/apiv2` 195/197 (2 pre-existing failures in `tasks.py`, confirmed via a throwaway git worktree to already fail identically on `main` before this change)
- **OpenAPI byte-diff**: generated the spec from this branch and from a clean worktree at the same base commit (same runtime env, same DB/redis network) — **md5-identical**

From the ty review findings (F2) / backend architecture review sequencing #4b.
