### PR TITLE
fix: widen GraphSearchResponse to accept ACL-graph vertices/edges (500 fix)

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -23,6 +23,12 @@ from typing import (
 
 if TYPE_CHECKING:
     from core.schemas import dfiq, entity, indicator, observable, rbac, roles, tag, user
+
+    # `neighbors()`'s own `user` parameter shadows the module inside its body
+    # (though not in its signature annotations, which resolve against this
+    # module's globals) -- this alias lets a body-position forward-ref string
+    # (the return-value cast) still reach the schema module.
+    from core.schemas import user as user_schema
     from core.schemas.graph import (
         GraphFilter,
         Relationship,
@@ -901,7 +907,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
     ) -> tuple[
         dict[
             str,
-            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag",
+            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag | dfiq.DFIQTypes | user.User | rbac.Group",
         ],
         List[List["RelationshipTypes"]],
         int,
@@ -1031,15 +1037,13 @@ class ArangoYetiConnector(AbstractYetiConnector):
             self._build_vertices(vertices, path["vertices"])
         if not include_original:
             vertices.pop(self.extended_id, None)
-        # _build_vertices can also populate Tag/User/Group/DFIQ instances (its
-        # type_mapping isn't limited to observable/entity/indicator), which the
-        # declared return type below doesn't enumerate -- a pre-existing gap,
-        # not something this cast newly introduces. Cast to the documented
-        # contract rather than widen it here; auditing every neighbors()
-        # caller for that gap is a separate, its own follow-up.
+        # `vertices` is typed as the base ArangoYetiConnector locally (matching
+        # any connector-mixed schema), but every value _build_vertices actually
+        # constructs is one of the members below (Tag/User/Group/DFIQ included
+        # -- its type_mapping isn't limited to observable/entity/indicator).
         return (
             cast(
-                "dict[str, observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag]",
+                "dict[str, observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag | dfiq.DFIQTypes | user_schema.User | rbac.Group]",
                 vertices,
             ),
             paths,

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, List, Type, TypeVar
 
 if TYPE_CHECKING:
-    from core.schemas import entity, graph, indicator, observable, tag, user
+    from core.schemas import dfiq, entity, graph, indicator, observable, rbac, tag, user
 
 TYetiObject = TypeVar("TYetiObject")
 
@@ -112,7 +112,7 @@ class AbstractYetiConnector(ABC):
     ) -> tuple[
         dict[
             str,
-            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag",
+            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag | dfiq.DFIQTypes | user.User | rbac.Group",
         ],
         List[List["graph.RelationshipTypes"]],
         int,

--- a/core/web/apiv2/graph.py
+++ b/core/web/apiv2/graph.py
@@ -6,7 +6,17 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
 from pydantic.functional_validators import field_validator
 
-from core.schemas import dfiq, entity, graph, indicator, observable, rbac, roles, tag
+from core.schemas import (
+    dfiq,
+    entity,
+    graph,
+    indicator,
+    observable,
+    rbac,
+    roles,
+    tag,
+    user,
+)
 from core.schemas.graph import GraphFilter
 from core.schemas.tag import MAX_TAGS_REQUEST
 
@@ -119,9 +129,11 @@ class GraphSearchResponse(BaseModel):
         | entity.EntityTypesRuntime
         | indicator.IndicatorTypesRuntime
         | tag.Tag
-        | dfiq.DFIQTypes,
+        | dfiq.DFIQTypes
+        | user.User
+        | rbac.Group,
     ]
-    paths: list[list[graph.Relationship]]
+    paths: list[list[graph.RelationshipTypes]]
     total: int
 
 

--- a/tests/apiv2/graph.py
+++ b/tests/apiv2/graph.py
@@ -6,6 +6,7 @@ import unittest
 from fastapi.testclient import TestClient
 
 from core import database_arango
+from core.schemas import rbac, roles
 from core.schemas.entity import AttackPattern, Malware, ThreatActor
 from core.schemas.graph import Relationship
 from core.schemas.indicator import DiamondModel, ForensicArtifact, Query, Regex
@@ -84,6 +85,36 @@ class SimpleGraphTest(unittest.TestCase):
         data = response.json()
         self.assertEqual(response.status_code, 400, data)
         self.assertIn("Cannot traverse graph 'tagged'", data["detail"])
+
+    def test_get_neighbors_acls_graph(self):
+        # Traversing the "acls" graph can surface Group/RoleRelationship
+        # vertices/edges that GraphSearchResponse previously didn't declare,
+        # which raised a pydantic ValidationError (500) instead of a response.
+        group = rbac.Group(name="acls-graph-test-group").save()
+        group.link_to_acl(self.observable1, roles.Role.OWNER)
+
+        response = client.post(
+            "/api/v2/graph/search",
+            json={
+                "source": self.observable1.extended_id,
+                "hops": 1,
+                "graph": "acls",
+                "direction": "inbound",
+                "include_original": False,
+            },
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(len(data["vertices"]), 1)
+        vertex = data["vertices"][group.extended_id]
+        self.assertEqual(vertex["name"], "acls-graph-test-group")
+        self.assertEqual(vertex["root_type"], "rbacgroup")
+
+        edges = data["paths"]
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0][0]["source"], group.extended_id)
+        self.assertEqual(edges[0][0]["target"], self.observable1.extended_id)
+        self.assertEqual(edges[0][0]["root_type"], "acl")
 
     def test_get_neighbors_bad_hops(self):
         response = client.post(


### PR DESCRIPTION
`POST /api/v2/graph/search` with `graph="acls"` raises an unhandled `pydantic.ValidationError` (500) for **any authenticated user, on essentially any object**. `GraphSearchRequest.graph` is a plain `str` (`TRAVERSABLE_GRAPHS` accepts both `"links"` and `"acls"`), and traversing the ACL graph returns `rbac.Group`/`user.User` vertices and `RoleRelationship` edges (via `ArangoYetiConnector._build_vertices`/`_build_edges`) — but `GraphSearchResponse`'s declared types never included them.

**Reproduced end-to-end before this fix**: a group-ACL'd observable queried via `graph="acls"` fails response construction with 55 validation errors (one per union member that isn't `Group`). Since every object gets a default ACL on creation and the `/search` route has no extra RBAC gate beyond being logged in, this isn't an edge case.

### Fix
- Widen `GraphSearchResponse.vertices` to add `user.User | rbac.Group`.
- Widen `GraphSearchResponse.paths` from `list[list[Relationship]]` to `list[list[graph.RelationshipTypes]]` (`Relationship | RoleRelationship` — already the correct type on the underlying `neighbors()` call; only this response model was narrower than what it wraps).
- Correct `ArangoYetiConnector.neighbors()`'s own declared return type and the abstract stub in `interfaces.py` to the same complete union (they were also missing `DFIQTypes`, since `_build_vertices`'s `type_mapping` covers `dfiq.TYPE_MAPPING` too) — previously documented as a known gap and left as a cast to the existing (incomplete) contract; fixed for real now that the live bug is confirmed.
- Adds a regression test (`tests/apiv2/graph.py::test_get_neighbors_acls_graph`) that creates a group-ACL'd observable and asserts `/api/v2/graph/search` with `graph="acls"` returns 200 with the group vertex and ACL edge serialized. Confirmed it **fails with the original `pydantic.ValidationError` on pre-fix code** and passes after.

### OpenAPI — deliberate, additive-only change
Unlike prior PRs in this batch, this one *does* change the schema: `GraphSearchResponse.vertices` gains `User`/`Group` members, `.paths` gains a `RoleRelationship` alternative. Diffed the generated spec against a clean `origin/main` worktree — **zero components added or removed**, only two existing `$ref`s (`User`, `Group-Output`, `RoleRelationship-Output`) newly referenced at the two sites; 18-line diff total.

### Verification
- Both ty jobs: 0 errors
- `ruff check` + `ruff format --check`: clean
- `tests/schemas` 186/186, `tests/core_tests` 29/29, `tests/apiv2` 196/198 (2 pre-existing failures in `tasks.py`, confirmed unrelated to this or prior PRs in the batch)

This is PR 1 of 2 for the `neighbors()` finding from the backend architecture review — the runtime fix. PR 2 (static-typing fix for why ty never caught this) follows, stacked on this branch.
