### PR TITLE
fix: make link_to()/link_to_acl() atomic under concurrent callers

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -41,7 +41,12 @@ import requests
 from arango import ArangoClient
 from arango.cursor import Cursor
 from arango.database import StandardDatabase
-from arango.exceptions import DocumentInsertError, ViewDeleteError, ViewGetError
+from arango.exceptions import (
+    AQLQueryExecuteError,
+    DocumentInsertError,
+    ViewDeleteError,
+    ViewGetError,
+)
 from arango.job import AsyncJob
 from arango.result import Result
 
@@ -105,6 +110,36 @@ def _wait_for_async_job(job: "Result[T]") -> T:
     while async_job.status() != "done":
         time.sleep(ASYNC_JOB_WAIT_TIME)
     return async_job.result()
+
+
+ARANGO_CONFLICT_ERROR_CODE = 1200  # write-write conflict
+AQL_CONFLICT_MAX_RETRIES = 10
+
+
+def _execute_aql_with_conflict_retry(
+    db: "ArangoDatabase", aql: str, bind_vars: dict
+) -> "Cursor":
+    """Execute a single-document AQL UPSERT/UPDATE, retrying on conflict.
+
+    ArangoDB evaluates an UPSERT/UPDATE against one document atomically
+    server-side (no client read-modify-write gap), but rejects one side of a
+    genuinely concurrent write to the *same* document with error 1200
+    ("write-write conflict") rather than silently losing an update. Retrying
+    is correct here specifically because the query is self-contained (it
+    reads and writes the same document in one statement) -- there is no
+    earlier client-side read to go stale.
+    """
+    for attempt in range(AQL_CONFLICT_MAX_RETRIES):
+        try:
+            return cast("Cursor", db.aql.execute(aql, bind_vars=bind_vars))
+        except AQLQueryExecuteError as error:
+            if (
+                error.error_code != ARANGO_CONFLICT_ERROR_CODE
+                or attempt == AQL_CONFLICT_MAX_RETRIES - 1
+            ):
+                raise
+            time.sleep(ASYNC_JOB_WAIT_TIME * (attempt + 1))
+    raise AssertionError("unreachable")
 
 
 class ArangoDatabase:
@@ -733,6 +768,12 @@ class ArangoYetiConnector(AbstractYetiConnector):
     ) -> "Relationship":
         """Creates a link between two YetiObjects.
 
+        Idempotent and safe under concurrent calls for the same
+        (source, target, relationship_type): the existence check and the
+        insert-or-bump-count are a single atomic ArangoDB UPSERT, so two
+        concurrent callers can't both see "no edge yet" and each create one
+        (which used to produce duplicate edges with an undercounted total).
+
         Args:
           target: The YetiObject to link to.
           relationship_type: The type of link. (e.g. targets, uses, mitigates)
@@ -741,73 +782,45 @@ class ArangoYetiConnector(AbstractYetiConnector):
         # Avoid circular dependency
         from core.schemas.graph import Relationship
 
-        async_graph = self._db.graph("threat_graph")
-
-        # Check if a relationship with the same link_type already exists
-        aql = """
-        WITH observables
-
-        FOR v, e, p IN 1..1 OUTBOUND @extended_id
-        links
-          FILTER e.type == @relationship_type
-          FILTER v._id == @target_extended_id
-        RETURN e"""
-        args = {
-            "extended_id": self.extended_id,
-            "target_extended_id": target.extended_id,
-            "relationship_type": relationship_type,
-        }
-        neighbors = self._db.aql.execute(aql, bind_vars=args)
-        if not neighbors.empty():
-            neighbor = neighbors.pop()
-            neighbor["__id"] = neighbor.pop("_key")
-            relationship = Relationship.load(neighbor)
-            relationship.modified = datetime.datetime.now(datetime.timezone.utc)
-            relationship.description = description
-            relationship.count += 1
-            edge = json.loads(relationship.model_dump_json())
-            edge["_id"] = neighbor["_id"]
-            job = async_graph.update_edge(edge)
-            while job.status() != "done":
-                time.sleep(ASYNC_JOB_WAIT_TIME)
-            if self._collection_name not in ("auditlog", "timeline"):
-                try:
-                    event = message.LinkEvent(
-                        type=message.EventType.update,
-                        source_object=self,
-                        target_object=target,
-                        relationship=relationship,
-                    )
-                    producer.publish_event(event)
-                except Exception:
-                    logging.exception("Error while publishing event")
-            return relationship
-
-        relationship = Relationship(
+        now = datetime.datetime.now(datetime.timezone.utc)
+        new_relationship = Relationship(
             type=relationship_type,
             source=self.extended_id,
             target=target.extended_id,
             count=1,
             description=description,
-            created=datetime.datetime.now(datetime.timezone.utc),
-            modified=datetime.datetime.now(datetime.timezone.utc),
+            created=now,
+            modified=now,
         )
-        col = async_graph.edge_collection("links")
-        job = col.link(
-            self.extended_id,
-            target.extended_id,
-            data=json.loads(relationship.model_dump_json()),
-            return_new=True,
-        )
-        while job.status() != "done":
-            time.sleep(ASYNC_JOB_WAIT_TIME)
-        result = job.result()["new"]
-        result["__id"] = result.pop("_key")
-        relationship = Relationship.load(result)
+        insert_doc = json.loads(new_relationship.model_dump_json())
+        insert_doc["_from"] = self.extended_id
+        insert_doc["_to"] = target.extended_id
+
+        aql = """
+        UPSERT { _from: @from, _to: @to, type: @type }
+        INSERT @insert_doc
+        UPDATE { count: OLD.count + 1, description: @description, modified: @modified }
+        IN links
+        RETURN { new: NEW, old: OLD }
+        """
+        args = {
+            "from": self.extended_id,
+            "to": target.extended_id,
+            "type": relationship_type,
+            "insert_doc": insert_doc,
+            "description": description,
+            "modified": insert_doc["modified"],
+        }
+        result = list(_execute_aql_with_conflict_retry(self._db, aql, args))[0]
+        is_new = result["old"] is None
+        document = result["new"]
+        document["__id"] = document.pop("_key")
+        relationship = Relationship.load(document)
+
         if self._collection_name not in ("auditlog", "timeline"):
             try:
                 event = message.LinkEvent(
-                    type=message.EventType.new,
+                    type=message.EventType.new if is_new else message.EventType.update,
                     source_object=self,
                     target_object=target,
                     relationship=relationship,
@@ -820,6 +833,10 @@ class ArangoYetiConnector(AbstractYetiConnector):
     def link_to_acl(self, target, role: "roles.Permission") -> "RoleRelationship":
         """Creates a link between two YetiObjects.
 
