### PR TITLE
Prune embeddings for deleted objects from the ChromaDB index

### DIFF
--- a/plugins/analytics/public/chromadb_indexer.py
+++ b/plugins/analytics/public/chromadb_indexer.py
@@ -93,5 +93,37 @@ class ChromaDBIndexer(task.AnalyticsTask):
             logging.info(f"Upserting {len(ids)} documents into ChromaDB...")
             collection.upsert(documents=docs, ids=ids, metadatas=metadatas)
 
+        # Prune against every object that exists, not just the ones documented
+        # successfully above -- an object whose document failed to build still
+        # exists, and must not have its previously-indexed embedding evicted
+        # because of a transient error.
+        self.prune_deleted(collection, {obj.extended_id for obj in objects_to_index})
+
+    def prune_deleted(self, collection, live_ids: set[str]) -> int:
+        """Removes embeddings whose Yeti object no longer exists.
+
+        Indexing is upsert-only, so deleting an object in Yeti leaves its
+        embedding behind. Those orphans are invisible in results -- the
+        endpoint drops any hit it can't load from the database -- but they
+        still occupy slots in the fixed-size nearest-neighbour window, so a
+        query asking for N results can quietly come back with fewer.
+
+        Reconciling against the full live set (rather than reacting to
+        delete events) means this also repairs drift from any cause: a
+        missed event, an object removed while the indexer was down, or an
+        index restored from an older snapshot.
+
+        Returns:
+            The number of stale embeddings removed.
+        """
+        indexed_ids = set(collection.get(include=[])["ids"])
+        stale_ids = indexed_ids - live_ids
+        if not stale_ids:
+            return 0
+
+        logging.info(f"Pruning {len(stale_ids)} stale documents from ChromaDB...")
+        collection.delete(ids=list(stale_ids))
+        return len(stale_ids)
+
 
 taskmanager.TaskManager.register_task(ChromaDBIndexer)

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -340,6 +340,93 @@ uuid: 00000000-0000-4000-8000-000000000004
         self.assertEqual(sections["dfiq"]["results"][0]["name"], "Suspicious DNS Query")
         self.assertEqual(len(sections["entity"]["results"]), 1, data)
 
+    @mock.patch("core.chromadb_client.get_client")
+    def test_deleted_objects_are_pruned_from_the_index(self, mock_get_client):
+        mock_get_client.return_value = self.chroma_client
+
+        trickbot = entity.save(
+            name="Trickbot", type="malware", description="A banking trojan"
+        )
+        entity.save(name="Emotet", type="malware", description="Botnet")
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        collection = self.chroma_client.get_collection("yeti_semantic_search")
+        self.assertEqual(collection.count(), 2)
+
+        trickbot.delete()
+        indexer.run()
+
+        self.assertEqual(collection.count(), 1)
+        self.assertNotIn(trickbot.extended_id, collection.get(include=[])["ids"])
+
+        # The surviving object is still searchable.
+        response = client.post(
+            "/api/v2/search/semantic", json={"query": "botnet", "count": 10}
+        )
+        data = response.json()
+        sections = sections_by_type(data)
+        self.assertEqual(sections["entity"]["total"], 1, data)
+        self.assertEqual(sections["entity"]["results"][0]["name"], "Emotet")
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_orphans_no_longer_consume_the_result_window(self, mock_get_client):
+        """A stale embedding used to eat a slot in the fixed-size nearest-
+        neighbour window: the endpoint drops hits it can't load, so asking
+        for N could return fewer than N even with N live matches available.
+        """
+        mock_get_client.return_value = self.chroma_client
+
+        doomed = entity.save(
+            name="Trickbot", type="malware", description="A banking trojan"
+        )
+        entity.save(name="Dridex", type="malware", description="A banking trojan")
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        doomed.delete()
+        indexer.run()
+
+        # count=1 must return the one live match, not an empty section that
+        # spent its only slot on the deleted object (which ranks first for
+        # this query, being an exact description match).
+        response = client.post(
+            "/api/v2/search/semantic", json={"query": "banking trojan", "count": 1}
+        )
+        data = response.json()
+        sections = sections_by_type(data)
+        self.assertEqual(sections["entity"]["total"], 1, data)
+        self.assertEqual(sections["entity"]["results"][0]["name"], "Dridex")
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_pruning_ignores_objects_whose_document_failed_to_build(
+        self, mock_get_client
+    ):
+        """A document that fails to build must not evict its own embedding:
+        the object still exists, so the previously-indexed copy should be
+        left alone rather than treated as stale.
+        """
+        mock_get_client.return_value = self.chroma_client
+
+        entity.save(name="Trickbot", type="malware", description="A banking trojan")
+        entity.save(name="Emotet", type="malware", description="Botnet")
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        collection = self.chroma_client.get_collection("yeti_semantic_search")
+        self.assertEqual(collection.count(), 2)
+
+        # Nothing was deleted, but every document build now fails.
+        with mock.patch.object(
+            ChromaDBIndexer, "build_object_document", side_effect=RuntimeError("boom")
+        ):
+            indexer.run()
+
+        self.assertEqual(collection.count(), 2)
+
 
 class ChromaDBClientTest(unittest.TestCase):
     @mock.patch("core.chromadb_client.chromadb.PersistentClient")


### PR DESCRIPTION
## Problem

Indexing is upsert-only, so deleting an object in Yeti left its embedding in ChromaDB forever.

Those orphans never surfaced in results — `/search/semantic` drops any hit it can't load from the database (`obj = cls.get(...)` / `if obj:`) — so no deleted data was ever returned. But they still occupied slots in the fixed-size nearest-neighbour window:

```python
fetch_count = count * 3 if enforce_acls else count
```

Whenever ACLs aren't being enforced (RBAC disabled, or an admin caller) `fetch_count == count` exactly, so **every orphan directly cost a live result** — asking for 5 could return 3, with nothing indicating why. With ACLs on they ate into the 3× overfetch alongside permission-filtered hits. The index also grew without bound on any deployment with real churn.

## Fix

The indexer now reconciles after upserting: diff the ids already in the collection against the ids of every object that currently exists, and delete the difference.

Reconciling rather than reacting to `EventType.delete` is deliberate — it repairs drift from *any* cause: a missed event, an object removed while the indexer was down, or an index restored from an older snapshot. An event consumer would be a reasonable latency optimisation on top later, but on its own it leaves no repair mechanism.

One subtlety worth review: pruning uses the full set of live objects, **not** the ids successfully documented in the same pass. An object whose `build_object_document` call throws still exists, and must not have its previously-indexed embedding evicted because of a transient error. There's a test for exactly that.

## Test plan
- [x] `test_deleted_objects_are_pruned_from_the_index` — deleted object's embedding is gone, survivor still searchable
- [x] `test_orphans_no_longer_consume_the_result_window` — `count=1` returns the live match rather than an empty section that spent its only slot on a deleted object that outranks it
- [x] `test_pruning_ignores_objects_whose_document_failed_to_build` — nothing evicted when every document build fails and nothing was actually deleted
- [x] **Confirmed the two pruning tests fail without the fix** (stashed it and re-ran), so they're genuine regression tests
- [x] Full `tests/core_tests/chromadb_test.py` — 12 passed
- [x] `ruff check` / `ruff format --check` clean

## Note
While investigating this I found the `semantic_score` calculation is built on a wrong assumption — the comment says cosine distance, but the collection is actually using `l2` (verified against the live index: `hnsw.space == 'l2'`). That produces negative scores for genuinely good matches. Fixing separately so this stays reviewable.