### PR TITLE
Dedupe observable/entity/indicator get-by-name/value endpoints (item #5, third slice)

### DIFF
--- a/core/web/apiv2/crud.py
+++ b/core/web/apiv2/crud.py
@@ -2,9 +2,31 @@ from typing import Type, TypeVar
 
 from fastapi import HTTPException, Request
 
-from core.schemas import audit
+from core.schemas import audit, rbac, roles
 
 T = TypeVar("T")
+
+
+def get_by_lookup(
+    base_type: Type[T], httpreq: Request, lookup: dict, not_found_detail: str
+) -> T:
+    """Finds a single object by an arbitrary lookup (e.g. value or name),
+    enforcing read permissions on the result."""
+    obj = base_type.find(**lookup)  # ty: ignore[unresolved-attribute]
+    if not obj:
+        raise HTTPException(status_code=404, detail=not_found_detail)
+    obj.get_tags()
+    if not rbac.RBAC_ENABLED or httpreq.state.user.admin:
+        return obj
+    if not httpreq.state.user.has_permissions(obj.extended_id, roles.Permission.READ):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"Forbidden: missing privileges {roles.Permission.READ} "
+                f"on target {obj.extended_id}"
+            ),
+        )
+    return obj
 
 
 def get_details(base_type: Type[T], id: str, not_found_detail: str) -> T:

--- a/core/web/apiv2/entities.py
+++ b/core/web/apiv2/entities.py
@@ -138,28 +138,12 @@ def get(
     type: EntityType | None = None,
 ) -> EntityTypesRuntime:
     """Gets an entity by name."""
-
     params = {"name": name}
     if type:
         params["type"] = type
-
-    entity = Entity.find(**params)
-    if not entity:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Entity {name} not found (type: {type or 'any'})",
-        )
-    entity.get_tags()
-    if not rbac.RBAC_ENABLED or httpreq.state.user.admin:
-        return entity
-    if not httpreq.state.user.has_permissions(
-        entity.extended_id, roles.Permission.READ
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail=f"Forbidden: missing privileges {roles.Permission.READ} on target {entity.extended_id}",
-        )
-    return entity
+    return crud.get_by_lookup(
+        Entity, httpreq, params, f"Entity {name} not found (type: {type or 'any'})"
+    )
 
 
 @router.get("/{id}")

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -184,30 +184,15 @@ def get(
     type: IndicatorType | None = None,
 ) -> IndicatorTypesRuntime:
     """Gets an indicator by name."""
-
     params = {"name": name}
     if type:
         params["type"] = type
-
-    indicator = Indicator.find(**params)
-    if not indicator:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Indicator {name} not found (type: {type or 'any'})",
-        )
-    indicator.get_tags()
-
-    if not rbac.RBAC_ENABLED or httpreq.state.user.admin:
-        return indicator
-
-    if not httpreq.state.user.has_permissions(
-        indicator.extended_id, roles.Permission.READ
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail=f"Forbidden: missing privileges {roles.Permission.READ} on target {indicator.extended_id}",
-        )
-    return indicator
+    return crud.get_by_lookup(
+        Indicator,
+        httpreq,
+        params,
+        f"Indicator {name} not found (type: {type or 'any'})",
+    )
 
 
 @router.get("/{id}")

--- a/core/web/apiv2/observables.py
+++ b/core/web/apiv2/observables.py
@@ -227,29 +227,15 @@ def get(
     type: ObservableType | None = None,
 ) -> ObservableTypesRuntime:
     """Gets an observable by value."""
-
     params = {"value": value}
     if type:
         params["type"] = type
-
-    observable = Observable.find(**params)
-    if not observable:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Observable {value} not found (type: {type or 'any'})",
-        )
-
-    observable.get_tags()
-    if not rbac.RBAC_ENABLED or httpreq.state.user.admin:
-        return observable
-    if not httpreq.state.user.has_permissions(
-        observable.extended_id, roles.Permission.READ
-    ):
-        raise HTTPException(
-            status_code=403,
-            detail=f"Forbidden: missing privileges {roles.Permission.READ} on target {observable.extended_id}",
-        )
-    return observable
+    return crud.get_by_lookup(
+        Observable,
+        httpreq,
+        params,
+        f"Observable {value} not found (type: {type or 'any'})",
+    )
 
 
 @router.get("/{id}")


### PR DESCRIPTION
## Summary

Third incremental slice of item #5 (observable/entity/indicator router
triplication), following #1333 (tag endpoint) and #1334 (details/delete
endpoints). This one covers the `GET /` (find-by-value/name) endpoint.

Each router's `get` endpoint built a lookup dict, called the model's
`find()`, raised 404 if nothing matched, called `get_tags()`, then ran the
identical RBAC read-permission check (admin/RBAC-disabled bypass, else
`has_permissions` check raising 403) before returning. The only real
differences were the not-found message wording and the query parameter
name itself — `value` for observable, `name` for entity/indicator.

## Change

Added `core/web/apiv2/crud.py::get_by_lookup()`, taking the base type, an
already-built lookup dict, and the not-found message; it performs the
`find()` call plus the shared not-found/tags/RBAC logic. Each router's
`get` endpoint still builds its own lookup dict — preserving the exact
per-type "only include `type` in the query if set" behavior and, crucially,
keeping the differing query parameter name (`value`/`name`) in its own
function signature, since that's part of the OpenAPI contract and not
something to unify.

**OpenAPI spec verified byte-identical** (md5 match between a throwaway
pre-change build and the post-change build, same method used for the
previous two slices).

No incidental bugs found this time — all three endpoints already agreed
on status codes and message format, unlike the tag/delete endpoints fixed
in #1333/#1334.

## Test plan

- [x] Full `tests/apiv2` suite: 201/203 pass (same 2 known pre-existing
      failures in `tests/apiv2/tasks.py`, unrelated) — includes the
      existing get-by-value/name and RBAC-forbidden tests for all three
      routers, unchanged.
- [x] `tests/schemas` (190/190) and `tests/core_tests` (31/31) pass
      unchanged.
- [x] `ty check` (core+yetictl and plugins jobs): 0 errors.
- [x] `ruff check` / `ruff format --check`: clean.

## Scope note

The one remaining item #5 candidate from the original list — the `search`
endpoint body — is the most entangled: entity/indicator support
`filter_aliases` and a separate `get_multiple` endpoint that observable
has neither of. Normalizing that safely needs a real design decision
(add the missing fields to observable's search, changing its OpenAPI
shape — additive but deliberate) rather than a blind extraction, so I'd
treat it as its own follow-up rather than bundling it here.