### PR TITLE
Fix 500 when a non-expiring API token is used as a raw bearer token

### DIFF
--- a/core/schemas/user.py
+++ b/core/schemas/user.py
@@ -27,10 +27,10 @@ def create_access_token(
     data: dict, expires_delta: datetime.timedelta | None = None
 ) -> str:
     to_encode = data.copy()
-    expire = None
     if expires_delta:
-        expire = datetime.datetime.now(datetime.timezone.utc) + expires_delta
-    to_encode.update({"exp": expire})
+        to_encode["exp"] = datetime.datetime.now(datetime.timezone.utc) + expires_delta
+    else:
+        to_encode.pop("exp", None)
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt
 

--- a/tests/apiv2/auth.py
+++ b/tests/apiv2/auth.py
@@ -115,6 +115,19 @@ class AuthTest(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(data["detail"], "Could not validate credentials")
 
+    def test_api_key_used_directly_as_bearer(self) -> None:
+        """A CLI-generated API key has no expiration. Used directly as a raw
+        Bearer token (bypassing the /api-token exchange), it must not crash
+        the server -- its JWT has no exp claim at all rather than a null
+        one, so PyJWT's expiration check is skipped instead of erroring."""
+        response = client.get(
+            "/api/v2/auth/me",
+            headers={"authorization": f"Bearer {self.user1_apikey}"},
+        )
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data["username"], "tomchop")
+
     def test_api_key_bearer(self) -> None:
         response = client.post(
             "/api/v2/auth/api-token", headers={"x-yeti-apikey": self.user1_apikey}


### PR DESCRIPTION
## Summary

Follow-up from yeti-docker#29 — one of two bugs bundled in that report (the
other, the empty-Feeds-page issue, was mitigated in
yeti-platform/yeti-docker#30; this is the separate `exp: null` 500 also
mentioned there).

`create_access_token()` (`core/schemas/user.py`) always set the `"exp"`
claim on the JWT payload, encoding it as `null` whenever no
`expires_delta` was given. PyJWT's `decode()` only skips its expiration
check when the `"exp"` key is **absent** from the payload
(`if "exp" in payload and options["verify_exp"]:` in
`jwt/api_jwt.py`) — if the key is present but `null`,
`_validate_exp()` does `int(payload["exp"])` and raises a raw
`TypeError`. That's not a `PyJWTError`, so none of the callers'
`except jwt.PyJWTError:` handlers catch it, and it becomes an unhandled
500.

This is reachable in practice:
- `create_api_key()` — used by both the `create-user` CLI command and
  the `/new-api-key` endpoint — generates a non-expiring token by
  default (no `expires_delta` passed through).
- `get_current_user()` (`core/web/apiv2/auth.py:89`) — the auth
  dependency behind every `/api/v2/*` endpoint — decodes any bearer
  token with PyJWT's default options (no `verify_exp` override), so
  presenting such a token directly as `Authorization: Bearer <token>`
  hits this path directly.

The `/api-token` exchange endpoint (`login_api`) was already unaffected
— it explicitly passes `options={"verify_exp": False}` and checks
expiration itself via the persisted `RegisteredApiKey.expired`.

**Not a regression, not fixed by the jose→PyJWT migration:** verified
both python-jose (as shipped in the currently released 2.5.0/2.5.1) and
PyJWT (current `main`) raise the identical uncaught `TypeError` on a
null `exp` claim.

## Fix

Omit the `"exp"` claim entirely when there's no expiration, instead of
encoding it as `null` — the standard, correct way to express "no
expiration" in a JWT, which PyJWT already treats as "skip the
expiration check".

## Test plan

- [x] Added `test_api_key_used_directly_as_bearer` to
      `tests/apiv2/auth.py`: uses a `create_api_key()`-issued token
      directly as a bearer token against `/api/v2/auth/me`, bypassing
      the `/api-token` exchange.
- [x] Verified it reproduces the exact `TypeError` traceback through
      `get_current_user()` on the pre-fix code, and passes with the fix.
- [x] Full `tests/apiv2` suite: 199/201 pass (same 2 known pre-existing
      failures in `tests/apiv2/tasks.py`, unrelated).
- [x] `tests/schemas` (190/190) and `tests/core_tests` (29/29) pass
      unchanged.
- [x] `ty check` (core+yetictl and plugins jobs): 0 errors.
- [x] `ruff check` / `ruff format --check`: clean.