### PR TITLE
fix: stop deletion from spuriously creating an empty "tags" graph

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -41,7 +41,7 @@ import requests
 from arango import ArangoClient
 from arango.cursor import Cursor
 from arango.database import StandardDatabase
-from arango.exceptions import DocumentInsertError
+from arango.exceptions import DocumentInsertError, ViewDeleteError, ViewGetError
 from arango.job import AsyncJob
 from arango.result import Result
 
@@ -379,7 +379,7 @@ class ArangoDatabase:
                 else:
                     self.db.view(f"{view_target}_view")
                     continue
-            except Exception:
+            except (ViewGetError, ViewDeleteError):
                 pass
 
             link_definitions[view_target] = {
@@ -408,7 +408,7 @@ class ArangoDatabase:
             else:
                 self.db.view("all_objects_view")
                 return
-        except Exception:
+        except (ViewGetError, ViewDeleteError):
             pass
 
         for target in link_definitions:
@@ -1428,7 +1428,13 @@ class ArangoYetiConnector(AbstractYetiConnector):
         return yeti_objects
 
     def _delete_vertex_refs_in_graphs(self, vertex_id):
-        for graph_name in {"tags", "systemroles", "threat_graph"}:
+        # "tags" is a leftover from the pre-embedded-tags design (see the old
+        # LINK_TYPE_TO_GRAPH = {"tagged": "tags", ...} this replaced) -- tags
+        # are embedded properties now, no graph or edge collection backs a
+        # "tags" name, and create_graphs() never creates one. Asking self._db
+        # for it here used to silently auto-create an empty graph by that
+        # name on the first ever object deletion.
+        for graph_name in {"systemroles", "threat_graph"}:
             graph = self._db.graph(graph_name)
             job = graph.edge_definitions()
             while job.status() != "done":

--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -1428,12 +1428,6 @@ class ArangoYetiConnector(AbstractYetiConnector):
         return yeti_objects
 
     def _delete_vertex_refs_in_graphs(self, vertex_id):
-        # "tags" is a leftover from the pre-embedded-tags design (see the old
-        # LINK_TYPE_TO_GRAPH = {"tagged": "tags", ...} this replaced) -- tags
-        # are embedded properties now, no graph or edge collection backs a
-        # "tags" name, and create_graphs() never creates one. Asking self._db
-        # for it here used to silently auto-create an empty graph by that
-        # name on the first ever object deletion.
         for graph_name in {"systemroles", "threat_graph"}:
             graph = self._db.graph(graph_name)
             job = graph.edge_definitions()

--- a/tests/schemas/observable.py
+++ b/tests/schemas/observable.py
@@ -95,6 +95,20 @@ class ObservableTest(unittest.TestCase):
         self.assertEqual([tag.name for tag in result.tags], ["tag1"])
         self.assertEqual(result.context[0], {"source": "source1", "some": "info"})
 
+    def test_observable_delete_no_spurious_tags_graph(self) -> None:
+        # _delete_vertex_refs_in_graphs used to include a "tags" entry left
+        # over from the pre-embedded-tags design; since create_graphs() never
+        # creates a graph by that name, and graph() auto-creates whatever it's
+        # asked for, the first ever deletion silently left a stray empty
+        # "tags" graph in the database.
+        if self.db.db.has_graph("tags"):
+            self.db.db.delete_graph("tags")
+
+        result = hostname.Hostname(value="delete-me.example.com").save()
+        result.delete()
+
+        self.assertFalse(self.db.db.has_graph("tags"))
+
     def test_create_generic_observable(self):
         result = generic.Generic(value="Some_String").save()
         self.assertIsNotNone(result.id)


### PR DESCRIPTION
Two small, concrete "warts" flagged in the backend architecture review (item #6), fixed independently of that item's larger (and now-paused) god-module-split recommendation.

### The bug
`_delete_vertex_refs_in_graphs()` iterates a hardcoded `{"tags", "systemroles", "threat_graph"}`, but `create_graphs()` only ever creates `"threat_graph"` and `"systemroles"`. `"tags"` is a leftover from the pre-embedded-tags design — this repo's history shows an old `LINK_TYPE_TO_GRAPH = {"tagged": "tags", "stix": "stix"}` mapping that was removed once tags became embedded properties, but this one reference was never cleaned up.

`graph(name)` auto-creates whatever graph name it's asked for if it doesn't exist — so **the first ever object deletion in a database silently leaves a stray, permanently-empty `"tags"` graph behind.** This isn't a functional bug (the graph is always empty, so the cleanup loop over its edge collections does nothing), but it's confusing DB-schema drift with no purpose. I actually watched this happen naturally in this session's long-lived dev-test database, and confirmed it by checking out the pre-fix code and watching the same probe script recreate it.

**Fix:** drop `"tags"` from the set.

### The other wart
While in the same function, narrowed `create_views()`'s two bare `except Exception: pass` clauses (guarding "does this view already exist") to the specific `arango.exceptions.ViewGetError`/`ViewDeleteError` they're meant to catch — so a real failure (auth, network, a typo) surfaces instead of being silently swallowed and masked by a doomed `create_arangosearch_view()` call right after.

### Regression test
Added a test (`tests/schemas/observable.py`) that deletes an observable and asserts no `"tags"` graph exists afterward. Confirmed it fails against the pre-fix code (`AssertionError: True is not false`) and passes after.

### Verification
- Both ty jobs: 0 errors
- `ruff check` + `ruff format --check`: clean
- `tests/schemas` 187/187 (full suite, incl. the new test), `tests/core_tests` 29/29, `tests/apiv2` 198/200 (2 pre-existing `tasks.py` failures, confirmed unrelated across prior PRs in this batch)

The larger recommendation in the same review item (extracting `database_arango.py`'s AQL builder into its own module) stays out of scope here — it existed mainly to make the de-async work easier, which is currently paused pending further investigation (see `plans/backend-architecture-review.md`).
