### PR TITLE
Validate the agent's response before writing it to the graph

### DIFF
--- a/plugins/analytics/public/ioc_extractor.py
+++ b/plugins/analytics/public/ioc_extractor.py
@@ -3,6 +3,7 @@ import logging
 from datetime import timedelta
 
 import httpx
+from pydantic import BaseModel, ValidationError
 
 from core import taskmanager
 from core.config.config import yeti_config
@@ -13,6 +14,39 @@ AGENT_HTTP_BASE = yeti_config.get("agents", "http_root")
 AGENT_STREAM_ENDPOINT = f"{AGENT_HTTP_BASE}/run_stream?agent_name=ioc_analyzer"
 
 FILTER_TAG = "extract_iocs"
+
+SSE_DATA_PREFIX = "data:"
+
+# The ioc_analyzer agent declares an ADK output_schema, so its final message is
+# JSON matching the models below. They are deliberately a subset of that schema:
+# unknown fields (tags, last_updated, external_references) are ignored rather
+# than rejected, so the agent can grow its response without breaking ingestion.
+#
+# The IOC types the agent can emit are its own enum, not Yeti's. Anything not
+# mapped here is left to Yeti's guesser.
+AGENT_TYPE_MAPPING = {
+    "sha256": "sha256",
+    "sha1": "sha1",
+    "md5": "md5",
+    "ipv4": "ipv4",
+    "ipv6": "ipv6",
+    "domain": "hostname",
+    "url": "url",
+    "email": "email",
+    "other": None,
+}
+
+
+class IOC(BaseModel):
+    value: str
+    type: str = "other"
+    description: str = ""
+
+
+class AgentReport(BaseModel):
+    title: str
+    summary: str
+    iocs: list[IOC] = []
 
 
 class IOCExtractor(task.AnalyticsTask):
@@ -40,18 +74,57 @@ class IOCExtractor(task.AnalyticsTask):
             "text": f"Analyze {url_obs.value} as per your instructions.",
         }
 
+        last_response = ""
         try:
-            last_response = ""
             with client.stream("POST", endpoint, json=payload) as response:
                 response.raise_for_status()
-                for chunk in response.iter_text():
-                    print(chunk)
-                    parsed_event = json.loads(chunk[6:].strip())
-                    for part in parsed_event["content"]["parts"]:
+                # Iterate lines rather than chunks: iter_text() splits on
+                # arbitrary boundaries, so a chunk may hold several SSE frames
+                # or half of one. Keepalive comments and blank separators are
+                # not JSON and are skipped.
+                for line in response.iter_lines():
+                    line = line.strip()
+                    if not line.startswith(SSE_DATA_PREFIX):
+                        continue
+                    data = line[len(SSE_DATA_PREFIX) :].strip()
+                    if not data:
+                        continue
+                    try:
+                        parsed_event = json.loads(data)
+                    except json.JSONDecodeError:
+                        logging.warning(
+                            "Skipping unparseable event from Agent for URL %s",
+                            url_obs.value,
+                        )
+                        continue
+
+                    # The agent reports its own failures as an event rather than
+                    # an HTTP error; surface the reason instead of letting the
+                    # missing content key look like a parsing bug.
+                    if "error" in parsed_event:
+                        logging.error(
+                            "Agent reported an error processing URL %s: %s (%s)",
+                            url_obs.value,
+                            parsed_event.get("error"),
+                            parsed_event.get("error_type", "unknown"),
+                        )
+                        return
+
+                    for part in parsed_event.get("content", {}).get("parts", []):
                         if "text" in part and not part.get("thought", False):
                             last_response = part["text"]
 
-            parsed_report = json.loads(last_response)
+            try:
+                parsed_report = AgentReport.model_validate_json(last_response)
+            except ValidationError:
+                logging.error(
+                    "Agent response for URL %s did not match the expected schema; "
+                    "no objects were created.",
+                    url_obs.value,
+                )
+                logging.debug(last_response)
+                return
+
             self.process_report(parsed_report, source=url_obs)
 
             url_obs.expire_tag(FILTER_TAG)
@@ -63,24 +136,69 @@ class IOCExtractor(task.AnalyticsTask):
             logging.exception(f"Error processing URL {url_obs.value} with Agent")
             logging.debug(last_response)
 
