### PR TITLE
Log database failures during plugin registration as errors, not warnings

### DIFF
--- a/core/taskscheduler.py
+++ b/core/taskscheduler.py
@@ -5,6 +5,8 @@ import logging
 import pathlib
 import pkgutil
 
+import requests
+from arango.exceptions import ArangoError
 from celery import Celery
 from celery.utils.log import get_task_logger
 
@@ -30,6 +32,22 @@ def get_plugins_list(task_class: type[Task] = Task) -> set[str]:
                 for _, obj in inspect.getmembers(module, inspect.isclass):
                     if issubclass(obj, task_class):
                         plugins_list.add(module_info.name)
+            # A plugin registers itself in the database as a side effect of
+            # being imported (see TaskManager.register_task) -- a database
+            # error here means that registration didn't happen, not that the
+            # plugin's own code is broken, so it needs a distinct, louder
+            # signal from the "this plugin's dependencies aren't installed"
+            # case below.
+            except (
+                ConnectionError,
+                requests.exceptions.ConnectionError,
+                ArangoError,
+            ) as error:
+                logging.error(
+                    f"Plugin {module_info.name} imported but failed to register "
+                    f"itself against the database -- it will not appear until "
+                    f"this process is restarted: {error}"
+                )
             except Exception as error:
                 logging.warning(f"Cannot import plugin {module_info.name}\n{error}")
     return plugins_list

--- a/tests/core_tests/taskscheduler.py
+++ b/tests/core_tests/taskscheduler.py
@@ -1,0 +1,38 @@
+import importlib
+import unittest
+from unittest import mock
+
+from arango.exceptions import ArangoClientError
+
+from core import taskscheduler
+
+REAL_IMPORT_MODULE = importlib.import_module
+FAILING_PLUGIN = "plugins.feeds.public.urlhaus"
+
+
+class GetPluginsListTest(unittest.TestCase):
+    def test_database_error_during_registration_logs_as_error(self) -> None:
+        """A plugin that imports fine but fails to register itself against
+        the database (TaskManager.register_task runs at plugin import time)
+        must be logged at ERROR, not folded into the same WARNING used for
+        plugins whose own dependencies simply aren't installed -- those are
+        very different failure classes operationally."""
+
+        def fake_import_module(name, *args, **kwargs):
+            if name == FAILING_PLUGIN:
+                raise ArangoClientError("simulated database failure")
+            return REAL_IMPORT_MODULE(name, *args, **kwargs)
+
+        with mock.patch("importlib.import_module", side_effect=fake_import_module):
+            with self.assertLogs(level="WARNING") as logs:
+                taskscheduler.get_plugins_list()
+
+        matching = [
+            (record.levelname, record.message)
+            for record in logs.records
+            if FAILING_PLUGIN in record.message
+        ]
+        self.assertEqual(len(matching), 1)
+        level, message = matching[0]
+        self.assertEqual(level, "ERROR")
+        self.assertIn("database", message)


### PR DESCRIPTION
## Summary

Closes the remaining part of yeti-docker#29 ("Feed tasks are not
initialized on fresh installation") — the actual mechanism behind the
empty Feeds page.

Every plugin registers itself as a `Task` document in the database as a
side effect of being imported (`TaskManager.register_task`, called from
each plugin module's own top-level code, e.g.
`plugins/feeds/public/urlhaus.py:92`). `get_plugins_list()`
(`core/taskscheduler.py`) wraps that import in a bare
`except Exception`, logging any failure at WARNING and moving on to the
next plugin — the right behavior for a plugin whose own optional
dependency isn't installed (e.g. `pymisp`/`otxv2`/`shodan` in a minimal
deployment), but not for a plugin that imported fine and then failed to
*register* because the database rejected or couldn't complete the write.
Both cases currently look identical in the logs, at a level easy to
miss in production, with no way to distinguish "this feed isn't
available in this deployment" from "this feed didn't get created and
won't until the process restarts."

This is the actual failure mode behind the reported bug: on a fresh
install, if the database only becomes reachable partway through the
plugin import phase — a startup race independently mitigated at the
compose level in yeti-platform/yeti-docker#30, and made significantly
less likely by the `connect()` retry fix in #1331 — every registration
attempt made before that point fails and is silently dropped, leaving
the Feeds page permanently empty for that process's lifetime with only
a WARNING-level trace buried among (likely legitimate) "plugin X isn't
installed" warnings.

## Fix

Add a dedicated `except` clause ahead of the generic one, catching the
same connectivity/database exception classes as #1331's `connect()` fix
(builtin `ConnectionError`, `requests.exceptions.ConnectionError`, and
`arango.exceptions.ArangoError` — the common base for every server- and
client-side python-arango error) and logging them at ERROR with a
message that names the actual consequence ("this feed will not appear
until the process is restarted"), instead of folding them into the
generic "plugin didn't import" warning.

This doesn't change *whether* the collection ends up empty in the
worst case (the deeper fix for that is #1331 + yeti-docker#30) — it
makes the failure loud and diagnosable instead of silent, which is the
main thing standing between "empty Feeds page, no idea why" and "check
the logs, database was unreachable during startup."

## Test plan

- [x] Added `test_database_error_during_registration_logs_as_error`
      (`tests/core_tests/taskscheduler.py`): makes one specific plugin's
      import raise `ArangoClientError` and asserts it's logged at ERROR
      rather than WARNING.
- [x] Verified it fails on the pre-fix code (logs at WARNING) and passes
      with the fix.
- [x] Full `tests/core_tests` suite: 30/30 pass.
- [x] `tests/schemas` (190/190) and `tests/apiv2` (198/200, same 2 known
      pre-existing failures) pass unchanged.
- [x] `ty check` (core+yetictl and plugins jobs): 0 errors.
- [x] `ruff check` / `ruff format --check`: clean.