### PR TITLE
Add a .dockerignore so .git stops being copied into the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Both Dockerfiles under extras/docker/ use `ADD . /app`, so anything not
+# excluded here is baked into the image.
+#
+# `.git` is the important one: actions/checkout writes credentials into
+# .git/config unless persist-credentials is disabled, and images published
+# before that was fixed (yeti <= 2.5.0) shipped a workflow token as a result.
+# The workflows set persist-credentials: false now, but there is no reason to
+# copy the repo history into the image either way.
+.git
+.github
+.gitattributes
+.gitignore
+
+# Local config and state. yeti.conf can hold real credentials; the image builds
+# its own from yeti.conf.sample, which is deliberately still included.
+yeti.conf
+celerybeat-schedule.db
+
+# Local virtualenv (~490MB, built for the host's architecture). The image runs
+# `uv sync` itself, and copying this in shadows the environment it creates.
+.venv
+activate
+
+# Caches and editor state.
+__pycache__
+*.pyc
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.vscode
+
+# Not needed at runtime.
+tests


### PR DESCRIPTION
Completes the set alongside yeti-platform/yeti-agents#4 and yeti-platform/yeti-feeds-frontend#311.

## Problem

Both Dockerfiles under `extras/docker/` use `ADD . /app`, and there was no `.dockerignore` — so the entire build context, `.git` included, landed in every published image.

Historically this leaked a credential. `actions/checkout` writes an `AUTHORIZATION: basic <token>` extraheader into `.git/config` unless `persist-credentials` is disabled, which #1270 fixed on 2026-05-15. I audited the published images to find the boundary:

| Image | `.git`? | Credential? |
|---|---|---|
| `yeti:latest`, `2.7.1`, `2.7.0`, `dev`, `2.6.1`, `2.5.1` | yes | clean |
| `yeti:2.5.0`, `2.4.2` and earlier | yes | **yes** |

So every release from **2.5.1 onward is clean**, and releases **≤ 2.5.0** (~35 tags) carry a workflow token. Those tokens are long dead — GitHub revokes `GITHUB_TOKEN` when the job ends, and these were built in 2025 or earlier — so this is housekeeping, not an incident. Independently corroborated with a trufflehog scan, which flagged `/app/.git/config` on 2.4.2 and found nothing under `.git` on `latest`.

Current images are credential-free, but they still ship the full repo history for no reason, and that's what makes any future checkout misconfiguration immediately exploitable again. This closes it at the source.

For reference, `yeti-frontend` was never affected at any version (multi-stage build, final image copies only `/app/dist`).

## Changes

`.dockerignore` excluding:
- **`.git`** and other VCS metadata — the point of the PR.
- **`yeti.conf`** — can hold real credentials on a developer's machine. `yeti.conf.sample` is deliberately kept, since the image builds its config from it via `cp yeti.conf.sample yeti.conf`.
- **`.venv`** (~490MB, host architecture) — the image runs its own `uv sync`; copying the host's in shadows it.
- Caches, editor state, `celerybeat-schedule.db`, and `tests/`.

## Test plan
- [x] Built `extras/docker/Dockerfile` with the change — `/app/.git` and `/app/tests` absent
- [x] Everything the build and entrypoint need is still present: `yeti.conf.sample`, `extras/`, `yetictl/`, `plugins/`, `core/`; `/docker-entrypoint.sh` and the generated `/app/yeti.conf` both created
- [x] `/app/.venv` still present and correct — built inside the image by `uv sync`
- [x] `import core.web.webapp` succeeds in the built image, plugin loading included (verified with config supplied via `YETI_AUTH_*` env vars)
- [x] Confirmed nothing reads `.git` at runtime — the only `git+` references in `pyproject.toml` are dependency URLs fetched over the network
- [x] Image size 1.76GB → 1.74GB

## Note
`.gitignore` has `venv*`, which does not match `.venv` (leading dot), so the local virtualenv is neither tracked nor ignored and shows up as untracked in `git status`. Not fixed here to keep this PR focused, but worth a one-line follow-up.