### PR TITLE
Add GET /system/types: dynamic list of every creatable object type

### DIFF
--- a/core/web/apiv2/system.py
+++ b/core/web/apiv2/system.py
@@ -1,12 +1,81 @@
+from collections.abc import Mapping
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, ConfigDict
 
 from core.config.config import yeti_config
+from core.schemas import dfiq, entity, indicator, observable
 from core.taskscheduler import app
 from core.web.apiv2.auth import get_current_active_user
 
 # API endpoints
 router = APIRouter()
+
+_OBSERVABLE_LABELS = {
+    "generic": "Generic observable",
+    "ipv6": "IPv6",
+    "ipv4": "IPv4",
+    "hostname": "Hostname",
+    "url": "Url",
+    "file": "File",
+    "sha256": "SHA256",
+    "md5": "MD5",
+    "sha1": "SHA1",
+    "asn": "ASN",
+    "wallet": "Wallet",
+    "certificate": "Certificate",
+    "cidr": "CIDR",
+    "mac_address": "Mac Address",
+    "command_line": "Command Line",
+    "registry_key": "Registry Key",
+    "imphash": "Imphash",
+    "tlsh": "TLSH",
+    "ssdeep": "SSDEEP",
+    "email": "Email",
+    "path": "Filesystem path",
+    "container_image": "Container Image",
+    "docker_image": "Docker Image",
+    "user_agent": "User-Agent",
+    "user_account": "User Account",
+    "iban": "IBAN",
+    "bic": "BIC",
+    "auth_secret": "Auth Secret",
+    "ja3": "JA3",
+    "jarm": "JARM",
+    "mutex": "Mutex",
+    "named_pipe": "Named Pipe",
+    "package": "Package",
+}
+
+_ENTITY_LABELS = {
+    "investigation": "Investigation",
+    "malware": "Malware",
+    "tool": "Tool",
+    "attack-pattern": "Attack pattern",
+    "threat-actor": "Threat actor",
+    "intrusion-set": "Intrusion set",
+    "campaign": "Campaign",
+    "identity": "Identity",
+    "company": "Company",
+    "vulnerability": "Vulnerability",
+    "course-of-action": "Course of action",
+    "note": "Note",
+}
+
+_INDICATOR_LABELS = {
+    "forensicartifact": "Forensic artifact",
+    "regex": "Regular expression",
+    "query": "Query",
+    "yara": "Yara",
+    "suricata": "Suricata",
+    "sigma": "Sigma",
+}
+
+_DFIQ_LABELS = {
+    "scenario": "Scenario",
+    "facet": "Facet",
+    "question": "Question",
+}
 
 
 class WorkerStatusResponse(BaseModel):
@@ -34,6 +103,42 @@ class SystemConfigResponse(BaseModel):
     agents_enabled: bool
 
 
+class TypeEntry(BaseModel):
+    """A single creatable object type."""
+
+    type: str
+    label: str
+
+
+class SystemTypesResponse(BaseModel):
+    """Available object types per family, for the frontend's creation UI."""
+
+    observables: list[TypeEntry]
+    entities: list[TypeEntry]
+    indicators: list[TypeEntry]
+    dfiq: list[TypeEntry]
+
+
+def _type_entries(
+    type_mapping: Mapping[str, type], base_class: type, labels: dict[str, str]
+) -> list[TypeEntry]:
+    """Turns a family's TYPE_MAPPING into a sorted list of API-facing entries.
+
+    Skips the alias keys (e.g. "observable"/"observables") that TYPE_MAPPING
+    maps back to the family's own base class rather than a concrete leaf type.
+    """
+    entries = [
+        TypeEntry(
+            type=type_str,
+            label=labels.get(type_str)
+            or type_str.replace("_", " ").replace("-", " ").title(),
+        )
+        for type_str, cls in type_mapping.items()
+        if cls is not base_class
+    ]
+    return sorted(entries, key=lambda entry: entry.label)
+
+
 @router.get("/config")
 def get_config() -> SystemConfigResponse:
     """Gets the system config."""
@@ -47,6 +152,26 @@ def get_config() -> SystemConfigResponse:
         agents_enabled=yeti_config.get("agents", "enabled"),
     )
     return config
+
+
+@router.get("/types", dependencies=[Depends(get_current_active_user)])
+def get_system_types() -> SystemTypesResponse:
+    """Lists every creatable object type, grouped by family.
+
+    Derived from each family's TYPE_MAPPING rather than a hand-maintained
+    list, so it automatically includes plugin-registered private/custom
+    types and can't drift from what the backend actually supports.
+    """
+    return SystemTypesResponse(
+        observables=_type_entries(
+            observable.TYPE_MAPPING, observable.Observable, _OBSERVABLE_LABELS
+        ),
+        entities=_type_entries(entity.TYPE_MAPPING, entity.Entity, _ENTITY_LABELS),
+        indicators=_type_entries(
+            indicator.TYPE_MAPPING, indicator.Indicator, _INDICATOR_LABELS
+        ),
+        dfiq=_type_entries(dfiq.TYPE_MAPPING, dfiq.DFIQBase, _DFIQ_LABELS),
+    )
 
 
 @router.get("/workers", dependencies=[Depends(get_current_active_user)])

