### PR TITLE
Dedupe observable/entity/indicator details/delete endpoints (item #5, second slice)

### DIFF
--- a/core/web/apiv2/crud.py
+++ b/core/web/apiv2/crud.py
@@ -1,0 +1,28 @@
+from typing import Type, TypeVar
+
+from fastapi import HTTPException, Request
+
+from core.schemas import audit
+
+T = TypeVar("T")
+
+
+def get_details(base_type: Type[T], id: str, not_found_detail: str) -> T:
+    """Returns full details (tags and ACLs included) for a single object."""
+    obj = base_type.get(id)  # ty: ignore[unresolved-attribute]
+    if not obj:
+        raise HTTPException(status_code=404, detail=not_found_detail)
+    obj.get_tags()
+    obj.get_acls()
+    return obj
+
+
+def delete_object(
+    base_type: Type[T], httpreq: Request, id: str, not_found_detail: str
+) -> None:
+    """Deletes a single object by id, recording an audit-log delete event."""
+    obj = base_type.get(id)  # ty: ignore[unresolved-attribute]
+    if not obj:
+        raise HTTPException(status_code=404, detail=not_found_detail)
+    audit.log_timeline(httpreq.state.username, obj, action="delete")
+    obj.delete()

--- a/core/web/apiv2/entities.py
+++ b/core/web/apiv2/entities.py
@@ -7,7 +7,7 @@ from core.schemas import audit, model, rbac, roles
 from core.schemas.entity import Entity, EntityType, EntityTypesRuntime
 from core.schemas.tag import MAX_TAGS_REQUEST
 
-from . import context, tagging
+from . import context, crud, tagging
 
 
 # Request schemas
@@ -166,23 +166,14 @@ def get(
 @rbac.permission_on_target(roles.Permission.READ)
 def details(httpreq: Request, id: str) -> EntityTypesRuntime:
     """Returns details about an observable."""
-    db_entity = Entity.get(id)
-    if not db_entity:
-        raise HTTPException(status_code=404, detail=f"Entity {id} not found")
-    db_entity.get_tags()
-    db_entity.get_acls()
-    return db_entity
+    return crud.get_details(Entity, id, f"Entity {id} not found")
 
 
 @router.delete("/{id}")
 @rbac.permission_on_target(roles.Permission.DELETE)
 def delete(httpreq: Request, id: str) -> None:
     """Deletes an Entity."""
-    db_entity = Entity.get(id)
-    if not db_entity:
-        raise HTTPException(status_code=404, detail=f"Entity ID {id} not found")
-    audit.log_timeline(httpreq.state.username, db_entity, action="delete")
-    db_entity.delete()
+    crud.delete_object(Entity, httpreq, id, f"Entity ID {id} not found")
 
 
 @router.post("/search")

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -16,7 +16,7 @@ from core.schemas.indicator import (
 )
 from core.schemas.tag import MAX_TAGS_REQUEST
 
-from . import context, tagging
+from . import context, crud, tagging
 
 logger = logging.getLogger(__name__)
 
@@ -214,23 +214,14 @@ def get(
 @rbac.permission_on_target(roles.Permission.READ)
 def details(httpreq: Request, id: str) -> IndicatorTypesRuntime:
     """Returns details about an indicator."""
-    db_indicator = Indicator.get(id)
-    if not db_indicator:
-        raise HTTPException(status_code=404, detail="indicator not found")
-    db_indicator.get_tags()
-    db_indicator.get_acls()
-    return db_indicator
+    return crud.get_details(Indicator, id, "indicator not found")
 
 
 @router.delete("/{id}")
 @rbac.permission_on_target(roles.Permission.DELETE)
 def delete(httpreq: Request, id: str) -> None:
     """Deletes an indicator."""
-    db_indicator = Indicator.get(id)
-    if not db_indicator:
-        raise HTTPException(status_code=404, detail="Indicator ID {id} not found")
-    audit.log_timeline(httpreq.state.username, db_indicator, action="delete")
-    db_indicator.delete()
+    crud.delete_object(Indicator, httpreq, id, f"Indicator ID {id} not found")
 
 
 @router.post("/search")

--- a/core/web/apiv2/observables.py
+++ b/core/web/apiv2/observables.py
@@ -9,7 +9,7 @@ from core.schemas import audit, model, observable, rbac, roles, tag
 from core.schemas.observable import Observable, ObservableType, ObservableTypesRuntime
 from core.schemas.rbac import global_permission, permission_on_ids, permission_on_target
 
-from . import context, tagging
+from . import context, crud, tagging
 
 # defaults to 10MiB if not defined
 MAX_FILE_UPLOAD = yeti_config.get("web", "max_file_upload", 10 * 1024 * 1024)
@@ -256,13 +256,7 @@ def get(
 @permission_on_target(roles.Permission.READ)
 def details(httpreq: Request, id: str) -> ObservableTypesRuntime:
     """Returns details about an observable."""
-    observable_obj = Observable.get(id)
-
-    if not observable_obj:
-        raise HTTPException(status_code=404, detail="Observable not found")
-    observable_obj.get_tags()
-    observable_obj.get_acls()
-    return observable_obj
+    return crud.get_details(Observable, id, "Observable not found")
 
 
 @router.post("/{id}/context")
@@ -415,8 +409,4 @@ def tag_observable(
 @permission_on_target(roles.Permission.DELETE)
 def delete(httpreq: Request, id: str) -> None:
     """Deletes an observable."""
-    observable_obj = Observable.get(id)
-    if not observable_obj:
-        raise HTTPException(status_code=404, detail="Observable not found")
-    audit.log_timeline(httpreq.state.username, observable_obj, action="delete")
-    observable_obj.delete()
+    crud.delete_object(Observable, httpreq, id, "Observable not found")

--- a/tests/apiv2/indicators.py
+++ b/tests/apiv2/indicators.py
@@ -184,6 +184,12 @@ class IndicatorTest(unittest.TestCase):
         response = client.get(f"/api/v2/indicators/{self.indicator1.id}")
         self.assertEqual(response.status_code, 404)
 
+    def test_delete_indicator_unknown_id(self):
+        response = client.delete("/api/v2/indicators/doesnotexist")
+        self.assertEqual(response.status_code, 404)
+        data = response.json()
+        self.assertIn("doesnotexist", data["detail"])
+
     def test_patch_indicator(self):
         self.indicator1.pattern = "blah"
         dump = self.indicator1.model_dump_json()


### PR DESCRIPTION
## Summary

Second incremental slice of item #5 (observable/entity/indicator router
triplication), following #1333's tag-endpoint extraction. This one covers
the `details` (`GET /{id}`) and `delete` (`DELETE /{id}`) endpoints — the
simplest of the remaining duplicated bodies, since all three routers
already agree on status code (404) for both, differing only in the
not-found message wording.

## Change

Added `core/web/apiv2/crud.py` with `get_details()` and `delete_object()`,
parameterized by base type and the not-found detail message — same
`Type[T]` pattern already used in `core/web/apiv2/context.py`. Each
router's `details`/`delete` endpoint is now a one-line call into the
shared helper. Request/response Pydantic models and route decorators are
untouched in all three routers.

**OpenAPI spec verified byte-identical**: diffed (md5) a throwaway build
of the pre-change routers against the post-change build.

**Incidental fix**: indicator's `delete` endpoint built its not-found
detail message without an `f` prefix, so it always returned the literal
string `"Indicator ID {id} not found"` instead of the real id — same
class of bug as observable's tag endpoint, fixed in #1333. Fixed here for
the same reason: preserving it faithfully in the extraction would have
meant deliberately keeping broken output.

## Test plan

- [x] Added `test_delete_indicator_unknown_id`
      (`tests/apiv2/indicators.py`) — verified it fails on the pre-fix
      router (literal `{id}` in the response) and passes with the fix.
- [x] Full `tests/apiv2` suite: 201/203 pass (same 2 known pre-existing
      failures in `tests/apiv2/tasks.py`, unrelated).
- [x] `tests/schemas` (190/190) and `tests/core_tests` (31/31) pass
      unchanged.
- [x] `ty check` (core+yetictl and plugins jobs): 0 errors.
- [x] `ruff check` / `ruff format --check`: clean.

## Scope note

Remaining item #5 candidates (search endpoint body, `get`-by-name) are
more entangled with genuine per-router asymmetries — observable's search
lacks `filter_aliases` and has no `get_multiple` endpoint at all, unlike
entity/indicator — so normalizing those safely needs its own dedicated
pass rather than a blind extraction.