### PR TITLE
chore: add backend agent guidance and portable template tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,8 @@
 # Backend agent instructions
 
-These instructions extend the workspace-level `../AGENTS.md` for the `yeti`
-repository.
+These instructions are self-contained for a standalone `yeti` checkout. When
+the repository is part of the optional sibling Yeti workspace and
+`../AGENTS.md` exists, follow it as well for cross-repository coordination.
 
 ## Project map
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# Backend agent instructions
+
+These instructions extend the workspace-level `../AGENTS.md` for the `yeti`
+repository.
+
+## Project map
+
+- `core/web`: FastAPI application and HTTP API.
+- `core/schemas`: domain schemas and ArangoDB-backed models.
+- `core/events`: event consumers.
+- `core/migrations`: persistence migrations.
+- `plugins`: feeds, analytics, events, exports, and inline extensions.
+- `yetictl`: command-line tooling.
+- `tests`: schema, API v2, and core tests.
+
+Find and follow an existing implementation in the relevant area. Do not edit
+`private` extension directories or generated/archive data unless the task names
+them explicitly.
+
+## Toolchain and commands
+
+Use Python 3.13 and `uv`; `uv.lock`, `pyproject.toml`, and CI are authoritative.
+Do not introduce Poetry commands.
+
+- Install: `uv sync --group dev`
+- Install optional plugin dependencies: `uv sync --all-groups`
+- Lint: `uv run --no-sync ruff check .`
+- Format check: `uv run --no-sync ruff format . --check`
+- Type check: `uv run ty check --exit-zero-on-warning`
+- Focused test: `YETI_TESTING=true uv run pytest <test-path>`
+- Full local test wrapper: `make -C .. test-backend`
+
+Run focused tests while iterating, then the affected configured suites. Plugin
+type checking is a separate CI job because it requires all dependency groups;
+follow `.github/workflows/typecheck.yml` for its exact scope.
+
+The workspace test wrapper supplies the same auth and system settings as
+`.github/workflows/unittests.yml`, together with host-local service addresses
+and writable artifact paths. Outside that workspace, reproduce the workflow's
+environment before invoking pytest; a bare test command can otherwise inherit
+the container-oriented `/opt/yeti` paths from `yeti.conf.sample`.
+
+## Backend boundaries
+
+- Tests must set `YETI_TESTING=true` or explicitly connect to `yeti_test`.
+  Database fixtures truncate collections; never point them at non-test data.
+- Ask before changing database schemas, migrations, authentication semantics,
+  permission behavior, or public API contracts.
+- Preserve FastAPI/Pydantic response shapes. When the OpenAPI contract changes,
+  coordinate regeneration of the frontend schema.
+- Feeds and third-party integrations can perform network requests. Use fixtures
+  or mocks unless live access is explicitly requested.
+- Keep Ruff and `ty` ratchets at least as strict as they are now. Do not suppress
+  new diagnostics broadly to make a check pass.

--- a/tests/apiv2/templates.py
+++ b/tests/apiv2/templates.py
@@ -1,9 +1,12 @@
 import json
 import logging
+import os
 import sys
+import tempfile
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from fastapi.testclient import TestClient
 
@@ -26,6 +29,16 @@ TEST_TEMPLATE = """<blah>
 class TemplateTest(unittest.TestCase):
     def setUp(self) -> None:
         logging.disable(sys.maxsize)
+        self.addCleanup(logging.disable, logging.NOTSET)
+
+        self.temp_template_path = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.enterContext(
+            mock.patch.dict(
+                os.environ,
+                {"YETI_SYSTEM_TEMPLATE_DIR": str(self.temp_template_path)},
+            )
+        )
+
         database_arango.db.connect(database="yeti_test")
         database_arango.db.truncate()
 
@@ -35,17 +48,10 @@ class TemplateTest(unittest.TestCase):
             "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
         ).json()
         client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
-        temp_path = Path("/opt/yeti/templates")
-        temp_path.mkdir(parents=True, exist_ok=True)
-        self.temp_template_path = temp_path
 
         Template(name="FakeTemplate", template=TEST_TEMPLATE).save()
         for i in range(0, 100):
             Template(name=f"template_blah_{i:02}", template=f"fake_template_{i}").save()
-
-    def tearDown(self) -> None:
-        for file in Path(self.temp_template_path).rglob("*.jinja2"):
-            file.unlink()
 
     def test_search_template(self):
         response = client.post("/api/v2/templates/search", json={"name": "Fake"})


### PR DESCRIPTION
## Summary

- add repository-local guidance for backend agents, including the current `uv`, Ruff, `ty`, pytest, and safety conventions
- isolate template API tests in per-test temporary directories instead of writing to `/opt/yeti/templates`
- register logging and environment cleanup before failure-prone setup so state cannot leak into later tests

## Why

The backend participates in a local multi-repository workspace, but its automation guidance needs to remain accurate when the repository is used independently. During validation, the template API tests reproduced five host-only `PermissionError` failures because they assumed a container filesystem path. The test-only hardening keeps production behavior unchanged while making local validation portable.

## Validation

- `uv sync --group dev`
- `uv run --no-sync ruff check .`
- `uv run --no-sync ruff format . --check`
- `uv run ty check --exit-zero-on-warning`
- focused red/green check: `uv run pytest tests/apiv2/templates.py tests/core_tests/taskscheduler.py` (6 passed)
- CI-equivalent suites with local Redis and ArangoDB:
  - `uv run pytest tests/schemas` (190 passed)
  - `uv run pytest tests/apiv2` (205 passed)
  - `uv run pytest tests/core_tests` (31 passed)

Total: 426 tests passed. Existing dependency and serializer warnings remain unchanged.