--- a/tests/apiv2/system.py
+++ b/tests/apiv2/system.py
@@ -5,6 +5,7 @@ import unittest
 from fastapi.testclient import TestClient
 
 from core import database_arango
+from core.schemas.user import UserSensitive
 from core.web import webapp
 
 client = TestClient(webapp.app)
@@ -23,3 +24,56 @@ class userTest(unittest.TestCase):
         self.assertIn("auth", data)
         self.assertIn("system", data)
         self.assertIn("rbac_enabled", data)
+
+
+class SystemTypesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        logging.disable(sys.maxsize)
+        database_arango.db.connect(database="yeti_test")
+        database_arango.db.truncate()
+
+        user = UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = user.create_api_key("default")
+        token_data = client.post(
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
+        ).json()
+        client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
+
+    def test_get_types(self) -> None:
+        response = client.get("/api/v2/system/types")
+        data = response.json()
+        self.assertEqual(response.status_code, 200, data)
+        self.assertIn("observables", data)
+        self.assertIn("entities", data)
+        self.assertIn("indicators", data)
+        self.assertIn("dfiq", data)
+
+        observable_types = {entry["type"] for entry in data["observables"]}
+        # These are the exact types issue #1260 reported missing from the
+        # frontend's hardcoded dropdown.
+        self.assertTrue(
+            {"ja3", "jarm", "mutex", "named_pipe", "package"} <= observable_types
+        )
+        # The family's own base type/aliases must not leak in as entries.
+        self.assertNotIn("observable", observable_types)
+        self.assertNotIn("observables", observable_types)
+
+        indicator_types = {entry["type"] for entry in data["indicators"]}
+        self.assertEqual(
+            indicator_types,
+            {"forensicartifact", "regex", "query", "yara", "suricata", "sigma"},
+        )
+
+        dfiq_types = {entry["type"] for entry in data["dfiq"]}
+        self.assertEqual(dfiq_types, {"scenario", "facet", "question"})
+        self.assertNotIn("dfiq", dfiq_types)
+
+        # Every entry carries a non-empty label.
+        for family in ("observables", "entities", "indicators", "dfiq"):
+            for entry in data[family]:
+                self.assertTrue(entry["label"])
+
+    def test_get_types_requires_auth(self) -> None:
+        client.headers = {}
+        response = client.get("/api/v2/system/types")
+        self.assertEqual(response.status_code, 401, response.json())


### PR DESCRIPTION
## Summary
- Fixes #1254 and the root cause of #1260. Observable/entity/indicator types are each defined via a static `TYPE_MAPPING` registry (`core/schemas/{observable,entity,indicator}.py`), which a CI test (`tests/schemas/registry.py`) already guarantees is complete relative to what's actually on disk -- but the frontend maintains its own hand-written, independently-drifting type list per family, which is exactly what let `ja3`/`jarm`/`mutex`/`named_pipe`/`package` silently go missing from the "New Observable" dropdown despite being fully supported.
- New `GET /system/types` derives its response directly from each family's `TYPE_MAPPING` (plus DFIQ's, for shape parity with the paired frontend PR) instead of hand-listing types a third time, so it can't drift the same way, and automatically includes plugin-registered private/custom types (`core/schemas/loader.py`'s `load_private_types`) for free -- directly answers the "how would you handle custom observables?" question raised in #1254's linked discussion.
- Labels are hardcoded to match the frontend's existing display strings exactly (cross-checked against `src/definitions/*.ts`) for every already-known type, falling back to a formatted version of the type string (`type.replace(...).title()`) for anything new -- verified this fallback produces sensible output for the two entity types the frontend doesn't currently expose at all (`note`, `phone`).
- Requires auth (matches `/workers`, not `/config` -- this isn't needed pre-login).

Paired with yeti-feeds-frontend#304, which already expects exactly this endpoint and response shape (`{observables, entities, indicators, dfiq}`, each a list of `{type, label}`).

## Test plan
- [x] New tests in `tests/apiv2/system.py`: response shape, all 5 previously-missing observable types present, base-type aliases (`observable`/`observables`/`dfiq`) don't leak into entries, indicator set matches exactly, every entry has a non-empty label, 401 without auth
- [x] Full `tests/apiv2/system.py` + `tests/schemas/observable.py` + `tests/schemas/entity.py` + `tests/schemas/indicator.py` + `tests/apiv2/dfiq.py` -- 127/127 pass
- [x] `ruff check`/`format --check` clean; `ty check` clean (fixed one real finding: `dict`'s invariant value type rejected passing `dict[str, type[Observable]]` where `dict[str, type]` was declared -- switched to `collections.abc.Mapping`, which is covariant)
- [x] End-to-end: stood up this branch as a real server, checked out yeti-feeds-frontend#304 against it, logged in through the actual UI, opened "New Observable" -- all 33 types render including JA3/Mutex/etc. that #1260 reported missing, zero console errors