### PR TITLE
test: add a structural contract test for GraphSearchResponse declared types

### DIFF
--- a/tests/apiv2/graph.py
+++ b/tests/apiv2/graph.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import time
+import typing
 import unittest
 
 from fastapi.testclient import TestClient
@@ -8,11 +9,12 @@ from fastapi.testclient import TestClient
 from core import database_arango
 from core.schemas import rbac, roles
 from core.schemas.entity import AttackPattern, Malware, ThreatActor
-from core.schemas.graph import Relationship
+from core.schemas.graph import Relationship, RoleRelationship
 from core.schemas.indicator import DiamondModel, ForensicArtifact, Query, Regex
 from core.schemas.observables import hostname, ipv4, url
 from core.schemas.user import UserSensitive
 from core.web import webapp
+from core.web.apiv2.graph import GraphSearchResponse
 
 client = TestClient(webapp.app)
 
@@ -653,6 +655,84 @@ supported_os:
                 "/var/spool/cron/**",
             },
         )
+
+
+class GraphSearchResponseContractTest(unittest.TestCase):
+    """Guards GraphSearchResponse's declared vertex/edge types against
+    everything ArangoYetiConnector._build_vertices/_build_edges can actually
+    construct.
+
+    This is the systemic version of the bug fixed in #1323: Group/User
+    vertices (and RoleRelationship edges) were constructible by the acls-graph
+    traversal but missing from GraphSearchResponse's declared union, which
+    only surfaced as a live 500 once someone queried a graph+data combination
+    that actually produced one. Comparing the two registries structurally
+    catches the same class of gap immediately -- no DB, no seeded graph data,
+    no need to guess which graph+data combination would expose it -- and
+    fails just as fast if a future TYPE_MAPPING addition (or a new vertex kind
+    mixed into _build_vertices) isn't reflected here.
+    """
+
+    def _flatten(self, tp) -> set[type]:
+        origin = typing.get_origin(tp)
+        if origin is typing.Annotated:
+            return self._flatten(typing.get_args(tp)[0])
+        if origin is None:
+            return {tp}
+        members: set[type] = set()
+        for arg in typing.get_args(tp):
+            if arg is type(None):
+                continue
+            members |= self._flatten(arg)
+        return members
+
+    def test_vertices_union_covers_build_vertices_output(self):
+        from core.schemas import dfiq, entity, indicator, observable, rbac, tag, user
+
+        # The base classes are also registered under generic TYPE_MAPPING
+        # aliases ("observable", "entity", ...) for internal lookup fallbacks;
+        # no real persisted document ever carries that literal type value, so
+        # they're excluded here rather than added to the response union.
+        registry_aliases = {
+            observable.Observable,
+            entity.Entity,
+            indicator.Indicator,
+            dfiq.DFIQBase,
+        }
+        constructible = {tag.Tag, user.User, rbac.Group}
+        constructible |= set(observable.TYPE_MAPPING.values())
+        constructible |= set(entity.TYPE_MAPPING.values())
+        constructible |= set(indicator.TYPE_MAPPING.values())
+        constructible |= set(dfiq.TYPE_MAPPING.values())
+        constructible -= registry_aliases
+
+        value_type = typing.get_args(
+            GraphSearchResponse.model_fields["vertices"].annotation
+        )[1]
+        declared = self._flatten(value_type)
+
+        for cls in sorted(constructible, key=lambda c: c.__name__):
+            with self.subTest(cls=cls.__name__):
+                self.assertTrue(
+                    any(issubclass(cls, member) for member in declared),
+                    f"{cls.__name__} can be constructed by _build_vertices "
+                    "but is missing from GraphSearchResponse.vertices' "
+                    "declared type",
+                )
+
+    def test_paths_union_covers_build_edges_output(self):
+        inner_list = typing.get_args(
+            GraphSearchResponse.model_fields["paths"].annotation
+        )[0]
+        declared = self._flatten(typing.get_args(inner_list)[0])
+
+        for cls in (Relationship, RoleRelationship):
+            with self.subTest(cls=cls.__name__):
+                self.assertTrue(
+                    any(issubclass(cls, member) for member in declared),
+                    f"{cls.__name__} can be constructed by _build_edges but "
+                    "is missing from GraphSearchResponse.paths' declared type",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Answering "what test could've caught the #1323 500 sooner": two different things, both worth having.

**The direct gap** was a straightforward enumeration miss: `TRAVERSABLE_GRAPHS` has exactly 2 valid values (`"links"`, `"acls"`), and the test suite exercised `"links"` (~13 tests) plus one negative case for an invalid graph name — but never `"acls"`, the other real value. #1323's regression test already closes that specific instance.

**This PR adds a second, complementary test** that doesn't depend on enumerating graph names or seeding matching data at all: it compares `GraphSearchResponse`'s declared `vertices`/`paths` union types directly against everything `ArangoYetiConnector._build_vertices`/`_build_edges` can actually construct (every observable/entity/indicator/dfiq `TYPE_MAPPING` value, plus `Tag`/`User`/`Group`, plus `Relationship`/`RoleRelationship`), via `typing` introspection on the pydantic field annotations. No DB, no API call, sub-millisecond.

### Verified both directions
Reverted `core/web/apiv2/graph.py` to its pre-#1323 state (via `git show <pre-fix-sha>:path`, never a directory checkout) and confirmed this test fails with **exactly** the three missing types that caused the live bug:
```
AssertionError: Group can be constructed by _build_vertices but is missing from GraphSearchResponse.vertices' declared type
AssertionError: User can be constructed by _build_vertices but is missing from GraphSearchResponse.vertices' declared type
AssertionError: RoleRelationship can be constructed by _build_edges but is missing from GraphSearchResponse.paths' declared type
```
Then restored the real fix and confirmed it passes. This would have caught the original gap without anyone needing to think to test `"acls"` specifically, and will catch the same class of gap for any future addition to `_build_vertices`/`_build_edges` that isn't mirrored in the response model.

The four `TYPE_MAPPING` values excluded from the check (`Observable`/`Entity`/`Indicator`/`DFIQBase`) are registry-fallback aliases under generic keys (`"observable"`, `"entity"`, ...), not real persisted vertex types — documented inline.

### Verification
- Both ty jobs: 0 errors
- `ruff check` + `ruff format --check`: clean
- `tests/apiv2/graph.py` 26/26 (full file), `tests/apiv2` 198/200 (2 pre-existing `tasks.py` failures, unrelated)
