### PR TITLE
Grant default-shared objects read access, not full ownership

### DIFF
--- a/core/schemas/rbac.py
+++ b/core/schemas/rbac.py
@@ -131,7 +131,7 @@ def set_acls(yeti_object: Any, user: "user.User | None" = None, set_default=True
         for identity in default_acls.split(","):
             group = Group.find(name=identity)
             if group:
-                group.link_to_acl(yeti_object, roles.Role.OWNER)
+                group.link_to_acl(yeti_object, roles.Role.READER)
                 access = True
             else:
                 logger.warning(f"Default ACL group {identity} not found.")

--- a/tests/apiv2/rbac.py
+++ b/tests/apiv2/rbac.py
@@ -311,3 +311,8 @@ class rbacTest(unittest.TestCase):
         test_malware = entity.Malware.find(name="test")
         test_malware.get_acls()
         self.assertCountEqual(test_malware.acls.keys(), ["All users", "user1"])
+        # The creator gets full ownership; the default-shared group only gets
+        # read access -- default_acls is meant to grant visibility, not hand
+        # every registered user delete rights over every new object.
+        self.assertEqual(test_malware.acls["All users"].role, roles.Role.READER)
+        self.assertEqual(test_malware.acls["user1"].role, roles.Role.OWNER)

--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -59,7 +59,7 @@ enabled = False
 default_global_role = writer
 
 # Default sharing settings for objects that are created.
-# `all_users` will share with all users on the platform
+# `all_users` will grant read access to all users on the platform
 # (this can be revoked later on)
 # `none` will add no additional sharing by default
 default_acls = All users


### PR DESCRIPTION
## Summary
- `set_acls()` granted every group listed in `[rbac] default_acls` (e.g. "All users") `Role.OWNER` on every new object -- full read/write/delete rights, not merely visibility. This looks like a copy-paste from the line right above it (the creator's own grant, which should stay Owner), since the config comment describes the setting as "sharing... this can be revoked later on," not as handing delete rights to the whole org by default.
- Changes the default-group grant to `Role.READER`. The creator's own grant is untouched.
- Clarified `yeti.conf.sample`'s comment to say "grant read access" explicitly.

**Behavior change, not retroactive**: existing objects already created keep whatever ACLs they have; this only changes what new objects get going forward. Deployments relying on the old (accidental) Owner-by-default behavior for the configured default group would need to grant it explicitly now, the same way any other role is granted.

## Test plan
- [x] `ruff check`/`format --check` and `ty check` clean
- [x] Strengthened `test_default_acls` to assert on the actual role values (`All users` -> Reader, creator -> Owner), not just ACL membership
- [x] Full `tests/schemas`, `tests/apiv2`, `tests/core_tests` suite run clean -- 3 pre-existing failures confirmed present on a clean `main` baseline too, unrelated to this change
