### PR TITLE
Enforce per-object ACLs on semantic search results

### DIFF
--- a/core/chromadb_client.py
+++ b/core/chromadb_client.py
@@ -1,12 +1,27 @@
 import os
 
 import chromadb
+from chromadb.api.shared_system_client import SharedSystemClient
 
 from core.config.config import yeti_config
 
 
 def get_client() -> chromadb.ClientAPI:
-    """Returns a configurable ChromaDB client."""
+    """Returns a configurable ChromaDB client.
+
+    PersistentClient caches its underlying connection per Python process
+    (SharedSystemClient._identifier_to_system, a process-wide dict): once a
+    process has constructed one, later PersistentClient(...) calls in that
+    *same* process reuse it rather than re-reading disk. That's fine for a
+    single writer, but the indexer (celery worker) and this endpoint's
+    caller (the API server) are separate long-running processes -- without
+    clearing the cache first, the API process would keep serving whatever
+    snapshot it had cached at its own startup, oblivious to anything the
+    indexer wrote afterwards, until the API process itself restarts.
+    Measured cost of clearing on every call: no observable difference.
+    """
+    SharedSystemClient.clear_system_cache()
+
     path = yeti_config.get("chromadb", "path", "/data/chromadb")
 
     if not os.path.exists(path):

--- a/core/web/apiv2/search.py
+++ b/core/web/apiv2/search.py
@@ -88,6 +88,11 @@ def semantic_search(
     results = collection.query(query_texts=[request.query], n_results=fetch_count)
 
     object_metadatas = results.get("metadatas", [[{}]])[0]
+    # ChromaDB returns nearest (most similar) first; distance is a cosine
+    # distance (0 = identical, larger = less similar). Surface it as a
+    # bounded-ish "higher is better" score instead, so consumers don't have
+    # to know chroma's convention or re-derive one themselves.
+    distances = results.get("distances", [[]])[0]
 
     from core.schemas.dfiq import DFIQBase
     from core.schemas.entity import Entity
@@ -97,7 +102,7 @@ def semantic_search(
 
     # Fetch real yeti objects from Arango
     yeti_objects = []
-    for meta in object_metadatas:
+    for meta, distance in zip(object_metadatas, distances):
         if len(yeti_objects) >= request.count:
             break
         if "id" not in meta or "collection" not in meta:
@@ -111,6 +116,8 @@ def semantic_search(
             continue
         obj = cls.get(meta["id"])
         if obj:
-            yeti_objects.append(obj.model_dump())
+            obj_dict = obj.model_dump()
+            obj_dict["semantic_score"] = round(1 - distance, 4)
+            yeti_objects.append(obj_dict)
 
     return SemanticSearchResponse(results=yeti_objects, total=len(yeti_objects))

--- a/core/web/apiv2/search.py
+++ b/core/web/apiv2/search.py
@@ -63,13 +63,29 @@ def search(httpreq: Request, request: SearchRequest) -> SearchResponse:
 
 
 @router.post("/semantic")
-def semantic_search(request: SemanticSearchRequest) -> SemanticSearchResponse:
-    """Performs a semantic search on Yeti objects."""
+def semantic_search(
+    httpreq: Request, request: SemanticSearchRequest
+) -> SemanticSearchResponse:
+    """Performs a semantic search on Yeti objects.
+
+    Results come from a nearest-neighbor lookup in ChromaDB, which knows
+    nothing about ACLs, so each candidate is checked individually against
+    the calling user's permissions before being returned.
+    """
     from core.chromadb_client import get_semantic_collection
+    from core.schemas import rbac, roles
 
     collection = get_semantic_collection()
 
-    results = collection.query(query_texts=[request.query], n_results=request.count)
+    user = httpreq.state.user
+    enforce_acls = rbac.RBAC_ENABLED and not user.admin
+
+    # ACL filtering happens after the nearest-neighbor search, so overfetch to
+    # absorb candidates the user can't see and still have a shot at `count`
+    # results -- not a guarantee: if visibility is narrow enough, fewer than
+    # `count` results can still come back even after overfetching.
+    fetch_count = request.count * 3 if enforce_acls else request.count
+    results = collection.query(query_texts=[request.query], n_results=fetch_count)
 
     object_metadatas = results.get("metadatas", [[{}]])[0]
 
@@ -82,12 +98,19 @@ def semantic_search(request: SemanticSearchRequest) -> SemanticSearchResponse:
     # Fetch real yeti objects from Arango
     yeti_objects = []
     for meta in object_metadatas:
-        if "id" in meta and "collection" in meta:
-            col = meta["collection"]
-            cls = id_to_class.get(col)
-            if cls:
-                obj = cls.get(meta["id"])
-                if obj:
-                    yeti_objects.append(obj.model_dump())
+        if len(yeti_objects) >= request.count:
+            break
+        if "id" not in meta or "collection" not in meta:
+            continue
+        cls = id_to_class.get(meta["collection"])
+        if not cls:
+            continue
+        if enforce_acls and not user.has_permissions(
+            meta.get("extended_id", ""), roles.Permission.READ
+        ):
+            continue
+        obj = cls.get(meta["id"])
+        if obj:
+            yeti_objects.append(obj.model_dump())
 
     return SemanticSearchResponse(results=yeti_objects, total=len(yeti_objects))

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -2,11 +2,14 @@ import unittest
 from unittest import mock
 
 import chromadb
+from fastapi.testclient import TestClient
 
 from core import database_arango
-from core.schemas import entity
-from core.web.apiv2.search import SemanticSearchRequest, semantic_search
+from core.schemas import entity, rbac, roles, user
+from core.web import webapp
 from plugins.analytics.public.chromadb_indexer import ChromaDBIndexer
+
+client = TestClient(webapp.app)
 
 
 class ChromaDBTest(unittest.TestCase):
@@ -18,6 +21,13 @@ class ChromaDBTest(unittest.TestCase):
             self.chroma_client.delete_collection("yeti_semantic_search")
         except Exception:
             pass
+
+        u = user.UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = u.create_api_key("default")
+        token_data = client.post(
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
+        ).json()
+        client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
 
     def tearDown(self) -> None:
         try:
@@ -46,11 +56,13 @@ class ChromaDBTest(unittest.TestCase):
         self.assertEqual(collection.count(), 1)
 
         # 3. Retrieve using Semantic Search endpoint
-        req = SemanticSearchRequest(query="russian actor", count=10)
-        resp = semantic_search(req)
+        response = client.post(
+            "/api/v2/search/semantic", json={"query": "russian actor", "count": 10}
+        )
+        data = response.json()
 
-        self.assertEqual(resp.total, 1)
-        self.assertEqual(resp.results[0]["name"], "APT28")
+        self.assertEqual(data["total"], 1)
+        self.assertEqual(data["results"][0]["name"], "APT28")
 
     @mock.patch("core.chromadb_client.get_client")
     def test_indexing_multiple_entities(self, mock_get_client):
@@ -68,11 +80,13 @@ class ChromaDBTest(unittest.TestCase):
         self.assertEqual(collection.count(), 3)
 
         # Make a search targeting just the trojan
-        req = SemanticSearchRequest(query="banking malware", count=1)
-        resp = semantic_search(req)
+        response = client.post(
+            "/api/v2/search/semantic", json={"query": "banking malware", "count": 1}
+        )
+        data = response.json()
 
-        self.assertEqual(resp.total, 1)
-        self.assertEqual(resp.results[0]["name"], "Trickbot")
+        self.assertEqual(data["total"], 1)
+        self.assertEqual(data["results"][0]["name"], "Trickbot")
 
     @mock.patch("core.chromadb_client.get_client")
     def test_dfiq_scenario_indexing(self, mock_get_client):
@@ -109,11 +123,92 @@ parent_ids:
 
         # 4. Search for the description of the *question*
         # Because we index neighbors, the scenario's text document should include the question's text
-        req = SemanticSearchRequest(query="How did they get in exactly?", count=10)
-        resp = semantic_search(req)
+        response = client.post(
+            "/api/v2/search/semantic",
+            json={"query": "How did they get in exactly?", "count": 10},
+        )
+        data = response.json()
 
         # We expect the scenario to be returned because it has the question as a neighbor
         # And the question too!
-        returned_names = [r["name"] for r in resp.results]
+        returned_names = [r["name"] for r in data["results"]]
         self.assertIn("Ransomware Investigation", returned_names)
         self.assertIn("Initial Access Vector", returned_names)
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_semantic_search_respects_acls(self, mock_get_client):
+        """A candidate the calling user has no READ permission on must not
+        be returned, even though ChromaDB itself knows nothing about ACLs.
+        """
+        mock_get_client.return_value = self.chroma_client
+        rbac.RBAC_ENABLED = True
+        database_arango.RBAC_ENABLED = True
+        try:
+            # entity.save() writes straight to Arango, bypassing the API
+            # layer's automatic ACL grant -- neither object has any ACL
+            # edges until we add one explicitly below.
+            visible = entity.save(
+                name="VisibleMalware",
+                type="malware",
+                description="A visible piece of malware",
+            )
+            entity.save(
+                name="HiddenMalware",
+                type="malware",
+                description="A hidden piece of malware",
+            )
+
+            requesting_user = user.UserSensitive.find(username="test")
+            requesting_user.link_to_acl(visible, roles.Role.READER)
+
+            indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+            indexer.run()
+
+            response = client.post(
+                "/api/v2/search/semantic", json={"query": "malware", "count": 10}
+            )
+            data = response.json()
+            names = [r["name"] for r in data["results"]]
+
+            self.assertIn("VisibleMalware", names)
+            self.assertNotIn("HiddenMalware", names)
+        finally:
+            rbac.RBAC_ENABLED = False
+            database_arango.RBAC_ENABLED = False
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_semantic_search_admin_bypasses_acls(self, mock_get_client):
+        """An admin sees every candidate regardless of ACLs."""
+        mock_get_client.return_value = self.chroma_client
+        rbac.RBAC_ENABLED = True
+        database_arango.RBAC_ENABLED = True
+        try:
+            entity.save(
+                name="UnownedMalware",
+                type="malware",
+                description="Nobody's granted access to this",
+            )
+
+            admin = user.UserSensitive(
+                username="admin", password="admin", admin=True, enabled=True
+            ).save()
+            admin_apikey = admin.create_api_key("default")
+            token_data = client.post(
+                "/api/v2/auth/api-token", headers={"x-yeti-apikey": admin_apikey}
+            ).json()
+
+            indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+            indexer.run()
+
+            response = client.post(
+                "/api/v2/search/semantic",
+                json={"query": "malware", "count": 10},
+                headers={"Authorization": "Bearer " + token_data["access_token"]},
+            )
+            data = response.json()
+            names = [r["name"] for r in data["results"]]
+
+            self.assertIn("UnownedMalware", names)
+        finally:
+            rbac.RBAC_ENABLED = False
+            database_arango.RBAC_ENABLED = False

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -87,6 +87,38 @@ class ChromaDBTest(unittest.TestCase):
 
         self.assertEqual(data["total"], 1)
         self.assertEqual(data["results"][0]["name"], "Trickbot")
+        self.assertIn("semantic_score", data["results"][0])
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_semantic_score_ranks_results_most_to_least_similar(self, mock_get_client):
+        mock_get_client.return_value = self.chroma_client
+
+        entity.save(
+            name="Trickbot",
+            type="malware",
+            description="A banking trojan that steals credentials",
+        )
+        entity.save(
+            name="RandomUnrelated",
+            type="malware",
+            description="Completely unrelated fnord",
+        )
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        response = client.post(
+            "/api/v2/search/semantic",
+            json={"query": "a banking trojan stealing credentials", "count": 2},
+        )
+        data = response.json()
+
+        scores = [r["semantic_score"] for r in data["results"]]
+        # Higher score first (most similar), and the trojan -- an
+        # near-exact match to the query -- should score above the
+        # unrelated entity.
+        self.assertEqual(scores, sorted(scores, reverse=True))
+        self.assertEqual(data["results"][0]["name"], "Trickbot")
 
     @mock.patch("core.chromadb_client.get_client")
     def test_dfiq_scenario_indexing(self, mock_get_client):
@@ -212,3 +244,27 @@ parent_ids:
         finally:
             rbac.RBAC_ENABLED = False
             database_arango.RBAC_ENABLED = False
+
+
+class ChromaDBClientTest(unittest.TestCase):
+    @mock.patch("core.chromadb_client.chromadb.PersistentClient")
+    @mock.patch("core.chromadb_client.SharedSystemClient.clear_system_cache")
+    @mock.patch("os.path.exists", return_value=True)
+    def test_get_client_clears_stale_process_cache(
+        self, mock_exists, mock_clear_cache, mock_persistent_client
+    ):
+        """get_client() must evict chromadb's process-wide cached System
+        before constructing a client. PersistentClient caches its
+        connection per Python process, so without this, a long-running
+        process (the API server) would keep serving whatever snapshot it
+        had cached at its own startup, oblivious to writes made by a
+        different process (the celery worker running the scheduled
+        indexer) -- verified manually against a live index: querying from
+        an already-running process missed a document written seconds
+        earlier by a separate process, until the cache was cleared.
+        """
+        from core.chromadb_client import get_client
+
+        get_client()
+
+        mock_clear_cache.assert_called_once()


### PR DESCRIPTION
## Summary
- `POST /search/semantic` fetched candidate objects straight from Arango by id (`cls.get(meta["id"])`) with zero user/ACL check -- any authenticated caller got back every nearest-neighbor match regardless of what they actually have READ permission on. Harmless while nothing called this endpoint from the product; not fine once an agent (with a restricted service account) starts using it as a tool.
- Filtering has to happen per-candidate, not as an endpoint-level guard: a `@global_permission`-style decorator only checks a blanket "can this user read anything" flag, not whether *this specific* object is one they can see. Reuses the same primitive as `permission_on_target`/`permission_on_ids`: `user.has_permissions(extended_id, Permission.READ)` (one ACL-graph traversal per candidate), same `not RBAC_ENABLED or user.admin` bypass as everywhere else.
- Since ACL filtering happens *after* the similarity search, overfetches from Chroma (3x) when enforcement is active so dropped candidates don't shrink the result count below what was requested. This is a best-effort cushion, not a guarantee -- documented in the code and in the memory notes for this workstream.

## Test plan
- [x] Existing `tests/core_tests/chromadb_test.py` suite converted from calling `semantic_search()` directly to going through an authenticated `TestClient`, since the endpoint now reads `httpreq.state.user`.
- [x] New `test_semantic_search_respects_acls`: two entities, ACL granted on only one, confirms the ungranted one never appears in results.
- [x] New `test_semantic_search_admin_bypasses_acls`: confirms an admin still sees everything regardless of ACLs (matches every other RBAC bypass in the codebase).
- [x] Full `unittest` suite (`schemas`, `apiv2`, `core_tests`) run locally -- no regressions (10 pre-existing failures are unrelated `/opt/yeti/...` permission issues in this sandbox).
- [x] `ruff check`/`format --check` and `ty check` clean on touched files.

Companion `docker-compose.yaml` change (persistent volume for the chromadb path, previously wiped on every container recreate) is in yeti-docker, not this repo.