+        Idempotent and safe under concurrent calls for the same
+        (source, target): the existence check and the insert-or-reassign-role
+        are a single atomic ArangoDB UPSERT (see link_to()).
+
         Args:
           target: The YetiObject to link to.
           role: The role to assign to the target.
@@ -827,50 +844,33 @@ class ArangoYetiConnector(AbstractYetiConnector):
         # Avoid circular dependency
         from core.schemas.graph import RoleRelationship
 
-        async_graph = self._db.graph("systemroles")
-
-        aql = """
-        WITH users, groups
-
-        FOR v, e, p IN 1..1 OUTBOUND @extended_id
-        acls
-          FILTER v._id == @target_extended_id
-        RETURN e"""
-        args = {
-            "extended_id": self.extended_id,
-            "target_extended_id": target.extended_id,
-        }
-        neighbors = self._db.aql.execute(aql, bind_vars=args)
-        if not neighbors.empty():
-            neighbor = neighbors.pop()
-            neighbor["__id"] = neighbor.pop("_key")
-            relationship = RoleRelationship.load(neighbor)
-            relationship.modified = datetime.datetime.now(datetime.timezone.utc)
-            relationship.role = role
-            edge = json.loads(relationship.model_dump_json())
-            edge["_id"] = neighbor["_id"]
-            job = async_graph.update_edge(edge)
-            while job.status() != "done":
-                time.sleep(ASYNC_JOB_WAIT_TIME)
-            return relationship
-
-        relationship = RoleRelationship(
+        now = datetime.datetime.now(datetime.timezone.utc)
+        new_relationship = RoleRelationship(
             role=role,
             source=self.extended_id,
             target=target.extended_id,
-            created=datetime.datetime.now(datetime.timezone.utc),
-            modified=datetime.datetime.now(datetime.timezone.utc),
+            created=now,
+            modified=now,
         )
-        col = async_graph.edge_collection("acls")
-        job = col.link(
-            self.extended_id,
-            target.extended_id,
-            data=json.loads(relationship.model_dump_json()),
-            return_new=True,
-        )
-        while job.status() != "done":
-            time.sleep(ASYNC_JOB_WAIT_TIME)
-        result = job.result()["new"]
+        insert_doc = json.loads(new_relationship.model_dump_json())
+        insert_doc["_from"] = self.extended_id
+        insert_doc["_to"] = target.extended_id
+
+        aql = """
+        UPSERT { _from: @from, _to: @to }
+        INSERT @insert_doc
+        UPDATE { role: @role, modified: @modified }
+        IN acls
+        RETURN NEW
+        """
+        args = {
+            "from": self.extended_id,
+            "to": target.extended_id,
+            "insert_doc": insert_doc,
+            "role": insert_doc["role"],
+            "modified": insert_doc["modified"],
+        }
+        result = list(_execute_aql_with_conflict_retry(self._db, aql, args))[0]
         result["__id"] = result.pop("_key")
         return RoleRelationship.load(result)
 

--- a/tests/schemas/graph.py
+++ b/tests/schemas/graph.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import time
 import unittest
 
@@ -35,6 +36,31 @@ class GraphTest(unittest.TestCase):
         self.observable1.delete()
         all_relationships = list(Relationship.list())
         self.assertEqual(len(all_relationships), 0)
+
+    def test_concurrent_link_to_same_pair_is_atomic(self) -> None:
+        """Concurrent link_to() calls for the same (source, target, type) must
+        collapse into one edge with an accurate count, not one edge per
+        caller with the count updates racing each other."""
+        concurrent_calls = 20
+        with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+            list(
+                executor.map(
+                    lambda _: self.observable1.link_to(
+                        self.observable2, "resolves", "DNS resolution"
+                    ),
+                    range(concurrent_calls),
+                )
+            )
+
+        matching = [
+            r
+            for r in Relationship.list()
+            if r.source == self.observable1.extended_id
+            and r.target == self.observable2.extended_id
+            and r.type == "resolves"
+        ]
+        self.assertEqual(len(matching), 1)
+        self.assertEqual(matching[0].count, concurrent_calls)
 
     def test_observable_to_observable_link(self) -> None:
         """Tests that a link between two observables can be created."""

--- a/tests/schemas/rbac.py
+++ b/tests/schemas/rbac.py
@@ -1,7 +1,9 @@
+import concurrent.futures
 import unittest
 
 from core import database_arango
 from core.schemas import entity, observable, rbac, roles, user
+from core.schemas.graph import RoleRelationship
 
 
 class RBACTest(unittest.TestCase):
@@ -32,6 +34,27 @@ class RBACTest(unittest.TestCase):
             role.role,
             roles.Permission.READ | roles.Permission.WRITE | roles.Permission.DELETE,
         )
