### PR TITLE
Dedupe observable/entity/indicator search/get-multiple endpoints (item #5, final slice)

### DIFF
--- a/core/web/apiv2/crud.py
+++ b/core/web/apiv2/crud.py
@@ -7,6 +7,32 @@ from core.schemas import audit, rbac, roles
 T = TypeVar("T")
 
 
+def search_objects(
+    base_type: Type[T],
+    httpreq: Request,
+    query: dict,
+    type_value: str | None,
+    sorting: list[tuple[str, bool]],
+    count: int,
+    page: int,
+    aliases: list[tuple[str, str]] | None = None,
+    links_count: bool = False,
+) -> tuple[list[T], int]:
+    """Runs a filter() search (or a get/multiple-style exact-match query)
+    and returns (objects, total)."""
+    if type_value:
+        query["type"] = type_value
+    return base_type.filter(  # ty: ignore[unresolved-attribute]
+        query_args=query,
+        offset=page * count,
+        count=count,
+        sorting=sorting,
+        aliases=aliases or [],
+        links_count=links_count,
+        user=httpreq.state.user,
+    )
+
+
 def get_by_lookup(
     base_type: Type[T], httpreq: Request, lookup: dict, not_found_detail: str
 ) -> T:

--- a/core/web/apiv2/entities.py
+++ b/core/web/apiv2/entities.py
@@ -163,20 +163,18 @@ def delete(httpreq: Request, id: str) -> None:
 @router.post("/search")
 def search(httpreq: Request, request: EntitySearchRequest) -> EntitySearchResponse:
     """Searches for observables."""
-    query = request.query
-    if request.type:
-        query["type"] = request.type
-    entities, total = Entity.filter(
-        query_args=query,
-        offset=request.page * request.count,
-        count=request.count,
-        sorting=request.sorting,
+    entities, total = crud.search_objects(
+        Entity,
+        httpreq,
+        request.query,
+        request.type,
+        request.sorting,
+        request.count,
+        request.page,
         aliases=request.filter_aliases,
         links_count=True,
-        user=httpreq.state.user,
     )
-    response = EntitySearchResponse(entities=entities, total=total)
-    return response
+    return EntitySearchResponse(entities=entities, total=total)
 
 
 @router.post("/get/multiple")
@@ -184,17 +182,16 @@ def get_multiple(
     httpreq: Request, request: EntityMultipleGetRequest
 ) -> EntitySearchResponse:
     """Gets multiple entities by name."""
-    query = {"name__in": request.names}
-    if request.type:
-        query["type"] = request.type
-    entities, total = Entity.filter(
-        query_args=query,
-        offset=request.page * request.count,
-        count=request.count,
-        sorting=request.sorting,
+    entities, total = crud.search_objects(
+        Entity,
+        httpreq,
+        {"name__in": request.names},
+        request.type,
+        request.sorting,
+        request.count,
+        request.page,
         aliases=request.filter_aliases,
         links_count=True,
-        user=httpreq.state.user,
     )
     return EntitySearchResponse(entities=entities, total=total)
 

--- a/core/web/apiv2/indicators.py
+++ b/core/web/apiv2/indicators.py
@@ -214,16 +214,16 @@ def search(
     httpreq: Request, request: IndicatorSearchRequest
 ) -> IndicatorSearchResponse:
     """Searches for indicators."""
-    query = request.query
-    if request.type:
-        query["type"] = request.type
-    indicators, total = Indicator.filter(
-        query_args=query,
-        offset=request.page * request.count,
-        count=request.count,
-        sorting=request.sorting,
+    indicators, total = crud.search_objects(
+        Indicator,
+        httpreq,
+        request.query,
+        request.type,
+        request.sorting,
+        request.count,
+        request.page,
         aliases=request.filter_aliases,
-        user=httpreq.state.user,
+        links_count=True,
     )
     return IndicatorSearchResponse(indicators=indicators, total=total)
 
@@ -233,16 +233,16 @@ def get_multiple(
     httpreq: Request, request: IndicatorMultipleGetRequest
 ) -> IndicatorSearchResponse:
     """Gets multiple indicators by name."""
-    query = {"name__in": request.names}
-    if request.type:
-        query["type"] = request.type
-    indicators, total = Indicator.filter(
-        query_args=query,
-        offset=request.page * request.count,
-        count=request.count,
-        sorting=request.sorting,
+    indicators, total = crud.search_objects(
+        Indicator,
+        httpreq,
+        {"name__in": request.names},
+        request.type,
+        request.sorting,
+        request.count,
+        request.page,
         aliases=request.filter_aliases,
-        user=httpreq.state.user,
+        links_count=True,
     )
     return IndicatorSearchResponse(indicators=indicators, total=total)
 

--- a/core/web/apiv2/observables.py
+++ b/core/web/apiv2/observables.py
@@ -277,15 +277,14 @@ def search(
     httpreq: Request, request: ObservableSearchRequest
 ) -> ObservableSearchResponse:
     """Searches for observables."""
-    query = request.query
-    if request.type:
-        query["type"] = request.type
-    observables, total = Observable.filter(
-        query,
-        offset=request.page * request.count,
-        count=request.count,
-        sorting=request.sorting,
-        user=httpreq.state.user,
+    observables, total = crud.search_objects(
+        Observable,
+        httpreq,
+        request.query,
+        request.type,
+        request.sorting,
+        request.count,
+        request.page,
     )
     return ObservableSearchResponse(observables=observables, total=total)
 

--- a/tests/apiv2/indicators.py
+++ b/tests/apiv2/indicators.py
@@ -3,11 +3,13 @@ import logging
 import sys
 import time
 import unittest
+from unittest import mock
 
 from fastapi.testclient import TestClient
 
 from core import database_arango
 from core.schemas import indicator
+from core.schemas.indicator import Indicator
 from core.schemas.user import UserSensitive
 from core.web import webapp
 
@@ -122,6 +124,19 @@ class IndicatorTest(unittest.TestCase):
         self.assertEqual(len(data["indicators"][0]["tags"]), 1)
         self.assertIn("hextag", [tag["name"] for tag in data["indicators"][0]["tags"]])
 
+    def test_search_indicators_requests_link_counts(self):
+        """Indicator search should request aggregated link counts from
+        filter(), matching entity's existing behavior."""
+        with mock.patch.object(
+            Indicator, "filter", return_value=([], 0)
+        ) as mock_filter:
+            response = client.post(
+                "/api/v2/indicators/search", json={"query": {"name": "he"}}
+            )
+        self.assertEqual(response.status_code, 200)
+        mock_filter.assert_called_once()
+        self.assertTrue(mock_filter.call_args.kwargs.get("links_count"))
+
     def test_get_multiple_indicators(self):
         response = client.post(
             "/api/v2/indicators/get/multiple",
@@ -132,6 +147,19 @@ class IndicatorTest(unittest.TestCase):
         self.assertEqual(len(data["indicators"]), 2)
         names = [indicator["name"] for indicator in data["indicators"]]
         self.assertCountEqual(names, ["hex", "localhost"])
+
+    def test_get_multiple_indicators_requests_link_counts(self):
+        """get/multiple should also request aggregated link counts,
+        matching entity's existing behavior."""
+        with mock.patch.object(
+            Indicator, "filter", return_value=([], 0)
+        ) as mock_filter:
+            response = client.post(
+                "/api/v2/indicators/get/multiple", json={"names": ["hex"]}
+            )
+        self.assertEqual(response.status_code, 200)
+        mock_filter.assert_called_once()
+        self.assertTrue(mock_filter.call_args.kwargs.get("links_count"))
 
     def test_search_indicators_tagged(self):
         response = client.post(


### PR DESCRIPTION
## Summary

Final slice of item #5 (observable/entity/indicator router triplication).
Unlike the previous three slices (#1333–#1335), this one has a genuine
asymmetry to navigate: entity and indicator support `filter_aliases` and a
`/get/multiple` endpoint that observable has neither of.

Dug into `filter()` itself (`core/database_arango.py:1127`) first: it's a
single shared method already taking `aliases`/`links_count` as optional
kwargs with defaults. So the asymmetry isn't a data-layer gap — it's purely
which of those kwargs each router's endpoint chooses to forward.

## Design decision (per discussion)

- **Dedupe the endpoint bodies without changing observable's API surface**
  — no `filter_aliases`, no `get_multiple` added to it. Keeps this PR a
  pure refactor rather than bundling in a feature decision about
  observable's search capabilities.
- **Align indicator's `search`/`get_multiple` to pass `links_count=True`**,
  matching entity's existing behavior (previously indicator passed neither
  `links_count` at all). `total_links`/`aggregated_links` are already
  nullable fields on the shared `YetiModel` base every object type
  inherits, so this is a runtime-behavior-only change with **zero effect
  on the OpenAPI schema** — verified via the same byte-for-byte spec diff
  (md5) used in the previous three slices.

## Change

Added `core/web/apiv2/crud.py::search_objects()`, taking the base type, an
already-built query dict, and the `filter()` kwargs each router already
passes (`aliases`/`links_count` default to "off", matching observable's
current behavior when omitted). Each router's `search`/`get_multiple`
endpoint still builds its own initial query dict (`request.query` vs
`{"name__in": request.names}`) and its own response object — only the
type-filter + `filter()`-call + tuple-unpack tail is shared.

## Found and deliberately left out of scope

`links_count=True` doesn't actually appear to populate `total_links`/
`aggregated_links` with a meaningful value in this environment — verified
empirically that entity's search (which has **always** passed
`links_count=True`) returns `total_links: null` even when a real link
exists between the returned object and another. This isn't something my
change to indicator regresses; it's a pre-existing characteristic of the
`links_count` feature itself (possibly related to the graph traversal
running against an ArangoSearch view rather than the raw collection),
worth its own separate investigation. Because of this, the regression
tests added here assert the `filter()` call itself now requests
`links_count=True` (mocking `Indicator.filter`), rather than asserting on
the currently-unreliable computed value.

## Test plan

- [x] Added `test_search_indicators_requests_link_counts` and
      `test_get_multiple_indicators_requests_link_counts`
      (`tests/apiv2/indicators.py`) — verified both fail on the pre-fix
      router (`links_count` never passed) and pass with the fix.
- [x] `docker compose`-style OpenAPI byte-diff (md5 match, throwaway
      pre/post build) confirms zero schema change.
- [x] Full `tests/apiv2` suite: 203/205 pass (same 2 known pre-existing
      failures in `tests/apiv2/tasks.py`, unrelated).
- [x] `tests/schemas` (190/190) and `tests/core_tests` (31/31) pass
      unchanged.
- [x] `ty check` (core+yetictl and plugins jobs): 0 errors.
- [x] `ruff check` / `ruff format --check`: clean.

This closes out item #5's incremental router-dedup work (4 PRs total:
#1333, #1334, #1335, and this one) per the architecture review's original
recommendation to extract shared *behaviors* while keeping thin,
explicit, per-type endpoint declarations.