### PR TITLE
feat: add bounded graph investigation API

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -948,7 +948,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
                 f"Cannot traverse graph '{graph}': expected one of "
                 f"{sorted(TRAVERSABLE_GRAPHS)}."
             )
-        query_filter = ""
+        query_filters = []
         args = {
             "extended_id": self.extended_id,
             "@graph": graph,
@@ -961,10 +961,10 @@ class ArangoYetiConnector(AbstractYetiConnector):
 
         if link_types:
             args["link_types"] = link_types
-            query_filter = "FILTER e.type IN @link_types"
+            query_filters.append("FILTER e.type IN @link_types")
         if target_types:
             args["target_types"] = target_types
-            query_filter = (
+            query_filters.append(
                 "FILTER (v.type IN @target_types OR v.root_type IN @target_types)"
             )
         if filter:
@@ -997,7 +997,9 @@ class ArangoYetiConnector(AbstractYetiConnector):
                     )
                 args[f"filter_key{i}"] = f.key
                 args[f"filter_value{i}"] = f.value
-            query_filter += f"FILTER {' OR '.join(filters)}"
+            query_filters.append(f"FILTER {' OR '.join(filters)}")
+
+        query_filter = "\n          ".join(query_filters)
 
         limit = ""
         if count != 0:
@@ -1135,6 +1137,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
         links_count: bool = False,
         wildcard: bool = True,
         user: "user.User | None" = None,
+        max_runtime: float | None = None,
     ) -> tuple[List[TYetiObject], int]:
         """Search in an ArangoDb collection.
 
@@ -1212,15 +1215,33 @@ class ArangoYetiConnector(AbstractYetiConnector):
                     item.value if isinstance(item, enum.Enum) else item
                     for item in value
                 ]
+            date_operator = None
+            for suffix, comparison in (
+                ("__gte", ">="),
+                ("__lte", "<="),
+                ("__gt", ">"),
+                ("__lt", "<"),
+            ):
+                if key.endswith(suffix) and key[: -len(suffix)] in {
+                    "created",
+                    "modified",
+                    "tags.expires",
+                }:
+                    key = key[: -len(suffix)]
+                    date_operator = comparison
+                    break
+
             if key.endswith("~"):
                 using_regex = True
                 key = key[:-1]
             else:
                 using_regex = False
-            if isinstance(value, str):
+            if isinstance(value, (str, int)):
                 aql_args[f"arg{i}_value"] = value
             elif isinstance(value, list):
-                aql_args[f"arg{i}_value"] = [v.strip() for v in value]
+                aql_args[f"arg{i}_value"] = [
+                    v.strip() if isinstance(v, str) else v for v in value
+                ]
 
             if key.startswith("in__"):
                 if using_view:
@@ -1244,19 +1265,24 @@ class ArangoYetiConnector(AbstractYetiConnector):
                         f"(FOR t in @arg{i}_value RETURN LOWER(t)) ALL IN o.tags[*].name"
                     )
             elif key in ("created", "modified", "tags.expires"):
-                # Value is a string, we're checking the first character.
-                operator = value[0]
-                if operator not in ["<", ">"]:
-                    operator = "="
-                else:
-                    aql_args[f"arg{i}_value"] = value[1:]
+                comparison = date_operator
+                if comparison is None:
+                    if not isinstance(value, str):
+                        raise ValueError("Date filters require string values")
+                    # The legacy vocabulary prefixes date values with < or >.
+                    operator = value[0]
+                    if operator not in ["<", ">"]:
+                        comparison = "=="
+                    else:
+                        comparison = f"{operator}="
+                        aql_args[f"arg{i}_value"] = value[1:]
                 if key == "tags.expires":
                     filter_conditions.append(
-                        f"o.tags[* RETURN DATE_TIMESTAMP(CURRENT.expires)] ANY {operator} DATE_TIMESTAMP(@arg{i}_value)"
+                        f"o.tags[* RETURN DATE_TIMESTAMP(CURRENT.expires)] ANY {comparison} DATE_TIMESTAMP(@arg{i}_value)"
                     )
                 else:
                     filter_conditions.append(
-                        f"DATE_TIMESTAMP(o.{key}) {operator}= DATE_TIMESTAMP(@arg{i}_value)"
+                        f"DATE_TIMESTAMP(o.{key}) {comparison} DATE_TIMESTAMP(@arg{i}_value)"
                     )
                     sorts.append(f"o.{key}")
             elif key in ("name", "value"):
@@ -1395,9 +1421,14 @@ class ArangoYetiConnector(AbstractYetiConnector):
             aql_string += "\nRETURN o"
         aql_args["@collection"] = colname
         logging.debug(f"aql_string: {aql_string}, aql_args: {aql_args}")
-        documents = cls._db.aql.execute(
-            aql_string, bind_vars=aql_args, count=True, full_count=True
-        )
+        execute_options: dict[str, Any] = {
+            "bind_vars": aql_args,
+            "count": True,
+            "full_count": True,
+        }
+        if max_runtime is not None:
+            execute_options["max_runtime"] = max_runtime
+        documents = cls._db.aql.execute(aql_string, **execute_options)
         stats = documents.statistics()
         results = []
         for doc in documents:

--- a/core/graph_explore.py
+++ b/core/graph_explore.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+from typing import Any, Literal, cast
+
+from arango.exceptions import AQLQueryExecuteError
+
+from core import database_arango
+from core.schemas import graph, user
+
+GRAPH_QUERY_MAX_RUNTIME_SECONDS = 10.0
+ROOT_COLLECTIONS = {
+    "observable": "observables",
+    "entity": "entities",
+    "indicator": "indicators",
+    "dfiq": "dfiq",
+}
+
+
+def _is_timeout(error: AQLQueryExecuteError) -> bool:
+    message = str(error).lower()
+    return error.error_code == 1500 or "max runtime" in message or "killed" in message
+
+
+def _execute_aql(query: str, bind_vars: dict[str, Any]) -> list[Any]:
+    try:
+        return list(
+            database_arango.db.aql.execute(
+                query,
+                bind_vars=bind_vars,
+                max_runtime=GRAPH_QUERY_MAX_RUNTIME_SECONDS,
+            )
+        )
+    except AQLQueryExecuteError as error:
+        if _is_timeout(error):
+            raise TimeoutError from error
+        raise
+
+
+def _filter_aql(filters: list[graph.GraphExploreFilter], args: dict[str, Any]) -> str:
+    clauses = []
+    for index, graph_filter in enumerate(filters):
+        key = f"filter_key_{index}"
+        value = f"filter_value_{index}"
+        args[key] = graph_filter.key
+        args[value] = graph_filter.value
+        if graph_filter.operator == "==":
+            condition = f"(edge[@{key}] == @{value} OR vertex[@{key}] == @{value})"
+        elif graph_filter.operator == "=~":
+            condition = (
+                f"(REGEX_TEST(edge[@{key}], @{value}, true) "
+                f"OR REGEX_TEST(vertex[@{key}], @{value}, true))"
+            )
+        else:
+            condition = (
+                f"(@{value} IN TO_ARRAY(edge[@{key}]) "
+                f"OR @{value} IN TO_ARRAY(vertex[@{key}]))"
+            )
+        if graph_filter.pathcompare == "NONE":
+            condition = f"NOT {condition}"
+        clauses.append(f"FILTER {condition}")
+    return "\n                ".join(clauses)
+
+
+def _item_rows(
+    request: graph.GraphExploreRequest,
+    scope: graph.GraphExploreItemScope,
+    current_user: user.User,
+) -> dict[str, list[dict[str, Any]]]:
+    args: dict[str, Any] = {
+        "anchor_ids": scope.items,
+        "rbac_bypass": (not database_arango.RBAC_ENABLED or bool(current_user.admin)),
+        "username": current_user.username,
+        # In an ANY traversal, a relationship between two anchors can be
+        # returned once from each endpoint. Fetch enough rows to observe one
+        # unique relationship beyond the requested budget after de-duplication.
+        "row_limit": 2 * (request.requested_limits.edges + 1),
+    }
+    link_filter = ""
+    if request.link_types:
+        args["link_types"] = request.link_types
+        link_filter = "FILTER edge.type IN @link_types"
+    target_filter = (
+        "FILTER vertex.type IN @target_types OR vertex.root_type IN @target_types"
+        if request.target_types
+        else ""
+    )
+    if request.target_types:
+        args["target_types"] = request.target_types
+    graph_filters = _filter_aql(request.filters, args)
+    direction = request.direction.upper()
+    query = f"""
+        WITH observables, entities, indicators, dfiq, acls
+        LET anchors = (
+            FOR anchor_id IN @anchor_ids
+                LET anchor = DOCUMENT(anchor_id)
+                FILTER anchor != null
+                FILTER @rbac_bypass OR LENGTH(
+                    FOR principal IN 1..2 INBOUND anchor acls
+                        FILTER principal.username == @username
+                        LIMIT 1
+                        RETURN 1
+                ) > 0
+                RETURN KEEP(
+                    anchor, "_id", "root_type", "type", "name", "value"
+                )
+        )
+        LET rows = (
+            FOR origin IN anchors
+                LET origin_index = POSITION(@anchor_ids, origin._id)
+                FOR vertex, edge IN 1..1 {direction} origin links
+                FILTER @rbac_bypass OR LENGTH(
+                    FOR principal IN 1..2 INBOUND vertex acls
+                        FILTER principal.username == @username
+                        LIMIT 1
+                        RETURN 1
+                ) > 0
+                {link_filter}
+                {target_filter}
+                {graph_filters}
+                SORT origin_index ASC, edge._id ASC
+                LIMIT @row_limit
+                RETURN {{
+                    origin_id: origin._id,
+                    vertex: KEEP(
+                        vertex, "_id", "root_type", "type", "name", "value"
+                    ),
+                    edge: KEEP(
+                        edge, "_id", "_from", "_to", "type", "description", "count"
+                    )
+                }}
+        )
+        RETURN {{anchors, rows}}
+    """
+    result = _execute_aql(query, args)
+    return result[0] if result else {"anchors": [], "rows": []}
+
+
+def _extended_id(document: dict[str, Any]) -> str:
+    root_type = str(document.get("root_type", ""))
+    collection = ROOT_COLLECTIONS.get(root_type)
+    if collection is None:
+        raise ValueError("Unsupported object type in query scope")
+    return f"{collection}/{document['id']}"
+
+
+def _induced_edges(
+    ids: list[str], request: graph.GraphExploreRequest
+) -> list[dict[str, Any]]:
+    if not ids:
+        return []
+    args: dict[str, Any] = {
+        "ids": ids,
+        "row_limit": request.requested_limits.edges + 1,
+    }
+    link_filter = ""
+    if request.link_types:
+        args["link_types"] = request.link_types
+        link_filter = "FILTER edge.type IN @link_types"
+    target_filter = (
+        "FILTER vertex.type IN @target_types OR vertex.root_type IN @target_types"
+        if request.target_types
+        else ""
+    )
+    if request.target_types:
+        args["target_types"] = request.target_types
+    graph_filters = _filter_aql(request.filters, args)
+    query = f"""
+        WITH observables, entities, indicators, dfiq
+        FOR edge IN links
+            FILTER edge._from IN @ids AND edge._to IN @ids
+            LET vertex = DOCUMENT(edge._to)
+            {link_filter}
+            {target_filter}
+            {graph_filters}
+            SORT edge._id ASC
+            LIMIT @row_limit
+            RETURN KEEP(
+                edge, "_id", "_from", "_to", "type", "description", "count"
+            )
+    """
+    return _execute_aql(query, args)
+
+
+def _node(
+    document: dict[str, Any],
+    role: Literal["anchor", "scope_match", "neighbor"],
+    origin_ids: list[str],
+) -> graph.GraphExploreNode:
+    identifier = str(document.get("_id") or _extended_id(document))
+    label = next(
+        (
+            str(document[field])
+            for field in ("value", "name")
+            if document.get(field) not in (None, "")
+        ),
+        identifier,
+    )
+    return graph.GraphExploreNode(
+        id=identifier,
+        label=label,
+        root_type=str(document.get("root_type", "unknown")),
+        object_type=str(document.get("type") or document.get("root_type", "unknown")),
+        role=role,
+        origin_ids=origin_ids,
+    )
+
+
+def _edge(document: dict[str, Any]) -> graph.GraphExploreEdge:
+    return graph.GraphExploreEdge(
+        id=str(document["_id"]),
+        source=str(document["_from"]),
+        target=str(document["_to"]),
+        type=str(document.get("type", "related")),
+        description=str(document.get("description", "")),
+        count=int(document.get("count", 1)),
+    )
+
+
+def _budget(
+    request: graph.GraphExploreRequest,
+    nodes: list[graph.GraphExploreNode],
+    edges: list[graph.GraphExploreEdge],
+    reasons: set[str],
+) -> graph.GraphExploreBudget:
+    ordered_reasons = [
+        cast("Any", reason)
+        for reason in ("node_limit", "edge_limit")
+        if reason in reasons
+    ]
+    return graph.GraphExploreBudget(
+        node_limit=request.requested_limits.nodes,
+        edge_limit=request.requested_limits.edges,
+        returned_nodes=len(nodes),
+        returned_edges=len(edges),
+        is_truncated=bool(ordered_reasons),
+        reasons=ordered_reasons,
+    )
+
+
+def _explore_items(
+    request: graph.GraphExploreRequest,
+    scope: graph.GraphExploreItemScope,
+    current_user: user.User,
+) -> graph.GraphExploreResponse:
+    result = _item_rows(request, scope, current_user)
+    anchors = result["anchors"]
+    if [anchor["_id"] for anchor in anchors] != scope.items:
+        raise LookupError
+
+    reasons: set[str] = set()
+    node_limit = request.requested_limits.nodes
+    edge_limit = request.requested_limits.edges
+    nodes_by_id: dict[str, graph.GraphExploreNode] = {}
+    anchor_ids = set(scope.items)
+    for anchor in anchors:
+        if len(nodes_by_id) >= node_limit:
+            reasons.add("node_limit")
+            break
+        identifier = str(anchor["_id"])
+        nodes_by_id[identifier] = _node(anchor, "anchor", [identifier])
+
+    edges_by_id: dict[str, graph.GraphExploreEdge] = {}
+    rows = result["rows"]
+    for row in rows:
+        edge = _edge(row["edge"])
+        if edge.id not in edges_by_id and len(edges_by_id) >= edge_limit:
+            reasons.add("edge_limit")
+            continue
+
+        origin_id = str(row["origin_id"])
+        vertex = row["vertex"]
+        vertex_id = str(vertex["_id"])
+        existing = nodes_by_id.get(vertex_id)
+        if existing is not None:
+            if origin_id not in existing.origin_ids:
+                existing.origin_ids.append(origin_id)
+        elif len(nodes_by_id) < node_limit:
+            role = "anchor" if vertex_id in anchor_ids else "neighbor"
+            origins = [vertex_id] if role == "anchor" else []
+            if origin_id not in origins:
+                origins.append(origin_id)
+            nodes_by_id[vertex_id] = _node(vertex, role, origins)
+        else:
+            reasons.add("node_limit")
+            continue
+
+        if edge.source not in nodes_by_id or edge.target not in nodes_by_id:
+            continue
+        if edge.id in edges_by_id:
+            continue
+        edges_by_id[edge.id] = edge
+
+    nodes = list(nodes_by_id.values())
+    edges = list(edges_by_id.values())
+    return graph.GraphExploreResponse(
+        scope=graph.GraphExploreScopeResult(
+            kind="items",
+            anchor_ids=scope.items,
+            accessible_match_count=len(scope.items),
+            ranking=None,
+        ),
+        nodes=nodes,
+        edges=edges,
+        budget=_budget(request, nodes, edges, reasons),
+    )
+
+
+def _explore_query(
+    request: graph.GraphExploreRequest,
+    scope: graph.GraphExploreQueryScope,
+    current_user: user.User,
+) -> graph.GraphExploreResponse:
+    ranking = list(scope.sorting) if scope.sorting else [("modified", False)]
+    if not any(field == "_id" for field, _ in ranking):
+        ranking.append(("_id", True))
+    try:
+        candidates, total = database_arango.ArangoYetiConnector.filter(
+            scope.query,
+            sorting=ranking,
+            aliases=cast("list[tuple[str, str]]", scope.filter_aliases),
+            count=request.requested_limits.nodes + 1,
+            user=current_user,
+            max_runtime=GRAPH_QUERY_MAX_RUNTIME_SECONDS,
+        )
+    except AQLQueryExecuteError as error:
+        if _is_timeout(error):
+            raise TimeoutError from error
+        raise
+    documents = cast("list[dict[str, Any]]", candidates)
+    reasons: set[str] = set()
+    if total > request.requested_limits.nodes:
+        reasons.add("node_limit")
+    documents = documents[: request.requested_limits.nodes]
+    nodes = [
+        _node(document, "scope_match", [_extended_id(document)])
+        for document in documents
+    ]
+    edges_raw = _induced_edges([node.id for node in nodes], request)
+    if len(edges_raw) > request.requested_limits.edges:
+        reasons.add("edge_limit")
+    edges = [
+        _edge(document) for document in edges_raw[: request.requested_limits.edges]
+    ]
+    return graph.GraphExploreResponse(
+        scope=graph.GraphExploreScopeResult(
+            kind="query",
+            anchor_ids=[],
+            accessible_match_count=total,
+            ranking=ranking,
+        ),
+        nodes=nodes,
+        edges=edges,
+        budget=_budget(request, nodes, edges, reasons),
+    )
+
+
+def explore_graph(
+    request: graph.GraphExploreRequest, current_user: user.User
+) -> graph.GraphExploreResponse:
+    if isinstance(request.scope, graph.GraphExploreItemScope):
+        return _explore_items(request, request.scope, current_user)
+    return _explore_query(request, request.scope, current_user)

--- a/core/schemas/graph.py
+++ b/core/schemas/graph.py
@@ -1,7 +1,15 @@
 import datetime
-from typing import ClassVar, Literal
+import re
+from typing import Annotated, ClassVar, Literal
 
-from pydantic import BaseModel, ConfigDict, computed_field
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    computed_field,
+    field_validator,
+    model_validator,
+)
 
 from core import database_arango
 from core.schemas import roles
@@ -15,6 +23,152 @@ class GraphFilter(BaseModel):
     value: str
     operator: str
     pathcompare: str = "ANY"
+
+
+class GraphExploreFilter(BaseModel):
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    key: str
+    value: str
+    operator: Literal["=~", "==", "in"] = "=="
+    pathcompare: Literal["ANY", "ALL", "NONE"] = "ANY"
+
+    @field_validator("key")
+    @classmethod
+    def validate_key(cls, value: str) -> str:
+        if not re.fullmatch(r"[a-zA-Z0-9_.]+", value):
+            raise ValueError("filter key contains unsupported characters")
+        return value
+
+
+class GraphExploreItemScope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["items"] = "items"
+    items: Annotated[list[str], Field(min_length=1, max_length=100)]
+
+    @field_validator("items")
+    @classmethod
+    def validate_items(cls, values: list[str]) -> list[str]:
+        deduplicated = list(dict.fromkeys(values))
+        for value in deduplicated:
+            if not re.fullmatch(
+                r"(?:observables|entities|indicators|dfiq)/[a-zA-Z0-9_:-]+", value
+            ):
+                raise ValueError("items must contain valid Yeti extended IDs")
+        return deduplicated
+
+
+GraphQueryValue = str | int | list[str | int]
+
+
+class GraphExploreQueryScope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["query"] = "query"
+    query: dict[str, GraphQueryValue] = Field(default_factory=dict)
+    sorting: list[tuple[str, bool]] = Field(default_factory=list, max_length=10)
+    filter_aliases: list[tuple[str, Literal["text", "option", "list"]]] = Field(
+        default_factory=list, max_length=20
+    )
+
+    @model_validator(mode="after")
+    def validate_fields(self):
+        safe_field = re.compile(r"[a-zA-Z0-9_.~]+")
+        for field in self.query:
+            if not safe_field.fullmatch(field):
+                raise ValueError("query field contains unsupported characters")
+        for field, _ in self.sorting:
+            if not safe_field.fullmatch(field):
+                raise ValueError("sort field contains unsupported characters")
+        for field, _ in self.filter_aliases:
+            if not safe_field.fullmatch(field):
+                raise ValueError("filter alias contains unsupported characters")
+        return self
+
+
+GraphExploreScope = Annotated[
+    GraphExploreItemScope | GraphExploreQueryScope, Field(discriminator="kind")
+]
+
+
+class GraphExploreLimits(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    nodes: int = Field(default=2000, ge=1, le=5000)
+    edges: int = Field(default=10000, ge=0, le=25000)
+
+
+class GraphExploreRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    scope: GraphExploreScope
+    direction: Literal["any", "inbound", "outbound"] = "any"
+    link_types: list[str] = Field(default_factory=list, max_length=100)
+    target_types: list[str] = Field(default_factory=list, max_length=100)
+    filters: list[GraphExploreFilter] = Field(default_factory=list, max_length=20)
+    requested_limits: GraphExploreLimits = Field(default_factory=GraphExploreLimits)
+
+    @model_validator(mode="after")
+    def validate_item_budget(self):
+        if isinstance(
+            self.scope, GraphExploreItemScope
+        ) and self.requested_limits.nodes < len(self.scope.items):
+            raise ValueError("node limit must accommodate every requested item")
+        return self
+
+
+class GraphExploreScopeResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["items", "query"]
+    anchor_ids: list[str]
+    accessible_match_count: int = Field(ge=0)
+    ranking: list[tuple[str, bool]] | None = None
+
+
+class GraphExploreNode(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    label: str
+    root_type: str
+    object_type: str
+    role: Literal["anchor", "scope_match", "neighbor"]
+    origin_ids: list[str]
+
+
+class GraphExploreEdge(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    source: str
+    target: str
+    type: str
+    description: str
+    count: int = Field(ge=0)
+
+
+class GraphExploreBudget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    node_limit: int
+    edge_limit: int
+    returned_nodes: int
+    returned_edges: int
+    is_truncated: bool
+    reasons: list[Literal["node_limit", "edge_limit"]]
+
+
+class GraphExploreResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal[1] = 1
+    scope: GraphExploreScopeResult
+    nodes: list[GraphExploreNode]
+    edges: list[GraphExploreEdge]
+    budget: GraphExploreBudget
 
 
 # Relationship and TagRelationship do not inherit from YetiModel

--- a/core/web/apiv2/graph.py
+++ b/core/web/apiv2/graph.py
@@ -1,4 +1,6 @@
 import datetime
+import logging
+import time
 from enum import Enum
 from typing import Annotated, Any
 
@@ -6,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, model_validator
 from pydantic.functional_validators import field_validator
 
+from core.graph_explore import explore_graph
 from core.schemas import (
     dfiq,
     entity,
@@ -19,6 +22,8 @@ from core.schemas import (
 )
 from core.schemas.graph import GraphFilter
 from core.schemas.tag import MAX_TAGS_REQUEST
+
+logger = logging.getLogger(__name__)
 
 GRAPH_TYPE_MAPPINGS = {}  # type: dict[str, Type[entity.Entity] | Type[observable.Observable] | Type[indicator.Indicator]]
 GRAPH_TYPE_MAPPINGS.update(observable.TYPE_MAPPING)
@@ -172,6 +177,61 @@ def search(httpreq: Request, request: GraphSearchRequest) -> GraphSearchResponse
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error))
     return GraphSearchResponse(vertices=vertices, paths=paths, total=total)
+
+
+@router.post("/explore")
+def explore(
+    httpreq: Request, request: graph.GraphExploreRequest
+) -> graph.GraphExploreResponse:
+    """Return a bounded, read-only graph for an investigation scope."""
+    started = time.monotonic()
+    outcome = "success"
+    returned_nodes = 0
+    returned_edges = 0
+    is_truncated = False
+    try:
+        response = explore_graph(request, httpreq.state.user)
+        returned_nodes = response.budget.returned_nodes
+        returned_edges = response.budget.returned_edges
+        is_truncated = response.budget.is_truncated
+        return response
+    except LookupError:
+        outcome = "unavailable"
+        raise HTTPException(
+            status_code=404,
+            detail="One or more requested objects are unavailable",
+        ) from None
+    except TimeoutError:
+        outcome = "timeout"
+        raise HTTPException(
+            status_code=503,
+            detail="Graph exploration timed out; retry later",
+        ) from None
+    except ValueError:
+        outcome = "unsupported"
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported graph exploration criteria",
+        ) from None
+    except Exception:
+        outcome = "error"
+        logger.error("Graph exploration failed")
+        raise HTTPException(
+            status_code=500,
+            detail="Graph exploration failed",
+        ) from None
+    finally:
+        logger.info(
+            "Graph exploration completed",
+            extra={
+                "scope_kind": request.scope.kind,
+                "outcome": outcome,
+                "duration_ms": round((time.monotonic() - started) * 1000, 2),
+                "returned_nodes": returned_nodes,
+                "returned_edges": returned_edges,
+                "is_truncated": is_truncated,
+            },
+        )
 
 
 @router.post("/add")

--- a/core/web/webapp.py
+++ b/core/web/webapp.py
@@ -159,7 +159,8 @@ app.include_router(api_router, prefix="/api/v2")
 
 @app.middleware("http")
 async def log_requests(request: Request, call_next):
-    req_body = await request.body()
+    suppress_body = request.url.path == "/api/v2/graph/explore"
+    req_body = b"" if suppress_body else await request.body()
     response = await call_next(request)
     try:
         extra = {

--- a/tests/apiv2/graph.py
+++ b/tests/apiv2/graph.py
@@ -291,6 +291,28 @@ class SimpleGraphTest(unittest.TestCase):
             data["vertices"][self.observable2.extended_id]["value"], "127.0.0.1"
         )
 
+    def test_neighbors_combines_link_and_target_types(self):
+        self.entity1.link_to(self.observable1, "resolves", "Wrong relationship")
+        self.entity1.link_to(self.observable2, "uses", "Wrong target type")
+
+        response = client.post(
+            "/api/v2/graph/search",
+            json={
+                "source": self.entity1.extended_id,
+                "hops": 1,
+                "graph": "links",
+                "direction": "any",
+                "link_types": ["uses"],
+                "target_types": ["hostname"],
+                "include_original": False,
+            },
+        )
+
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertEqual(data["vertices"], {})
+        self.assertEqual(data["paths"], [])
+
     def test_neighbors_filter(self):
         self.entity1.link_to(self.observable1, "uses", "asd")
         self.entity1.link_to(self.observable2, "uses", "asd")

--- a/tests/apiv2/graph_explore.py
+++ b/tests/apiv2/graph_explore.py
@@ -1,0 +1,427 @@
+import logging
+import sys
+import time
+import unittest
+from unittest import mock
+
+from arango.exceptions import AQLQueryExecuteError
+from fastapi.testclient import TestClient
+
+from core import database_arango, graph_explore
+from core.schemas import rbac, roles
+from core.schemas.entity import ThreatActor
+from core.schemas.observables.hostname import Hostname
+from core.schemas.user import UserSensitive
+from core.web import webapp
+
+client = TestClient(webapp.app)
+
+
+def item_request(items: list[str], **overrides):
+    request = {
+        "schema_version": 1,
+        "scope": {"kind": "items", "items": items},
+        "direction": "any",
+        "link_types": [],
+        "target_types": [],
+        "filters": [],
+        "requested_limits": {"nodes": 2000, "edges": 10000},
+    }
+    request.update(overrides)
+    return request
+
+
+def query_request(query: dict, **scope_overrides):
+    scope = {
+        "kind": "query",
+        "query": query,
+        "sorting": [],
+        "filter_aliases": [],
+    }
+    scope.update(scope_overrides)
+    return {
+        "schema_version": 1,
+        "scope": scope,
+        "direction": "any",
+        "link_types": [],
+        "target_types": [],
+        "filters": [],
+        "requested_limits": {"nodes": 2000, "edges": 10000},
+    }
+
+
+class GraphExploreTest(unittest.TestCase):
+    def setUp(self) -> None:
+        logging.disable(sys.maxsize)
+        database_arango.db.connect(database="yeti_test")
+        database_arango.db.truncate()
+        self.user = UserSensitive(
+            username="graph-explore", password="test", enabled=True
+        ).save()
+        api_key = self.user.create_api_key("default")
+        token_data = client.post(
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": api_key}
+        ).json()
+        client.headers = {"Authorization": f"Bearer {token_data['access_token']}"}
+
+    def tearDown(self) -> None:
+        database_arango.RBAC_ENABLED = False
+        rbac.RBAC_ENABLED = False
+        database_arango.db.truncate()
+        client.headers = {}
+        logging.disable(logging.NOTSET)
+
+    def test_item_scope_deduplicates_anchors_and_preserves_provenance(self):
+        anchor_a = ThreatActor(name="anchor-a").save()
+        anchor_b = ThreatActor(name="anchor-b").save()
+        neighbor = Hostname(value="shared.example").save()
+        edge_a = anchor_a.link_to(neighbor, "resolves", "first path")
+        edge_b = anchor_b.link_to(neighbor, "uses", "second path")
+
+        response = client.post(
+            "/api/v2/graph/explore",
+            json=item_request(
+                [anchor_a.extended_id, anchor_a.extended_id, anchor_b.extended_id]
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        data = response.json()
+        self.assertEqual(
+            data["scope"]["anchor_ids"],
+            [anchor_a.extended_id, anchor_b.extended_id],
+        )
+        nodes = {node["id"]: node for node in data["nodes"]}
+        self.assertEqual(nodes[anchor_a.extended_id]["role"], "anchor")
+        self.assertEqual(nodes[neighbor.extended_id]["role"], "neighbor")
+        self.assertEqual(
+            nodes[neighbor.extended_id]["origin_ids"],
+            [anchor_a.extended_id, anchor_b.extended_id],
+        )
+        self.assertEqual(
+            {edge["id"] for edge in data["edges"]},
+            {f"links/{edge_a.id}", f"links/{edge_b.id}"},
+        )
+
+    def test_item_scope_fails_atomically_when_any_anchor_is_missing(self):
+        anchor = ThreatActor(name="available").save()
+
+        response = client.post(
+            "/api/v2/graph/explore",
+            json=item_request([anchor.extended_id, "entities/missing"]),
+        )
+
+        self.assertEqual(response.status_code, 404, response.json())
+        self.assertEqual(
+            response.json()["detail"],
+            "One or more requested objects are unavailable",
+        )
+        self.assertNotIn(anchor.extended_id, response.text)
+
+    def test_item_scope_fails_atomically_for_an_inaccessible_anchor(self):
+        available = ThreatActor(name="available").save()
+        hidden = ThreatActor(name="hidden").save()
+        self.user.link_to_acl(available, roles.Role.READER)
+        rbac.RBAC_ENABLED = True
+        database_arango.RBAC_ENABLED = True
+
+        response = client.post(
+            "/api/v2/graph/explore",
+            json=item_request([available.extended_id, hidden.extended_id]),
+        )
+
+        self.assertEqual(response.status_code, 404, response.json())
+        self.assertNotIn(hidden.extended_id, response.text)
+
+    def test_item_scope_composes_relationship_and_target_filters(self):
+        anchor = ThreatActor(name="anchor").save()
+        hostname = Hostname(value="host.example").save()
+        other = ThreatActor(name="other").save()
+        anchor.link_to(hostname, "resolves", "wrong relationship")
+        anchor.link_to(other, "uses", "wrong target")
+
+        response = client.post(
+            "/api/v2/graph/explore",
+            json=item_request(
+                [anchor.extended_id],
+                link_types=["uses"],
+                target_types=["hostname"],
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(
+            [node["id"] for node in response.json()["nodes"]], [anchor.extended_id]
+        )
+        self.assertEqual(response.json()["edges"], [])
+
+    def test_item_scope_preserves_directed_parallel_relationships(self):
+        anchor = ThreatActor(name="anchor").save()
+        neighbor = Hostname(value="parallel.example").save()
+        first = anchor.link_to(neighbor, "resolves", "first observation")
+        second = anchor.link_to(neighbor, "uses", "second observation")
+
+        response = client.post(
+            "/api/v2/graph/explore", json=item_request([anchor.extended_id])
+        )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        edges = {edge["id"]: edge for edge in response.json()["edges"]}
+        self.assertEqual(set(edges), {f"links/{first.id}", f"links/{second.id}"})
+        self.assertEqual(
+            {(edge["source"], edge["target"]) for edge in edges.values()},
+            {(anchor.extended_id, neighbor.extended_id)},
+        )
+
+    def test_item_scope_does_not_return_an_inaccessible_neighbor_or_edge(self):
+        anchor = ThreatActor(name="available").save()
+        hidden = Hostname(value="hidden.example").save()
+        anchor.link_to(hidden, "resolves", "hidden relationship")
+        self.user.link_to_acl(anchor, roles.Role.READER)
+        rbac.RBAC_ENABLED = True
+        database_arango.RBAC_ENABLED = True
+
+        response = client.post(
+            "/api/v2/graph/explore", json=item_request([anchor.extended_id])
+        )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(
+            [node["id"] for node in response.json()["nodes"]], [anchor.extended_id]
+        )
+        self.assertEqual(response.json()["edges"], [])
+        self.assertNotIn(hidden.extended_id, response.text)
+
+    def test_query_scope_is_stable_and_returns_induced_edges(self):
+        actor_b = ThreatActor(name="bravo").save()
+        actor_a = ThreatActor(name="alpha").save()
+        relationship = actor_b.link_to(actor_a, "targets", "ordered evidence")
+        Hostname(value="outside.example").save()
+
+        response = client.post(
+            "/api/v2/graph/explore",
+            json=query_request({"root_type": "entity"}, sorting=[["name", True]]),
+        )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        data = response.json()
+        self.assertEqual(data["scope"]["accessible_match_count"], 2)
+        self.assertEqual([node["label"] for node in data["nodes"]], ["alpha", "bravo"])
+        self.assertTrue(all(node["role"] == "scope_match" for node in data["nodes"]))
+        self.assertEqual(data["edges"][0]["id"], f"links/{relationship.id}")
+        self.assertEqual(data["scope"]["ranking"], [["name", True], ["_id", True]])
+
+    def test_query_scope_can_return_an_empty_graph(self):
+        response = client.post(
+            "/api/v2/graph/explore",
+            json=query_request({"name": "does-not-exist"}),
+        )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(response.json()["nodes"], [])
+        self.assertEqual(response.json()["edges"], [])
+        self.assertEqual(response.json()["scope"]["accessible_match_count"], 0)
+
+    def test_query_scope_supports_a_time_range(self):
+        old = ThreatActor(name="old").save()
+        new = ThreatActor(name="new").save()
+        entities = database_arango.db.collection("entities")
+        entities.update({"_key": old.id, "modified": "2020-06-01T00:00:00Z"})
+        entities.update({"_key": new.id, "modified": "2024-06-01T00:00:00Z"})
+
+        response = client.post(
+            "/api/v2/graph/explore",
+            json=query_request(
+                {
+                    "root_type": "entity",
+                    "modified__gte": "2020-01-01",
+                    "modified__lte": "2020-12-31",
+                }
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(
+            [node["id"] for node in response.json()["nodes"]], [old.extended_id]
+        )
+
+    def test_query_scope_supports_tags_and_concrete_types(self):
+        tagged = Hostname(value="tagged.example").save()
+        tagged.tag(["graph-scope"])
+        Hostname(value="untagged.example").save()
+        time.sleep(0.5)
+
+        response = client.post(
+            "/api/v2/graph/explore",
+            json=query_request({"tags": ["graph-scope"], "type": "hostname"}),
+        )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(
+            [node["id"] for node in response.json()["nodes"]], [tagged.extended_id]
+        )
+
+    def test_query_scope_totals_and_edges_are_rbac_filtered(self):
+        visible = ThreatActor(name="visible").save()
+        hidden = ThreatActor(name="hidden").save()
+        visible.link_to(hidden, "related", "must not leak")
+        self.user.link_to_acl(visible, roles.Role.READER)
+        rbac.RBAC_ENABLED = True
+        database_arango.RBAC_ENABLED = True
+
+        response = client.post(
+            "/api/v2/graph/explore", json=query_request({"root_type": "entity"})
+        )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(response.json()["scope"]["accessible_match_count"], 1)
+        self.assertEqual(
+            [node["id"] for node in response.json()["nodes"]], [visible.extended_id]
+        )
+        self.assertEqual(response.json()["edges"], [])
+        self.assertNotIn(hidden.extended_id, response.text)
+
+    def test_item_scope_reports_node_budget_truncation(self):
+        anchor = ThreatActor(name="anchor").save()
+        anchor.link_to(Hostname(value="one.example").save(), "resolves", "one")
+        anchor.link_to(Hostname(value="two.example").save(), "resolves", "two")
+        request = item_request([anchor.extended_id])
+        request["requested_limits"] = {"nodes": 2, "edges": 10000}
+
+        response = client.post("/api/v2/graph/explore", json=request)
+
+        self.assertEqual(response.status_code, 200, response.json())
+        budget = response.json()["budget"]
+        self.assertEqual(budget["returned_nodes"], 2)
+        self.assertTrue(budget["is_truncated"])
+        self.assertIn("node_limit", budget["reasons"])
+
+    def test_zero_edge_budget_does_not_return_orphan_neighbors(self):
+        anchor = ThreatActor(name="anchor").save()
+        anchor.link_to(Hostname(value="neighbor.example").save(), "resolves", "one")
+        request = item_request([anchor.extended_id])
+        request["requested_limits"] = {"nodes": 2, "edges": 0}
+
+        response = client.post("/api/v2/graph/explore", json=request)
+
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(
+            [node["id"] for node in response.json()["nodes"]], [anchor.extended_id]
+        )
+        self.assertEqual(response.json()["edges"], [])
+        self.assertEqual(response.json()["budget"]["reasons"], ["edge_limit"])
+
+    def test_item_scope_deduplicates_rows_before_applying_edge_budget(self):
+        anchors = [ThreatActor(name=f"anchor-{index}").save() for index in range(4)]
+        neighbor = Hostname(value="last.example").save()
+        first = anchors[0].link_to(anchors[1], "related", "first")
+        second = anchors[2].link_to(anchors[3], "related", "second")
+        third = anchors[3].link_to(neighbor, "resolves", "third")
+        request = item_request([anchor.extended_id for anchor in anchors])
+        request["requested_limits"] = {"nodes": 5, "edges": 3}
+
+        response = client.post("/api/v2/graph/explore", json=request)
+
+        self.assertEqual(response.status_code, 200, response.json())
+        self.assertEqual(
+            {edge["id"] for edge in response.json()["edges"]},
+            {f"links/{first.id}", f"links/{second.id}", f"links/{third.id}"},
+        )
+        self.assertFalse(response.json()["budget"]["is_truncated"])
+
+    def test_limits_and_scope_shape_are_strict(self):
+        anchor = ThreatActor(name="anchor").save()
+        second_anchor = ThreatActor(name="second-anchor").save()
+        over_limit = item_request([anchor.extended_id])
+        over_limit["requested_limits"]["nodes"] = 5001
+        undersized_limit = item_request([anchor.extended_id, second_anchor.extended_id])
+        undersized_limit["requested_limits"]["nodes"] = 1
+        extra_field = item_request([anchor.extended_id])
+        extra_field["scope"]["source"] = anchor.extended_id
+
+        self.assertEqual(
+            client.post("/api/v2/graph/explore", json=over_limit).status_code, 422
+        )
+        self.assertEqual(
+            client.post("/api/v2/graph/explore", json=extra_field).status_code, 422
+        )
+        self.assertEqual(
+            client.post("/api/v2/graph/explore", json=undersized_limit).status_code,
+            422,
+        )
+
+    def test_timeout_during_cursor_iteration_is_normalized(self):
+        timeout = AQLQueryExecuteError.__new__(AQLQueryExecuteError)
+        Exception.__init__(timeout, "query killed")
+        timeout.error_code = 1500
+
+        class TimedOutCursor:
+            def __iter__(self):
+                raise timeout
+
+        fake_database = mock.Mock()
+        fake_database.aql.execute.return_value = TimedOutCursor()
+        with mock.patch.object(database_arango, "db", fake_database):
+            with self.assertRaises(TimeoutError):
+                graph_explore._execute_aql("RETURN 1", {})
+
+    def test_timeout_returns_generic_retryable_error(self):
+        anchor = ThreatActor(name="anchor").save()
+
+        with mock.patch(
+            "core.web.apiv2.graph.explore_graph",
+            side_effect=TimeoutError,
+        ):
+            response = client.post(
+                "/api/v2/graph/explore", json=item_request([anchor.extended_id])
+            )
+
+        self.assertEqual(response.status_code, 503, response.json())
+        self.assertEqual(
+            response.json()["detail"], "Graph exploration timed out; retry later"
+        )
+        self.assertNotIn(anchor.extended_id, response.text)
+
+    def test_request_audit_suppresses_explore_body(self):
+        anchor = ThreatActor(name="sensitive-anchor").save()
+
+        with mock.patch.object(webapp.logger, "info") as audit_info:
+            response = client.post(
+                "/api/v2/graph/explore", json=item_request([anchor.extended_id])
+            )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        explore_calls = [
+            call
+            for call in audit_info.call_args_list
+            if call.kwargs.get("extra", {}).get("path") == "/api/v2/graph/explore"
+        ]
+        self.assertEqual(len(explore_calls), 1)
+        self.assertEqual(explore_calls[0].kwargs["extra"]["body"], b"")
+
+    def test_operation_log_contains_only_sanitized_graph_metadata(self):
+        anchor = ThreatActor(name="sensitive-anchor").save()
+
+        with mock.patch("core.web.apiv2.graph.logger.info") as operation_info:
+            response = client.post(
+                "/api/v2/graph/explore", json=item_request([anchor.extended_id])
+            )
+
+        self.assertEqual(response.status_code, 200, response.json())
+        metadata = operation_info.call_args.kwargs["extra"]
+        self.assertEqual(
+            set(metadata),
+            {
+                "scope_kind",
+                "outcome",
+                "duration_ms",
+                "returned_nodes",
+                "returned_edges",
+                "is_truncated",
+            },
+        )
+        self.assertNotIn(anchor.extended_id, str(metadata))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add strict POST /api/v2/graph/explore item and query scopes
- enforce atomic RBAC, one-hop traversal, compact projections, stable ordering, and node/edge/runtime budgets
- preserve directed parallel relationships and fix composed legacy graph filters
- emit sanitized operational metadata while suppressing request bodies

## Dependency

Stacked on #1337. Merge or rebase that prerequisite before changing this PR base to main.

## Validation

- make check-backend
- make test-backend: 190 schema, 225 API, and 31 core tests passed
- disposable real-stack suite: 10 passed

## Security and data handling

Explicit item scopes fail atomically when any item is absent or inaccessible. Query totals, nodes, and induced edges are RBAC filtered. AQL values use bind variables; response, anchor, hop, and runtime limits are server enforced. Logs omit IDs, criteria, labels, descriptions, credentials, and request bodies. Tests use synthetic data only.

## Rollback

Revert the additive endpoint commit. No database migration or persistence-schema change is involved.