### PR TITLE
types: sync neighbors() mirror stub so ty stops seeing Any (F4 follow-up)

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -23,6 +23,12 @@ from typing import (
 
 if TYPE_CHECKING:
     from core.schemas import dfiq, entity, indicator, observable, rbac, roles, tag, user
+
+    # `neighbors()`'s own `user` parameter shadows the module inside its body
+    # (though not in its signature annotations, which resolve against this
+    # module's globals) -- this alias lets a body-position forward-ref string
+    # (the return-value cast) still reach the schema module.
+    from core.schemas import user as user_schema
     from core.schemas.graph import (
         GraphFilter,
         Relationship,
@@ -901,7 +907,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
     ) -> tuple[
         dict[
             str,
-            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag",
+            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag | dfiq.DFIQTypes | user.User | rbac.Group",
         ],
         List[List["RelationshipTypes"]],
         int,
@@ -1031,15 +1037,13 @@ class ArangoYetiConnector(AbstractYetiConnector):
             self._build_vertices(vertices, path["vertices"])
         if not include_original:
             vertices.pop(self.extended_id, None)
-        # _build_vertices can also populate Tag/User/Group/DFIQ instances (its
-        # type_mapping isn't limited to observable/entity/indicator), which the
-        # declared return type below doesn't enumerate -- a pre-existing gap,
-        # not something this cast newly introduces. Cast to the documented
-        # contract rather than widen it here; auditing every neighbors()
-        # caller for that gap is a separate, its own follow-up.
+        # `vertices` is typed as the base ArangoYetiConnector locally (matching
+        # any connector-mixed schema), but every value _build_vertices actually
+        # constructs is one of the members below (Tag/User/Group/DFIQ included
+        # -- its type_mapping isn't limited to observable/entity/indicator).
         return (
             cast(
-                "dict[str, observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag]",
+                "dict[str, observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag | dfiq.DFIQTypes | user_schema.User | rbac.Group]",
                 vertices,
             ),
             paths,

--- a/core/interfaces.py
+++ b/core/interfaces.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, List, Type, TypeVar
 
 if TYPE_CHECKING:
-    from core.schemas import entity, graph, indicator, observable, tag, user
+    from core.schemas import dfiq, entity, graph, indicator, observable, rbac, tag, user
 
 TYetiObject = TypeVar("TYetiObject")
 
@@ -112,7 +112,7 @@ class AbstractYetiConnector(ABC):
     ) -> tuple[
         dict[
             str,
-            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag",
+            "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | tag.Tag | dfiq.DFIQTypes | user.User | rbac.Group",
         ],
         List[List["graph.RelationshipTypes"]],
         int,

--- a/core/schemas/dfiq.py
+++ b/core/schemas/dfiq.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field, computed_field
 from core import database_arango
 from core.helpers import now
 from core.schemas import audit, indicator, rbac
+from core.schemas.graph import Relationship
 from core.schemas.model import YetiAclModel, YetiModel
 
 LATEST_SUPPORTED_DFIQ_VERSION = "1.1.0"
@@ -304,6 +305,11 @@ class DFIQBase(YetiModel, YetiAclModel, database_arango.ArangoYetiConnector):
         vertices, relationships, total = self.neighbors()
         for edge in relationships:
             for rel in edge:
+                # This walks the default "links" graph, so edges are always
+                # Relationship, never the acls graph's RoleRelationship -- but
+                # neighbors() is typed for any graph, so narrow explicitly.
+                if not isinstance(rel, Relationship):
+                    continue
                 if rel.type not in {t.value for t in DFIQType}:
                     continue
                 if rel.target != self.extended_id:

--- a/core/schemas/indicators/yara.py
+++ b/core/schemas/indicators/yara.py
@@ -171,7 +171,13 @@ class Yara(indicator.Indicator):
 
         for edge in relationships:
             for rel in edge:
-                if nodes[rel.target].name not in self.dependencies:
+                # "depends" links only ever connect Yara indicators to other
+                # Yara indicators, so the target vertex is always a Yara --
+                # but neighbors() is typed for any graph, hence the narrow.
+                target = nodes[rel.target]
+                if not isinstance(target, Yara):
+                    continue
+                if target.name not in self.dependencies:
                     rel.delete()
 
         for dependency in self.dependencies:

--- a/core/schemas/model.py
+++ b/core/schemas/model.py
@@ -11,6 +11,8 @@ from core.events.producer import producer
 from core.schemas.graph import RoleRelationship
 
 if TYPE_CHECKING:
+    from core.schemas import dfiq, entity, indicator, observable, rbac, user
+    from core.schemas.graph import RelationshipTypes
     from core.schemas.tag import Tag
 
 
@@ -39,7 +41,16 @@ class YetiBaseModel(BaseModel):
 
         def delete(self, *args: Any, **kwargs: Any) -> None: ...
 
-        def neighbors(self, *args: Any, **kwargs: Any) -> Any: ...
+        def neighbors(
+            self, *args: Any, **kwargs: Any
+        ) -> tuple[
+            dict[
+                str,
+                "observable.ObservableTypes | entity.EntityTypes | indicator.IndicatorTypes | Tag | dfiq.DFIQTypes | user.User | rbac.Group",
+            ],
+            list[list["RelationshipTypes"]],
+            int,
+        ]: ...
 
         @property
         def extended_id(self) -> str: ...
@@ -122,17 +133,22 @@ class YetiAclModel(YetiBaseModel):
         Args:
             user: The user to check permissions for.
         """
+        # Avoid circular dependency (rbac/user both import from this module).
+        from core.schemas import rbac, user
+
         vertices, paths, total = self.neighbors(
             graph="acls", direction="inbound", max_hops=1 if direct else 2
         )
         for path in paths:
             source = path[-1].source  # inbound, so source is last.
             for edge in path:
+                if not isinstance(edge, RoleRelationship):
+                    continue
                 if edge.target == self.extended_id:
                     identity = vertices[source]
-                    if identity.root_type == "rbacgroup":
+                    if isinstance(identity, rbac.Group):
                         self._acls[identity.name] = edge
-                    if identity.root_type == "user":
+                    if isinstance(identity, user.User):
                         self._acls[identity.username] = edge
 
 

--- a/core/schemas/user.py
+++ b/core/schemas/user.py
@@ -140,9 +140,11 @@ class User(YetiModel, database_arango.ArangoYetiConnector):
             for edge in path:
                 assert isinstance(edge, graph.RoleRelationship)
                 group = groups[edge.target]
+                if not isinstance(group, rbac.Group):
+                    continue
                 group._acls[self.username] = edge
                 all_groups[group.name] = group
-        return list(groups.values())
+        return [g for g in groups.values() if isinstance(g, rbac.Group)]
 
 
 class UserSensitive(User):

--- a/core/web/apiv2/graph.py
+++ b/core/web/apiv2/graph.py
@@ -6,7 +6,17 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
 from pydantic.functional_validators import field_validator
 
-from core.schemas import dfiq, entity, graph, indicator, observable, rbac, roles, tag
+from core.schemas import (
+    dfiq,
+    entity,
+    graph,
+    indicator,
+    observable,
+    rbac,
+    roles,
+    tag,
+    user,
+)
 from core.schemas.graph import GraphFilter
 from core.schemas.tag import MAX_TAGS_REQUEST
 
@@ -119,9 +129,11 @@ class GraphSearchResponse(BaseModel):
         | entity.EntityTypesRuntime
         | indicator.IndicatorTypesRuntime
         | tag.Tag
-        | dfiq.DFIQTypes,
+        | dfiq.DFIQTypes
+        | user.User
+        | rbac.Group,
     ]
-    paths: list[list[graph.Relationship]]
+    paths: list[list[graph.RelationshipTypes]]
     total: int
 
 

--- a/tests/apiv2/graph.py
+++ b/tests/apiv2/graph.py
@@ -6,6 +6,7 @@ import unittest
 from fastapi.testclient import TestClient
 
 from core import database_arango
+from core.schemas import rbac, roles
 from core.schemas.entity import AttackPattern, Malware, ThreatActor
 from core.schemas.graph import Relationship
 from core.schemas.indicator import DiamondModel, ForensicArtifact, Query, Regex
@@ -84,6 +85,36 @@ class SimpleGraphTest(unittest.TestCase):
         data = response.json()
         self.assertEqual(response.status_code, 400, data)
         self.assertIn("Cannot traverse graph 'tagged'", data["detail"])
+
+    def test_get_neighbors_acls_graph(self):
+        # Traversing the "acls" graph can surface Group/RoleRelationship
+        # vertices/edges that GraphSearchResponse previously didn't declare,
+        # which raised a pydantic ValidationError (500) instead of a response.
+        group = rbac.Group(name="acls-graph-test-group").save()
+        group.link_to_acl(self.observable1, roles.Role.OWNER)
+
+        response = client.post(
+            "/api/v2/graph/search",
+            json={
+                "source": self.observable1.extended_id,
+                "hops": 1,
+                "graph": "acls",
+                "direction": "inbound",
+                "include_original": False,
+            },
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(len(data["vertices"]), 1)
+        vertex = data["vertices"][group.extended_id]
+        self.assertEqual(vertex["name"], "acls-graph-test-group")
+        self.assertEqual(vertex["root_type"], "rbacgroup")
+
+        edges = data["paths"]
+        self.assertEqual(len(edges), 1)
+        self.assertEqual(edges[0][0]["source"], group.extended_id)
+        self.assertEqual(edges[0][0]["target"], self.observable1.extended_id)
+        self.assertEqual(edges[0][0]["root_type"], "acl")
 
     def test_get_neighbors_bad_hops(self):
         response = client.post(


### PR DESCRIPTION
**Stacked on #1323** — this needs its corrected `neighbors()` return type to mirror, so its base branch is that PR's branch, not `main`. Merge #1323 first; this one's diff will show cleanly against `main` afterward.

### The gap
Investigating why ty never caught the #1323 bug, I found that **every** `<schema-instance>.neighbors(...)` call resolves to `Any` under ty — not to `ArangoYetiConnector.neighbors()`'s precise return type. Confirmed via `reveal_type` probes on `Yara`, `DFIQBase`, `YetiAclModel`, `User`, and a plain `Observable` parameter: all five gave `Any`.

**Cause:** `YetiBaseModel`'s `TYPE_CHECKING` mirror block (documented as F4 in the earlier ty-ratchet review) declares `neighbors(self, *args: Any, **kwargs: Any) -> Any`, and `YetiBaseModel` precedes `ArangoYetiConnector` in every concrete schema class's MRO — so ty resolves `.neighbors` to that generic stub first. The real, precise signature was dead type information for every realistic call site, which is exactly why #1323's gap (missing `User`/`Group`/`DFIQTypes` in the declared return) was never flagged despite being wrong for years.

### Fix
Give the mirror stub the same precise return type as the real implementation. Re-ran the same five `reveal_type` probes — all now show the full union instead of `Any`.

### Fallout (expected, fixed here)
Making the type visible surfaced four real, previously-masked narrowing gaps — places where code relied on a runtime invariant ty couldn't check before:
- `dfiq.py`'s parent-link cleanup accessed `.type` on graph edges without narrowing away `RoleRelationship` (which has no `.type`) — the loop only walks the default "links" graph, so added an `isinstance(rel, Relationship)` guard.
- `yara.py`'s dependency-graph cleanup accessed `.name` on an unnarrowed vertex — "depends" links only ever connect `Yara` to `Yara`, so narrowed with `isinstance(target, Yara)`.
- `model.py`'s `get_acls()` assigned into `self._acls: dict[str, RoleRelationship]` from an unnarrowed acls-graph walk, and read `.name`/`.username` off the unnarrowed identity vertex — added `isinstance` guards for both the edge and the vertex (`Group` vs `User`).
- `user.py`'s `get_groups()` had the same vertex-narrowing gap — added `isinstance(group, rbac.Group)` before touching `group._acls`/`group.name`, and the return statement now filters to `Group` instances instead of implicitly trusting the (unchecked) `target_types` runtime filter.

`model.py`'s fix needs `rbac`/`user` imported inside the method body rather than at module level (matches this file's existing pattern — `tag()` does the same) since both modules import from `core.schemas.model`, so a module-level import would cycle.

### Scope note
This closes the specific `neighbors()` MRO-shadowing gap. The deeper, structural fix (a `PersistedModel` base class so there's one real method instead of a stub + a shadowed implementation) remains a separate, bigger architecture item, tracked in `plans/backend-architecture-review.md` — not needed to close this gap.

### Verification
- Both ty jobs: 0 errors
- `ruff check` + `ruff format --check`: clean
- `tests/schemas` 186/186, `tests/core_tests` 29/29, `tests/apiv2` 196/198 (2 pre-existing failures in `tasks.py`, unrelated)
- `tests/schemas/rbac.py` 10/10, `tests/apiv2/rbac.py` 9/9 — exercise `get_acls`/`get_groups` via direct and group-mediated permission resolution
- #1323's regression test still passes on top of this
- Annotation/narrowing-only: OpenAPI spec is byte-identical to #1323's (already-fixed) spec
