### PR TITLE
Let semantic search be scoped to one type, and stop it crowding types

### DIFF
--- a/core/web/apiv2/search.py
+++ b/core/web/apiv2/search.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from fastapi import APIRouter, Request
 from pydantic import BaseModel, ConfigDict
 
@@ -37,13 +39,18 @@ class SemanticSearchRequest(BaseModel):
 
     query: str
     count: int = 10
+    root_type: Literal["entity", "indicator", "dfiq"] | None = None
 
 
 class SemanticSearchResponse(BaseModel):
-    """Semantic Search Response."""
+    """Semantic Search Response, bucketed by type like grouped exact-match
+    search: each type gets its own independently-bounded slice of nearest
+    neighbors, so results from one type can't crowd another out of a
+    shared page. `total` here is just how many were returned for that
+    type (not a corpus-wide count) -- ANN search doesn't have a cheap way
+    to count "everything within the top-K" beyond what was fetched."""
 
-    results: list[dict]
-    total: int = 0
+    sections: list[SearchResultSection]
 
 
 @router.post("/")
@@ -62,53 +69,48 @@ def search(httpreq: Request, request: SearchRequest) -> SearchResponse:
     return SearchResponse(sections=[SearchResultSection(**s) for s in sections])
 
 
-@router.post("/semantic")
-def semantic_search(
-    httpreq: Request, request: SemanticSearchRequest
-) -> SemanticSearchResponse:
-    """Performs a semantic search on Yeti objects.
+SEMANTIC_TYPE_TO_COLLECTION = {
+    "entity": "entities",
+    "indicator": "indicators",
+    "dfiq": "dfiq",
+}
 
-    Results come from a nearest-neighbor lookup in ChromaDB, which knows
-    nothing about ACLs, so each candidate is checked individually against
-    the calling user's permissions before being returned.
+
+def _semantic_search_one_type(
+    collection, query: str, count: int, collection_name: str, cls, user, enforce_acls
+) -> SearchResultSection:
+    """Queries ChromaDB for nearest neighbors within a single type's
+    collection (via a metadata filter), so this type's results are bounded
+    independently of how many candidates other types produce -- mirrors
+    grouped_search's per-type isolation, just as a separate Chroma query
+    per type instead of one AQL query fanning out, since Chroma's ANN
+    index doesn't support per-group limits within a single query.
     """
-    from core.chromadb_client import get_semantic_collection
-    from core.schemas import rbac, roles
-
-    collection = get_semantic_collection()
-
-    user = httpreq.state.user
-    enforce_acls = rbac.RBAC_ENABLED and not user.admin
+    from core.schemas import roles
 
     # ACL filtering happens after the nearest-neighbor search, so overfetch to
     # absorb candidates the user can't see and still have a shot at `count`
     # results -- not a guarantee: if visibility is narrow enough, fewer than
     # `count` results can still come back even after overfetching.
-    fetch_count = request.count * 3 if enforce_acls else request.count
-    results = collection.query(query_texts=[request.query], n_results=fetch_count)
+    fetch_count = count * 3 if enforce_acls else count
+    results = collection.query(
+        query_texts=[query],
+        n_results=fetch_count,
+        where={"collection": collection_name},
+    )
 
-    object_metadatas = results.get("metadatas", [[{}]])[0]
+    object_metadatas = results.get("metadatas", [[]])[0]
     # ChromaDB returns nearest (most similar) first; distance is a cosine
     # distance (0 = identical, larger = less similar). Surface it as a
     # bounded-ish "higher is better" score instead, so consumers don't have
     # to know chroma's convention or re-derive one themselves.
     distances = results.get("distances", [[]])[0]
 
-    from core.schemas.dfiq import DFIQBase
-    from core.schemas.entity import Entity
-    from core.schemas.indicator import Indicator
-
-    id_to_class = {"entities": Entity, "indicators": Indicator, "dfiq": DFIQBase}
-
-    # Fetch real yeti objects from Arango
     yeti_objects = []
     for meta, distance in zip(object_metadatas, distances):
-        if len(yeti_objects) >= request.count:
+        if len(yeti_objects) >= count:
             break
-        if "id" not in meta or "collection" not in meta:
-            continue
-        cls = id_to_class.get(meta["collection"])
-        if not cls:
+        if "id" not in meta:
             continue
         if enforce_acls and not user.has_permissions(
             meta.get("extended_id", ""), roles.Permission.READ
@@ -120,4 +122,54 @@ def semantic_search(
             obj_dict["semantic_score"] = round(1 - distance, 4)
             yeti_objects.append(obj_dict)
 
-    return SemanticSearchResponse(results=yeti_objects, total=len(yeti_objects))
+    type_name = next(
+        t for t, c in SEMANTIC_TYPE_TO_COLLECTION.items() if c == collection_name
+    )
+    return SearchResultSection(
+        type=type_name, results=yeti_objects, total=len(yeti_objects)
+    )
+
+
+@router.post("/semantic")
+def semantic_search(
+    httpreq: Request, request: SemanticSearchRequest
+) -> SemanticSearchResponse:
+    """Performs a semantic search on Yeti objects, bucketed by type.
+
+    Results come from a nearest-neighbor lookup in ChromaDB, which knows
+    nothing about ACLs, so each candidate is checked individually against
+    the calling user's permissions before being returned. Pass root_type
+    to scope the search to just one type (e.g. "dfiq" for investigative
+    guidance rather than threat data); omit it to search every indexed
+    type, each independently bounded to `count`.
+    """
+    from core.chromadb_client import get_semantic_collection
+    from core.schemas import rbac, roles
+    from core.schemas.dfiq import DFIQBase
+    from core.schemas.entity import Entity
+    from core.schemas.indicator import Indicator
+
+    collection = get_semantic_collection()
+
+    user = httpreq.state.user
+    enforce_acls = rbac.RBAC_ENABLED and not user.admin
+
+    id_to_class = {"entities": Entity, "indicators": Indicator, "dfiq": DFIQBase}
+    types_to_query = (
+        [request.root_type] if request.root_type else list(SEMANTIC_TYPE_TO_COLLECTION)
+    )
+
+    sections = [
+        _semantic_search_one_type(
+            collection,
+            request.query,
+            request.count,
+            SEMANTIC_TYPE_TO_COLLECTION[type_name],
+            id_to_class[SEMANTIC_TYPE_TO_COLLECTION[type_name]],
+            user,
+            enforce_acls,
+        )
+        for type_name in types_to_query
+    ]
+
+    return SemanticSearchResponse(sections=sections)

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -12,6 +12,10 @@ from plugins.analytics.public.chromadb_indexer import ChromaDBIndexer
 client = TestClient(webapp.app)
 
 
+def sections_by_type(data: dict) -> dict[str, dict]:
+    return {section["type"]: section for section in data["sections"]}
+
+
 class ChromaDBTest(unittest.TestCase):
     def setUp(self) -> None:
         database_arango.db.connect(database="yeti_test")
@@ -60,9 +64,10 @@ class ChromaDBTest(unittest.TestCase):
             "/api/v2/search/semantic", json={"query": "russian actor", "count": 10}
         )
         data = response.json()
+        sections = sections_by_type(data)
 
-        self.assertEqual(data["total"], 1)
-        self.assertEqual(data["results"][0]["name"], "APT28")
+        self.assertEqual(sections["entity"]["total"], 1, data)
+        self.assertEqual(sections["entity"]["results"][0]["name"], "APT28")
 
     @mock.patch("core.chromadb_client.get_client")
     def test_indexing_multiple_entities(self, mock_get_client):
@@ -84,10 +89,11 @@ class ChromaDBTest(unittest.TestCase):
             "/api/v2/search/semantic", json={"query": "banking malware", "count": 1}
         )
         data = response.json()
+        sections = sections_by_type(data)
 
-        self.assertEqual(data["total"], 1)
-        self.assertEqual(data["results"][0]["name"], "Trickbot")
-        self.assertIn("semantic_score", data["results"][0])
+        self.assertEqual(sections["entity"]["total"], 1, data)
+        self.assertEqual(sections["entity"]["results"][0]["name"], "Trickbot")
+        self.assertIn("semantic_score", sections["entity"]["results"][0])
 
     @mock.patch("core.chromadb_client.get_client")
     def test_semantic_score_ranks_results_most_to_least_similar(self, mock_get_client):
@@ -112,13 +118,15 @@ class ChromaDBTest(unittest.TestCase):
             json={"query": "a banking trojan stealing credentials", "count": 2},
         )
         data = response.json()
+        sections = sections_by_type(data)
+        results = sections["entity"]["results"]
 
-        scores = [r["semantic_score"] for r in data["results"]]
+        scores = [r["semantic_score"] for r in results]
         # Higher score first (most similar), and the trojan -- an
         # near-exact match to the query -- should score above the
         # unrelated entity.
         self.assertEqual(scores, sorted(scores, reverse=True))
-        self.assertEqual(data["results"][0]["name"], "Trickbot")
+        self.assertEqual(results[0]["name"], "Trickbot")
 
     @mock.patch("core.chromadb_client.get_client")
     def test_dfiq_scenario_indexing(self, mock_get_client):
@@ -160,10 +168,11 @@ parent_ids:
             json={"query": "How did they get in exactly?", "count": 10},
         )
         data = response.json()
+        sections = sections_by_type(data)
 
         # We expect the scenario to be returned because it has the question as a neighbor
         # And the question too!
-        returned_names = [r["name"] for r in data["results"]]
+        returned_names = [r["name"] for r in sections["dfiq"]["results"]]
         self.assertIn("Ransomware Investigation", returned_names)
         self.assertIn("Initial Access Vector", returned_names)
 
@@ -200,7 +209,8 @@ parent_ids:
                 "/api/v2/search/semantic", json={"query": "malware", "count": 10}
             )
             data = response.json()
-            names = [r["name"] for r in data["results"]]
+            sections = sections_by_type(data)
+            names = [r["name"] for r in sections["entity"]["results"]]
 
             self.assertIn("VisibleMalware", names)
             self.assertNotIn("HiddenMalware", names)
@@ -238,12 +248,97 @@ parent_ids:
                 headers={"Authorization": "Bearer " + token_data["access_token"]},
             )
             data = response.json()
-            names = [r["name"] for r in data["results"]]
+            sections = sections_by_type(data)
+            names = [r["name"] for r in sections["entity"]["results"]]
 
             self.assertIn("UnownedMalware", names)
         finally:
             rbac.RBAC_ENABLED = False
             database_arango.RBAC_ENABLED = False
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_root_type_scopes_to_a_single_type(self, mock_get_client):
+        """A DFIQ scenario and an entity can both semantically match the
+        same query -- root_type must exclude the other type entirely, not
+        just deprioritize it.
+        """
+        mock_get_client.return_value = self.chroma_client
+        from core.schemas.dfiq import DFIQScenario
+
+        entity.save(
+            name="Suspicious DNS Malware",
+            type="malware",
+            description="Malware that performs suspicious DNS queries for C2",
+        )
+        DFIQScenario.from_yaml("""
+type: scenario
+id: S0102
+dfiq_version: 1.0.0
+name: Suspicious DNS Query
+description: Investigating a suspicious DNS query
+uuid: 00000000-0000-4000-8000-000000000003
+""").save()
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        response = client.post(
+            "/api/v2/search/semantic",
+            json={
+                "query": "suspicious DNS query",
+                "count": 10,
+                "root_type": "dfiq",
+            },
+        )
+        data = response.json()
+
+        self.assertEqual(len(data["sections"]), 1, data)
+        self.assertEqual(data["sections"][0]["type"], "dfiq")
+        names = [r["name"] for r in data["sections"][0]["results"]]
+        self.assertIn("Suspicious DNS Query", names)
+        self.assertNotIn("Suspicious DNS Malware", names)
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_unscoped_search_does_not_let_one_type_crowd_out_another(
+        self, mock_get_client
+    ):
+        """A high-volume type (many matching entities) must not push a
+        low-volume type's (one matching DFIQ scenario) results out of the
+        response -- each type is queried and bounded independently.
+        """
+        mock_get_client.return_value = self.chroma_client
+        from core.schemas.dfiq import DFIQScenario
+
+        for i in range(8):
+            entity.save(
+                name=f"DNS Malware {i}",
+                type="malware",
+                description="Malware that performs suspicious DNS queries for C2",
+            )
+        DFIQScenario.from_yaml("""
+type: scenario
+id: S0103
+dfiq_version: 1.0.0
+name: Suspicious DNS Query
+description: Investigating a suspicious DNS query
+uuid: 00000000-0000-4000-8000-000000000004
+""").save()
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        response = client.post(
+            "/api/v2/search/semantic",
+            json={"query": "suspicious DNS query", "count": 1},
+        )
+        data = response.json()
+        sections = sections_by_type(data)
+
+        # The single DFIQ match is present regardless of how many entity
+        # matches exist -- it isn't sharing a page with them.
+        self.assertEqual(sections["dfiq"]["total"], 1, data)
+        self.assertEqual(sections["dfiq"]["results"][0]["name"], "Suspicious DNS Query")
+        self.assertEqual(len(sections["entity"]["results"]), 1, data)
 
 
 class ChromaDBClientTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
`/search/semantic` always ran one nearest-neighbor lookup across every indexed type and truncated to `count` total -- so a query like "how do I investigate a suspicious DNS query" could come back full of unrelated threat-actor entities that happen to mention DNS, crowding out the DFIQ investigative guidance that's actually the right answer. Same class of bug as the exact-match global search fix (yeti#1344), just in embedding space instead of substring space.

- New optional `root_type` request field scopes the search to one type (`"entity"` | `"indicator"` | `"dfiq"`), filtered server-side via Chroma's `where={"collection": ...}` metadata filter -- no re-indexing needed, the indexer already stores this.
- When `root_type` is omitted, each type now gets its own independently-bounded Chroma query, mirroring `grouped_search`'s per-type isolation for exact-match search (as separate queries instead of one AQL fan-out, since Chroma's ANN index has no per-group limit within a single query).
- **Response shape changes** from `{results, total}` to `{sections: [...]}`, reusing the same `SearchResultSection` grouped search already returns.
- Deliberately does **not** add a minimum-score cutoff: live testing showed genuinely correct matches scoring as low as 0.01-0.19 with the small default embedding model, so a fixed threshold would risk dropping real results without more empirical tuning than a guess.

## Merge ordering
yeti-platform/yeti-agents#3 (the semantic_search agent tool) is still open, not yet merged -- it consumes the old flat `{results, total}` shape. I've pushed a companion commit onto that same PR branch updating it for the new sectioned shape and adding `root_type` passthrough. Land both together (or yeti-agents#3 first with its update, then this) so nothing ends up consuming a shape that doesn't exist yet.

## Test plan
- [x] Rewrote all 6 existing `tests/core_tests/chromadb_test.py` tests for the sectioned response.
- [x] New `test_root_type_scopes_to_a_single_type`: entity and DFIQ both match the same query, `root_type="dfiq"` returns only the DFIQ section.
- [x] New `test_unscoped_search_does_not_let_one_type_crowd_out_another`: 8 matching entities can't push a single matching DFIQ scenario out of the response.
- [x] Full suite (schemas/apiv2/core_tests) run sequentially -- no regressions (2 pre-existing `tasks.py` failures already confirmed unrelated on a clean `main`, an eventual-consistency issue specific to this dev sandbox).
- [x] `ruff check`/`format --check` and `ty check` clean.
- [x] **Verified live** against real MITRE-seeded DFIQ content: `root_type="dfiq"` query for "how do i investigate a suspicious dns query" returned the actual "Suspicious DNS Query" scenario and its facets at 0.34-0.51 similarity, cleanly separated from entity noise.