### PR TITLE
chore: swap unit-test CI from unittest discover to pytest

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -48,9 +48,9 @@ jobs:
       run: cp yeti.conf.sample yeti.conf
     - name: Start redis & arangodb conainers
       run: docker compose -f extras/docker/dev/docker-compose.yaml up -d redis arangodb
-    - name: Test with unittest (schemas)
-      run: uv run python -m unittest discover -s tests/schemas -p '*.py'
-    - name: Test with unittest (apiv2)
-      run: uv run python -m unittest discover -s tests/apiv2 -p '*.py'
-    - name: Test with unittest (core_tests)
-      run: uv run python -m unittest discover -s tests/core_tests -p '*.py'
+    - name: Test with pytest (schemas)
+      run: uv run pytest tests/schemas
+    - name: Test with pytest (apiv2)
+      run: uv run pytest tests/apiv2
+    - name: Test with pytest (core_tests)
+      run: uv run pytest tests/core_tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,3 +121,10 @@ unused-ignore-comment = "warn"      # 2 (core-only, env-dependent)
 
 [tool.uv.sources]
 artifacts = { git = "https://github.com/forensicartifacts/artifacts.git", rev = "main" }
+
+[tool.pytest.ini_options]
+# Test modules don't follow the test_*.py convention. No python_classes
+# override is needed: pytest collects unittest.TestCase subclasses by
+# subclass introspection, not name-matching.
+testpaths = ["tests/schemas", "tests/apiv2", "tests/core_tests"]
+python_files = ["*.py"]


### PR DESCRIPTION
`pytest` has been a dev dependency since early in the ty ratchet effort but was never actually used as the runner — CI drove `tests/{schemas,apiv2,core_tests}` via `python -m unittest discover -p '*.py'` (the custom `-p` pattern exists because these test modules don't follow the `test_*.py` convention).

### Change
Added `[tool.pytest.ini_options]`:
```toml
testpaths = ["tests/schemas", "tests/apiv2", "tests/core_tests"]
python_files = ["*.py"]
```
No `python_classes` override needed — pytest collects `unittest.TestCase` subclasses by subclass introspection, not name-matching, so classes like `ObservableTest`/`FixtureTest`/`SimpleGraphTest` (ending in "Test", not starting with it, per pytest's own default convention) collect correctly regardless. Verified this empirically via `--collect-only` before relying on it — every `.py` file in the three test directories is a real `unittest.TestCase`-based module (checked), so there's no risk of the broad `python_files` pattern picking up something unexpected.

CI now runs `pytest tests/<dir>` instead of `python -m unittest discover -s tests/<dir> -p '*.py'` per job, same 3-job structure.

**No test files changed.**

### Verification — pytest reproduces unittest's results exactly
- `tests/schemas` 187/187
- `tests/apiv2` 198/200 (2 pre-existing `tasks.py` failures — the same ones confirmed unrelated across every PR in this batch)
- `tests/core_tests` 29/29
- Also confirmed via a bare `uv run pytest` (no path): 416 = 187+200+29, using `testpaths`

`tests/migration.py` (ad-hoc `unittest` invocation) and `tests/feeds.py` (`feedtest.yml`, external-service-dependent, scheduled weekly) are out of scope — left exactly as they are.

### Why
Gets fixtures, `-k` test selection, and a path toward parallelism (`pytest-xdist`) for later; removes the "tests aren't named `test_*`" footgun documented in the ty-ratchet review brief.

Both ty jobs: 0 errors. `ruff check` + `format --check`: clean.

From the backend architecture review, item #13 (test architecture) — the small, self-contained "runner swap" slice; the larger unit-test-tier recommendation stays out of scope here.