-    def process_report(self, report, source: observable.Observable):
+    def _build_observable(self, ioc: IOC) -> observable.ObservableTypes | None:
+        """Turns an agent IOC into an unsaved observable, or None if it can't be
+        trusted.
+
+        The agent supplies a type, so there is no need to guess one. Passing it
+        through is not enough on its own: create() will happily build an ipv4
+        holding a hostname, so the value is checked against the type it claims
+        to be. A mismatch means either the value or the type is wrong, and
+        neither is worth storing.
+        """
+        observable_type = AGENT_TYPE_MAPPING.get(ioc.type)
+        try:
+            obs = observable.create(value=ioc.value, type=observable_type)
+        except ValueError:
+            logging.warning(
+                "Skipping IOC with unusable value %r (agent type: %s)",
+                ioc.value,
+                ioc.type,
+            )
+            return None
+
+        if not obs.is_valid:
+            logging.warning(
+                "Skipping IOC %r: value does not match the type the agent "
+                "reported (%s)",
+                ioc.value,
+                ioc.type,
+            )
+            return None
+
+        return obs
+
+    def process_report(self, report: AgentReport, source: observable.Observable):
+        # Build every observable before writing anything. Saving the
+        # investigation first would leave it orphaned, with a partial set of
+        # links, if an IOC further down the list turned out to be unusable.
+        valid_iocs = []
+        for ioc in report.iocs:
+            obs = self._build_observable(ioc)
+            if obs is not None:
+                valid_iocs.append((obs, ioc.description))
+
         report_entity = investigation.Investigation(
-            name=report["title"],
-            description=report["summary"],
+            name=report.title,
+            description=report.summary,
             reference=source.value,
         ).save()
 
         report_entity.link_to(source, "related_to", "source_url")
 
