### PR TITLE
Dedupe observable/entity/indicator tag endpoint bodies (item #5, first slice)

### DIFF
--- a/core/web/apiv2/entities.py
+++ b/core/web/apiv2/entities.py
@@ -7,7 +7,7 @@ from core.schemas import audit, model, rbac, roles
 from core.schemas.entity import Entity, EntityType, EntityTypesRuntime
 from core.schemas.tag import MAX_TAGS_REQUEST
 
-from . import context
+from . import context, tagging
 
 
 # Request schemas
@@ -228,21 +228,15 @@ def get_multiple(
 @rbac.permission_on_ids(roles.Permission.WRITE)
 def tag(httpreq: Request, request: EntityTagRequest) -> EntityTagResponse:
     """Tags entities."""
-    entities = []
-    for entity_id in request.ids:
-        db_entity = Entity.get(entity_id)
-        if not db_entity:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Tagging request contained an unknown entity: ID:{entity_id}",
-            )
-        entities.append(db_entity)
-
-    entity_tags = {}
-    for db_entity in entities:
-        old_tags = [tag.name for tag in db_entity.get_tags().values()]
-        db_entity = db_entity.tag(request.tags, clear=request.strict)
-        audit.log_timeline_tags(httpreq.state.username, db_entity, old_tags)
-        entity_tags[db_entity.extended_id] = {tag.name: tag for tag in db_entity.tags}
-
-    return EntityTagResponse(tagged=len(entities), tags=entity_tags)
+    tagged, tags = tagging.tag_objects(
+        Entity,
+        httpreq,
+        request.ids,
+        request.tags,
+        request.strict,
+        not_found_status_code=404,
+        not_found_detail=(
+            lambda eid: f"Tagging request contained an unknown entity: ID:{eid}"
+        ),
+    )
+    return EntityTagResponse(tagged=tagged, tags=tags)

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -16,7 +16,7 @@ from core.schemas.indicator import (
 )
 from core.schemas.tag import MAX_TAGS_REQUEST
 
-from . import context
+from . import context, tagging
 
 logger = logging.getLogger(__name__)
 
@@ -275,26 +275,18 @@ def get_multiple(
 @rbac.permission_on_ids(roles.Permission.WRITE)
 def tag(httpreq: Request, request: IndicatorTagRequest) -> IndicatorTagResponse:
     """Tags entities."""
-    indicators = []
-    for indicator_id in request.ids:
-        db_indicator = Indicator.get(indicator_id)
-        if not db_indicator:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Tagging request contained an unknown indicator: ID:{indicator_id}",
-            )
-        indicators.append(db_indicator)
-
-    indicator_tags = {}
-    for db_indicator in indicators:
-        old_tags = [tag.name for tag in db_indicator.get_tags().values()]
-        db_indicator = db_indicator.tag(request.tags, clear=request.strict)
-        audit.log_timeline_tags(httpreq.state.username, db_indicator, old_tags)
-        indicator_tags[db_indicator.extended_id] = {
-            tag.name: tag for tag in db_indicator.tags
-        }
-
-    return IndicatorTagResponse(tagged=len(indicators), tags=indicator_tags)
+    tagged, tags = tagging.tag_objects(
+        Indicator,
+        httpreq,
+        request.ids,
+        request.tags,
+        request.strict,
+        not_found_status_code=404,
+        not_found_detail=(
+            lambda iid: f"Tagging request contained an unknown indicator: ID:{iid}"
+        ),
+    )
+    return IndicatorTagResponse(tagged=tagged, tags=tags)
 
 
 @router.post("/yara/bundle")

--- a/core/web/apiv2/observables.py
+++ b/core/web/apiv2/observables.py
@@ -9,7 +9,7 @@ from core.schemas import audit, model, observable, rbac, roles, tag
 from core.schemas.observable import Observable, ObservableType, ObservableTypesRuntime
 from core.schemas.rbac import global_permission, permission_on_ids, permission_on_target
 
-from . import context
+from . import context, tagging
 
 # defaults to 10MiB if not defined
 MAX_FILE_UPLOAD = yeti_config.get("web", "max_file_upload", 10 * 1024 * 1024)
@@ -397,26 +397,18 @@ def tag_observable(
     httpreq: Request, request: ObservableTagRequest
 ) -> ObservableTagResponse:
     """Tags a set of observables, individually or in bulk."""
-    observables = []
-    for observable_id in request.ids:
-        observable_obj = Observable.get(observable_id)
-        if not observable_obj:
-            raise HTTPException(
-                status_code=400,
-                detail="Tagging request contained an unknown observable: ID:{observable_id}",
-            )
-        observables.append(observable_obj)
-
-    observable_tags = {}
-    for observable_obj in observables:
-        old_tags = [tag.name for tag in observable_obj.get_tags().values()]
-        observable_obj = observable_obj.tag(request.tags, clear=request.strict)
-        audit.log_timeline_tags(httpreq.state.username, observable_obj, old_tags)
-        observable_tags[observable_obj.extended_id] = {
-            tag.name: tag for tag in observable_obj.tags
-        }
-
-    return ObservableTagResponse(tagged=len(observables), tags=observable_tags)
+    tagged, tags = tagging.tag_objects(
+        Observable,
+        httpreq,
+        request.ids,
+        request.tags,
+        request.strict,
+        not_found_status_code=400,
+        not_found_detail=(
+            lambda oid: f"Tagging request contained an unknown observable: ID:{oid}"
+        ),
+    )
+    return ObservableTagResponse(tagged=tagged, tags=tags)
 
 
 @router.delete("/{id}")

--- a/core/web/apiv2/tagging.py
+++ b/core/web/apiv2/tagging.py
@@ -1,0 +1,36 @@
+from typing import Callable, Type, TypeVar
+
+from fastapi import HTTPException, Request
+
+from core.schemas import audit, model
+
+T = TypeVar("T")
+
+
+def tag_objects(
+    base_type: Type[T],
+    httpreq: Request,
+    ids: list[str],
+    tags: list[str],
+    strict: bool,
+    not_found_status_code: int,
+    not_found_detail: Callable[[str], str],
+) -> tuple[int, dict[str, dict[str, model.YetiTagInstance]]]:
+    """Tags a set of arbitrary Yeti Objects, individually or in bulk."""
+    objects = []
+    for object_id in ids:
+        obj = base_type.get(object_id)  # ty: ignore[unresolved-attribute]
+        if not obj:
+            raise HTTPException(
+                status_code=not_found_status_code, detail=not_found_detail(object_id)
+            )
+        objects.append(obj)
+
+    object_tags = {}
+    for obj in objects:
+        old_tags = [t.name for t in obj.get_tags().values()]
+        obj = obj.tag(tags, clear=strict)
+        audit.log_timeline_tags(httpreq.state.username, obj, old_tags)
+        object_tags[obj.extended_id] = {t.name: t for t in obj.tags}
+
+    return len(objects), object_tags

--- a/tests/apiv2/observables.py
+++ b/tests/apiv2/observables.py
@@ -530,6 +530,15 @@ class ObservableTest(unittest.TestCase):
         self.assertEqual(len(data["tags"]), 1)
         self.assertEqual(data["total"], 1)
 
+    def test_tag_observable_unknown_id(self):
+        response = client.post(
+            "/api/v2/observables/tag",
+            json={"ids": ["observables/doesnotexist"], "tags": ["tag1"]},
+        )
+        self.assertEqual(response.status_code, 400)
+        data = response.json()
+        self.assertIn("observables/doesnotexist", data["detail"])
+
     def test_remove_tags_observables(self):
         response = client.post(
             "/api/v2/observables/", json={"value": "toto.com", "type": "hostname"}


### PR DESCRIPTION
## Summary

First incremental slice of the architecture review's item #5 (the
observable/entity/indicator router triplication) — the `/tag` endpoint
body, one of the four behaviors the review names as extraction
candidates ("search endpoint body, tag endpoint body, context
endpoints, bulk-add loop").

The observable, entity, and indicator routers each independently
implemented the exact same `/tag` endpoint logic: look up every
requested ID (raising on any miss), then tag each found object and
record its resulting tags. The only genuine per-type differences were:
- the not-found status code — observable uses 400, entity/indicator use
  404 (an existing, unintentional inconsistency — preserved here
  exactly rather than silently "fixed" as a side effect of a refactor)
- the wording of the not-found detail message

## Change

Added `core/web/apiv2/tagging.py` with a single `tag_objects()` helper,
parameterized by base type and the two per-type variation points above
— mirroring the existing pattern in `core/web/apiv2/context.py`
(`add_context`/`replace_context`/`delete_context`, already generic over
`Type[T]`). Each router's `/tag` endpoint is now a few lines that call
the helper and wrap the result in its own typed response model. The
request/response Pydantic models and route decorators are untouched in
all three routers.

**OpenAPI spec verified byte-identical**: generated the spec from a
throwaway build of the pre-change routers and diffed it (md5) against
the post-change build — identical.

**Incidental fix**: observable's `/tag` endpoint built its not-found
detail message without an `f` prefix, so on a missing ID it literally
returned the string `"...ID:{observable_id}"` instead of the real ID.
Preserving this exactly would have meant deliberately keeping a broken
string in the new shared helper's callback, which seemed worse than
just fixing it — so it's fixed here, called out explicitly rather than
silently bundled in. Doesn't change status code or response shape, only
the `detail` string content on an already-erroring request.

## Test plan

- [x] Added `test_tag_observable_unknown_id`
      (`tests/apiv2/observables.py`) covering the incidental fix —
      verified it fails on the pre-fix router (asserts the literal
      broken string) and passes with the fix.
- [x] Full `tests/apiv2` suite: 200/202 pass (same 2 known pre-existing
      failures in `tests/apiv2/tasks.py`, unrelated).
- [x] `tests/schemas` (190/190) and `tests/core_tests` (31/31) pass
      unchanged.
- [x] `ty check` (core+yetictl and plugins jobs): 0 errors.
- [x] `ruff check` / `ruff format --check`: clean.

## Scope note

This is deliberately just the tag endpoint. The review's other named
candidates (search endpoint body, `get`-by-name, `details`, `delete`,
bulk-add) are structurally similar but each has its own small
asymmetries worth checking individually (e.g. observable's `search`
lacks the `filter_aliases`/`get_multiple` support entity/indicator
have) — better done as separate, individually-reviewable follow-ups
than one large PR.