+
+    def test_concurrent_link_to_acl_same_pair_is_atomic(self) -> None:
+        """Concurrent link_to_acl() calls for the same (source, target) must
+        collapse into one ACL edge, not one per caller."""
+        concurrent_calls = 20
+        with concurrent.futures.ThreadPoolExecutor(max_workers=20) as executor:
+            list(
+                executor.map(
+                    lambda _: self.user1.link_to_acl(self.group1, roles.Role.OWNER),
+                    range(concurrent_calls),
+                )
+            )
+
+        matching = [
+            r
+            for r in RoleRelationship.list()
+            if r.source == self.user1.extended_id
+            and r.target == self.group1.extended_id
+        ]
+        self.assertEqual(len(matching), 1)
+        self.assertEqual(matching[0].role, roles.Role.OWNER)
 
     def test_group_group_role_association(self) -> None:
         """Test that a role can be created"""


### PR DESCRIPTION
Both `link_to()` and `link_to_acl()` do check-then-act: query whether an edge already exists between `(source, target[, type])`, then either update it or create a new one. Under concurrent calls for the same pair — two feed workers linking the same observable/entity, or `rbac.set_acls()` called concurrently — two callers can both see "no edge yet" and each create one, producing **duplicate edges** instead of one edge with an accurate count. The count update on top of that races independently too (classic lost-update on `.count += 1`).

**Reproduced empirically before this fix**: 20 concurrent `link_to()` calls for the same pair produced 3 duplicate edges whose counts summed to less than 20 — two compounding races, not one.

### Fix
Replace the check-then-act with a single atomic ArangoDB AQL **UPSERT** per call (match on `_from`/`_to`[`/type`], `INSERT` if absent, `UPDATE` count/description/modified if present). ArangoDB evaluates a single-document UPSERT atomically server-side — there's no client-side read to go stale — but two genuinely concurrent writers to the *same* document can still hit ArangoDB's own write-write-conflict rejection (error 1200) rather than a silent lost update. Added a small retry helper for that case — verified: without it, 50 concurrent increments on one counter reproducibly hit this conflict; with it, they don't and land exactly correct.

Both methods keep their exact external contract: same return type/shape, same `LinkEvent` semantics (`EventType.new` vs `.update`, derived from whether the UPSERT's `OLD` pseudo-variable is null — verified this is exactly null on insert, the previous document on update), same collection-name event-skip guard.

The replacement uses a direct sync AQL call (matching what the existing existence-check query in the same method already did) rather than the async-execution context the old "create" branch used — **this doesn't touch or resolve the separate, currently-paused question of de-asyncing the rest of the connector** (see `plans/backend-architecture-review.md`).

### Tests
Added concurrency regression tests (`tests/schemas/graph.py`, `tests/schemas/rbac.py`): 20 concurrent callers linking the same pair collapse to exactly one edge with the correct count/role. Verified both **fail against the pre-fix code** (2 duplicate edges each) and pass against the fix.

### Found and deliberately left out of scope
Deleting a `RoleRelationship` object always fails to publish its deletion event — `core/events/message.py`'s `YetiObjectTypes` discriminated union has no `"acl"` branch for it (only `"relationship"` for the plain `Relationship`). Pre-existing, unrelated to this change (`link_to_acl()` itself never published events even before this fix), silently swallowed by `delete()`'s broad `except`. Worth a follow-up.

### Verification
- Both ty jobs: 0 errors
- `ruff check` + `ruff format --check`: clean
- `tests/schemas` 189/189 (full suite, incl. the 2 new tests), `tests/core_tests` 29/29, `tests/apiv2` 198/200 (2 pre-existing `tasks.py` failures, confirmed unrelated across every PR in this batch)

From the backend architecture review, item #7 (transactions/racy denormalized counters) — the two spots it named as having user-visible atomicity gaps. `tag()`'s count race (same item, different file) is a separate, smaller follow-up.