-        for ioc in report["iocs"]:
-            obs = observable.save(value=ioc["value"])
-            obs.add_context(
-                source=self.name, context={"description": ioc["description"]}
+        for obs, description in valid_iocs:
+            saved_obs = obs.save()
+            saved_obs.add_context(
+                source=self.name, context={"description": description}
             )
-            report_entity.link_to(obs, "contains", ioc["description"])
+            report_entity.link_to(saved_obs, "contains", description)
 
+        skipped = len(report.iocs) - len(valid_iocs)
         logging.info(
-            f"Created investigation: {report_entity.id} with {len(report['iocs'])} IOCs"
+            "Created investigation: %s with %d IOCs (%d skipped)",
+            report_entity.id,
+            len(valid_iocs),
+            skipped,
         )
 
 

--- a/tests/core_tests/ioc_extractor.py
+++ b/tests/core_tests/ioc_extractor.py
@@ -1,0 +1,213 @@
+import json
+import logging
+import unittest
+from unittest import mock
+
+from core import database_arango
+from core.schemas import observable
+from core.schemas.entities.investigation import Investigation
+from core.schemas.observable import Observable, ObservableType
+from plugins.analytics.public import ioc_extractor
+
+
+def sse(event: dict) -> str:
+    """Frames an event the way the agent service does: 'data: {json}\\n\\n'."""
+    return f"data: {json.dumps(event)}\n\n"
+
+
+def agent_text(payload) -> dict:
+    """Wraps a final agent answer in the ADK event envelope."""
+    text = payload if isinstance(payload, str) else json.dumps(payload)
+    return {"content": {"parts": [{"text": text}]}}
+
+
+VALID_REPORT = {
+    "title": "Report title",
+    "summary": "Report summary",
+    "tags": ["apt", "phishing"],
+    "last_updated": "2026-08-01",
+    "external_references": [],
+    "iocs": [
+        {"value": "1.2.3.4", "type": "ipv4", "description": "C2 server"},
+        {"value": "evil.example.com", "type": "domain", "description": "Phishing"},
+    ],
+}
+
+
+class FakeStream:
+    """Stands in for the context manager returned by httpx.Client.stream."""
+
+    def __init__(self, chunks: list[str]):
+        self._chunks = chunks
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_text(self):
+        yield from self._chunks
+
+    def iter_lines(self):
+        buffered = "".join(self._chunks)
+        yield from buffered.splitlines()
+
+
+def fake_client(chunks: list[str]) -> mock.MagicMock:
+    client = mock.MagicMock()
+    client.stream.return_value = FakeStream(chunks)
+    return client
+
+
+class IOCExtractorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        database_arango.db.connect(database="yeti_test")
+        database_arango.db.truncate()
+        defaults = ioc_extractor.IOCExtractor._defaults.copy()
+        self.analytics = ioc_extractor.IOCExtractor(**defaults)
+        self.url = observable.save(value="http://report.example.com/apt")
+        self.url.tag([ioc_extractor.FILTER_TAG])
+
+    def run_with(self, chunks: list[str]) -> None:
+        self.analytics.process_url(
+            fake_client(chunks), "http://agent/endpoint", self.url
+        )
+
+    def test_malformed_response_writes_nothing(self) -> None:
+        """A response that is not valid JSON must not create any objects."""
+        self.run_with([sse(agent_text("this is not json at all"))])
+
+        self.assertEqual(Investigation.count(), 0)
+        self.assertEqual(len(Observable.filter({"value": "1.2.3.4"})[0]), 0)
+
+    def test_response_missing_required_fields_writes_nothing(self) -> None:
+        """Well-formed JSON of the wrong shape must not create any objects."""
+        self.run_with([sse(agent_text({"unexpected": "shape"}))])
+
+        self.assertEqual(Investigation.count(), 0)
+
+    def test_valid_report_is_saved_with_iocs(self) -> None:
+        """The happy path creates the investigation and links its IOCs."""
+        self.run_with([sse(agent_text(VALID_REPORT))])
+
+        self.assertEqual(Investigation.count(), 1)
+        investigation = Investigation.find(name="Report title")
+        assert investigation is not None
+        self.assertEqual(investigation.description, "Report summary")
+
+    def test_agent_domain_type_is_translated_to_hostname(self) -> None:
+        """The agent's vocabulary is mapped onto Yeti's.
+
+        The agent says 'domain'; Yeti has no such type and calls it a hostname.
+        """
+        ioc = ioc_extractor.IOC(
+            value="evil.example.com", type="domain", description="Phishing"
+        )
+
+        built = self.analytics._build_observable(ioc)
+
+        assert built is not None
+        self.assertEqual(built.type, ObservableType.hostname)
+
+    def test_ioc_of_unknown_agent_type_falls_back_to_guessing(self) -> None:
+        """'other' carries no type information, so Yeti decides."""
+        ioc = ioc_extractor.IOC(value="1.2.3.4", type="other", description="C2")
+
+        built = self.analytics._build_observable(ioc)
+
+        assert built is not None
+        self.assertEqual(built.type, ObservableType.ipv4)
+
+    def test_untypeable_ioc_does_not_drop_the_iocs_after_it(self) -> None:
+        """A bad IOC is skipped; the ones that follow it are still stored."""
+        report = json.loads(json.dumps(VALID_REPORT))
+        report["iocs"].insert(
+            0,
+            {
+                "value": "see report for hashes",
+                "type": "other",
+                "description": "not an observable",
+            },
+        )
+
+        with self.assertLogs(level=logging.WARNING):
+            self.run_with([sse(agent_text(report))])
+
+        self.assertEqual(Investigation.count(), 1)
+        self.assertEqual(
+            len(Observable.filter({"value": "see report for hashes"})[0]), 0
+        )
+        # Both IOCs listed after the bad one must survive.
+        self.assertEqual(len(Observable.filter({"value": "1.2.3.4"})[0]), 1)
+        self.assertEqual(len(Observable.filter({"value": "evil.example.com"})[0]), 1)
+
+    def test_mismatched_ioc_type_is_skipped(self) -> None:
+        """A value contradicting its declared type is rejected, not re-guessed.
+
+        Yeti would happily guess 'evil.example.com' as a hostname; the agent
+        calling it an ipv4 means one of the two is wrong, so it is not stored.
+        """
+        report = json.loads(json.dumps(VALID_REPORT))
+        report["iocs"] = [
+            {"value": "evil.example.com", "type": "ipv4", "description": "bad"}
+        ]
+
+        with self.assertLogs(level=logging.WARNING):
+            self.run_with([sse(agent_text(report))])
+
+        self.assertEqual(len(Observable.filter({"value": "evil.example.com"})[0]), 0)
+
+    def test_two_events_in_one_chunk(self) -> None:
+        """The stream may deliver several SSE frames in a single chunk."""
+        self.run_with(
+            [sse(agent_text({"content": "ignored"})) + sse(agent_text(VALID_REPORT))]
+        )
+
+        self.assertEqual(Investigation.count(), 1)
+
+    def test_keepalive_lines_are_ignored(self) -> None:
+        """SSE comments and blank lines must not abort processing."""
+        self.run_with([": keep-alive\n\n", sse(agent_text(VALID_REPORT))])
+
+        self.assertEqual(Investigation.count(), 1)
+
+    def test_agent_error_event_is_logged_and_writes_nothing(self) -> None:
+        """An error event from the agent is reported, not silently retried."""
+        error = {"error": "quota exceeded", "error_type": "RESOURCE_EXHAUSTED"}
+
+        with self.assertLogs(level=logging.ERROR) as logs:
+            self.run_with([sse(error)])
+
+        self.assertEqual(Investigation.count(), 0)
+        self.assertTrue(
+            any("RESOURCE_EXHAUSTED" in line for line in logs.output),
+            f"error_type not surfaced in logs: {logs.output}",
+        )
+
+    def test_successful_run_expires_the_filter_tag(self) -> None:
+        """A processed URL is not picked up again on the next run."""
+        self.run_with([sse(agent_text(VALID_REPORT))])
+
+        refreshed = Observable.find(value=self.url.value)
+        assert refreshed is not None
+        tags = refreshed.get_tags()
+        self.assertIn(ioc_extractor.FILTER_TAG, tags)
+        self.assertFalse(tags[ioc_extractor.FILTER_TAG].fresh)
+
+    def test_failed_run_keeps_the_filter_tag(self) -> None:
+        """A rejected response leaves the tag in place for a later retry."""
+        self.run_with([sse(agent_text("not json"))])
+
+        refreshed = Observable.find(value=self.url.value)
+        assert refreshed is not None
+        tags = refreshed.get_tags()
+        self.assertIn(ioc_extractor.FILTER_TAG, tags)
+        self.assertTrue(tags[ioc_extractor.FILTER_TAG].fresh)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`IOCExtractor` parses the agent's streamed reply with `json.loads` and indexes the result
directly, and saves the `Investigation` before the IOC loop that can fail. This PR validates
the response against the schema the agent already declares, and writes nothing until the
whole report has been checked.

Some of this may already be planned — happy to drop any part of it.

### What was happening

`observable.save()` raises `ValueError: Invalid type for observable` for values the model
sometimes returns (`"see report for hashes"`, `"multiple IPs"`, an empty string). Because the
`Investigation` is saved first, a bad value part-way down the list left an orphaned
investigation with a partial set of links — and since the exception escaped before
`url_obs.expire_tag(FILTER_TAG)`, the URL was picked up again on the next run and the partial
write repeated hourly.

Three smaller things surfaced alongside it:

- The stream is read with `json.loads(chunk[6:])` over `iter_text()`, which assumes one whole
  `data:` frame per chunk. `iter_text()` splits on arbitrary boundaries, so two frames in a
  chunk, a frame split across chunks, or a keepalive comment each raise `JSONDecodeError` and
  abort the URL.
- Agent-side failures arrive as `data: {"error": …, "error_type": …}` with no `content.parts`,
  so the `parts` walk raises `KeyError` and is swallowed by the broad handler — the
  `error_type` is lost and a quota error looks like a parsing bug.
- `ioc["type"]` is discarded, so Yeti re-guesses a type the agent already supplied.

### What this changes

`AgentReport` / `IOC` mirror the `Report` / `Ioc` models the `ioc_analyzer` agent declares via
its ADK `output_schema`. They are deliberately a subset — `tags`, `last_updated` and
`external_references` are ignored rather than rejected, so the agent can grow its response
without breaking ingestion. A response that fails validation is logged and skipped with
nothing written.

Observables are built before anything is saved, so an unusable IOC no longer discards the
report or the IOCs listed after it; it is skipped with a warning.

The agent's IOC type is mapped onto Yeti's vocabulary (`domain` → `hostname`, `other` → let
Yeti guess) instead of being re-derived, and the value is checked against the type it claims
to be. That second check is the part that actually matters: `create(value="evil.example.com",
type="ipv4")` does not raise — it builds an `ipv4` holding a hostname. For well-formed values
Yeti's guess and the agent's type agree, so the mapping's practical benefit is catching the
mismatch rather than better typing.

The stream is read with `iter_lines()`, skipping blank and non-`data:` lines and guarding each
`json.loads`, and error events are logged with their `error_type`.

Also removed a leftover `print(chunk)` that wrote raw agent output to worker stdout.

### Tests

`tests/core_tests/ioc_extractor.py`, 12 cases, mocking the httpx client so no agent is needed:
malformed and wrong-shape responses write nothing; a bad IOC does not drop the ones after it;
a value contradicting its declared type is skipped; multiple frames per chunk and keepalive
lines are handled; an error event is logged with its `error_type`; and the filter tag is
expired on success but kept on failure.

### Checks

```
ruff check .              pass
ruff format --check .     pass
ty check                  pass          (core/yetictl)
ty check plugins          pass          (no new diagnostics; the 11 local ones are
                                         unresolved-import for optional deps not
                                         installed locally, which CI installs)
pytest tests/schemas      193 passed
pytest tests/apiv2        217 passed
pytest tests/core_tests    49 passed    (12 new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
