### PR TITLE
Make the Role schema honestly reflect the composite values it accepts

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -835,7 +835,7 @@ class ArangoYetiConnector(AbstractYetiConnector):
                 logging.exception("Error while publishing event")
         return relationship
 
-    def link_to_acl(self, target, role: "roles.Permission") -> "RoleRelationship":
+    def link_to_acl(self, target, role: "roles.Role") -> "RoleRelationship":
         """Creates a link between two YetiObjects.
 
         Idempotent and safe under concurrent calls for the same

--- a/core/schemas/graph.py
+++ b/core/schemas/graph.py
@@ -64,7 +64,7 @@ class RoleRelationship(BaseModel, database_arango.ArangoYetiConnector):
 
     source: str
     target: str
-    role: roles.Permission
+    role: roles.Role
     created: datetime.datetime
     modified: datetime.datetime
 

--- a/core/schemas/roles.py
+++ b/core/schemas/roles.py
@@ -1,4 +1,4 @@
-from enum import IntFlag
+from enum import IntEnum, IntFlag
 
 
 class Permission(IntFlag):
@@ -7,8 +7,17 @@ class Permission(IntFlag):
     DELETE = 0b0100  # 4
 
 
-class Role:
-    NONE = Permission(0)
+class Role(IntEnum):
+    """The Permission combinations actually granted over the API.
+
+    A plain int/enum (not Permission itself) so FastAPI's OpenAPI generation
+    -- and hence generated client types -- list exactly these four values
+    instead of Permission's individual flags (1, 2, 4), which don't include
+    the composite values (0, 3, 7) every role-granting endpoint actually
+    accepts.
+    """
+
+    NONE = 0
     READER = Permission.READ
     WRITER = Permission.READ | Permission.WRITE
     OWNER = Permission.READ | Permission.WRITE | Permission.DELETE

--- a/core/web/apiv2/groups.py
+++ b/core/web/apiv2/groups.py
@@ -23,7 +23,7 @@ class GroupSearchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str = ""
-    permissions: roles.Permission | None = None
+    permissions: roles.Role | None = None
     count: int = 50
     page: int = 0
 

--- a/core/web/apiv2/rbac.py
+++ b/core/web/apiv2/rbac.py
@@ -18,7 +18,7 @@ class UpdateACLRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     ids: list[RBACIdentity]
-    role: roles.Permission = roles.Role.READER
+    role: roles.Role = roles.Role.READER
 
 
 class UpdateMembersResponse(BaseModel):

--- a/core/web/apiv2/users.py
+++ b/core/web/apiv2/users.py
@@ -45,7 +45,7 @@ class PatchRoleRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     user_id: str
-    role: roles.Permission
+    role: roles.Role
 
 
 class NewApiKeyRequest(BaseModel):

--- a/tests/apiv2/groups.py
+++ b/tests/apiv2/groups.py
@@ -164,7 +164,7 @@ class rbacTest(unittest.TestCase):
                     {"id": self.user2.id, "type": "user"},
                     {"id": self.admin.id, "type": "user"},
                 ],
-                "role": 4,
+                "role": roles.Role.WRITER,
             },
             headers={"Authorization": f"Bearer {self.user1_token}"},
         )
@@ -181,3 +181,4 @@ class rbacTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         members = list(data["acls"].keys())
         self.assertCountEqual(members, ["user1", "user2", "yeti"])
+        self.assertEqual(data["acls"]["user2"]["role"], roles.Role.WRITER)

--- a/tests/apiv2/rbac.py
+++ b/tests/apiv2/rbac.py
@@ -237,6 +237,62 @@ class rbacTest(unittest.TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
+    def test_update_members_every_valid_role(self):
+        """Every value Role actually declares (0, 1, 3, 7) must be grantable
+        through the update-members endpoint, and the granted value must
+        round-trip correctly through the ACL response.
+        """
+        self.user1.link_to_acl(self.entity1, roles.Role.OWNER)
+
+        for role in roles.Role:
+            with self.subTest(role=role):
+                response = client.post(
+                    f"/api/v2/rbac/entity/{self.entity1.id}/update-members",
+                    json={
+                        "ids": [{"id": self.user2.id, "type": "user"}],
+                        "role": role,
+                    },
+                    headers={"Authorization": f"Bearer {self.user1_token}"},
+                )
+                data = response.json()
+                self.assertEqual(response.status_code, 200, data)
+                self.assertEqual(data["updated"], 1)
+                self.assertEqual(data["failed"], 0)
+
+                response = client.get(
+                    f"/api/v2/rbac/entity/{self.entity1.id}",
+                    headers={"Authorization": f"Bearer {self.user1_token}"},
+                )
+                data = response.json()
+                self.assertEqual(response.status_code, 200, data)
+                self.assertEqual(data["acls"]["user2"]["role"], role)
+
+    def test_update_members_rejects_non_composite_role(self):
+        """Values Permission accepts but Role doesn't (2, 4, 5, 6) -- and
+        values outside Permission's range entirely (8, -1) -- must be
+        rejected with a clean 422, and must not create an ACL edge.
+        """
+        self.user1.link_to_acl(self.entity1, roles.Role.OWNER)
+
+        for invalid_role in (2, 4, 5, 6, 8, -1):
+            with self.subTest(invalid_role=invalid_role):
+                response = client.post(
+                    f"/api/v2/rbac/entity/{self.entity1.id}/update-members",
+                    json={
+                        "ids": [{"id": self.user2.id, "type": "user"}],
+                        "role": invalid_role,
+                    },
+                    headers={"Authorization": f"Bearer {self.user1_token}"},
+                )
+                self.assertEqual(response.status_code, 422, response.json())
+
+                response = client.get(
+                    f"/api/v2/rbac/entity/{self.entity1.id}",
+                    headers={"Authorization": f"Bearer {self.user1_token}"},
+                )
+                data = response.json()
+                self.assertNotIn("user2", data["acls"])
+
     def test_default_acls(self):
         """Test that a user can create a new entity"""
         self.user1.global_role = roles.Role.WRITER

--- a/tests/apiv2/users.py
+++ b/tests/apiv2/users.py
@@ -288,3 +288,37 @@ class userTest(unittest.TestCase):
         user = UserSensitive.get(self.user.id)
         self.assertIsNotNone(user)
         self.assertEqual(user.global_role, roles.Role.OWNER)
+
+    def test_patch_user_role_every_valid_value(self):
+        """Every value Role actually declares (0, 1, 3, 7) must be settable."""
+        for role in roles.Role:
+            with self.subTest(role=role):
+                response = client.patch(
+                    "/api/v2/users/role",
+                    json={"user_id": self.user.id, "role": role},
+                    headers={"Authorization": f"Bearer {self.admin_token}"},
+                )
+                data = response.json()
+                self.assertEqual(response.status_code, 200, data)
+                self.assertEqual(data["global_role"], role)
+
+                user = UserSensitive.get(self.user.id)
+                self.assertEqual(user.global_role, role)
+
+    def test_patch_user_role_rejects_non_composite_values(self):
+        """Values Permission accepts but Role doesn't (2, 4, 5, 6) -- and
+        values outside Permission's range entirely (8, -1) -- must be
+        rejected with a clean 422, not silently accepted.
+        """
+        for invalid_role in (2, 4, 5, 6, 8, -1):
+            with self.subTest(invalid_role=invalid_role):
+                response = client.patch(
+                    "/api/v2/users/role",
+                    json={"user_id": self.user.id, "role": invalid_role},
+                    headers={"Authorization": f"Bearer {self.admin_token}"},
+                )
+                self.assertEqual(response.status_code, 422, response.json())
+
+                # Rejected requests must not have side effects.
+                user = UserSensitive.get(self.user.id)
+                self.assertNotEqual(user.global_role, invalid_role)

--- a/tests/schemas/roles.py
+++ b/tests/schemas/roles.py
@@ -1,0 +1,39 @@
+import unittest
+
+from core.schemas import roles
+
+
+class RoleTest(unittest.TestCase):
+    def test_role_has_exactly_the_meaningful_composite_values(self) -> None:
+        """Role must stay exactly {NONE, READER, WRITER, OWNER} = {0, 1, 3, 7}.
+
+        This is the enum FastAPI/OpenAPI generation exposes as the accepted
+        `role` values on every role-granting endpoint -- adding, removing, or
+        renumbering a member here directly changes the public API contract.
+        """
+        self.assertEqual(
+            {member.name: member.value for member in roles.Role},
+            {"NONE": 0, "READER": 1, "WRITER": 3, "OWNER": 7},
+        )
+
+    def test_role_values_match_permission_flag_combinations(self) -> None:
+        self.assertEqual(roles.Role.NONE, 0)
+        self.assertEqual(roles.Role.READER, roles.Permission.READ)
+        self.assertEqual(
+            roles.Role.WRITER, roles.Permission.READ | roles.Permission.WRITE
+        )
+        self.assertEqual(
+            roles.Role.OWNER,
+            roles.Permission.READ | roles.Permission.WRITE | roles.Permission.DELETE,
+        )
+
+    def test_role_is_a_real_int_enum_not_the_permission_flag(self) -> None:
+        """Role must NOT be Permission (or a Permission subclass/alias).
+
+        Sharing Permission's type is exactly the bug this enum exists to
+        avoid: OpenAPI would only list Permission's individually-declared
+        flags (1, 2, 4), not the composite values (0, 3, 7) actually
+        accepted.
+        """
+        self.assertFalse(issubclass(roles.Role, roles.Permission))
+        self.assertNotIsInstance(roles.Role.OWNER, roles.Permission)


### PR DESCRIPTION
## Summary
- `Permission` is an `IntFlag`, so pydantic accepts any bitwise combination at runtime, but OpenAPI generation only lists its explicit members (`1 | 2 | 4`) -- never the composite values (`0`, `3`, `7`) that role-granting endpoints actually require. The frontend has been working around this with manual type-widening.
- Adds `Role`, a plain `IntEnum` with exactly the four values the API grants (`NONE=0`, `READER=1`, `WRITER=3`, `OWNER=7`), and uses it everywhere a role is accepted or returned over the API.
- Non-canonical values `Permission` used to silently accept (`2`, `4`, `5`, `6`, `8`, `-1`) are now correctly rejected with 422.

## Test plan
- [x] `ruff check` / `ruff format --check` clean on all touched lines
- [x] `ty check` clean
- [x] New exhaustive coverage: schema-level lock-in test for `Role`'s member set, plus endpoint tests for every valid `Role` value and rejection of every meaningful invalid value, on both `PATCH /users/role` and `POST /rbac/{type}/{id}/update-members`
- [x] Full `tests/schemas`, `tests/apiv2`, `tests/core_tests` run clean (only 2 pre-existing unrelated failures in `tasks.py`, confirmed present on a clean `main` baseline too)
