### PR TITLE
Normalize semantic_score to a 0-1 similarity

### DIFF
--- a/core/web/apiv2/search.py
+++ b/core/web/apiv2/search.py
@@ -76,6 +76,25 @@ SEMANTIC_TYPE_TO_COLLECTION = {
 }
 
 
+def _similarity_score(distance: float) -> float:
+    """Converts a ChromaDB distance into a 0-1 similarity, 1 being identical.
+
+    The collection uses ChromaDB's default `l2` space, so `distance` is a
+    *squared* euclidean distance, and the default embedding function returns
+    unit-length vectors. For unit vectors ||a-b||^2 == 2 - 2*cos(a, b), which
+    inverts to the cosine similarity below and bounds the raw distance to
+    [0, 4].
+
+    Cosine similarity is itself [-1, 1], so this clamps to [0, 1]. The
+    negative half only occurs for anti-correlated embeddings, which for text
+    means nothing more specific than "unrelated" -- the same thing 0 already
+    conveys -- so clamping loses no usable signal and gives clients a scale
+    they can threshold on directly.
+    """
+    cosine_similarity = 1 - (distance / 2)
+    return round(max(0.0, min(1.0, cosine_similarity)), 4)
+
+
 def _semantic_search_one_type(
     collection, query: str, count: int, collection_name: str, cls, user, enforce_acls
 ) -> SearchResultSection:
@@ -100,10 +119,8 @@ def _semantic_search_one_type(
     )
 
     object_metadatas = results.get("metadatas", [[]])[0]
-    # ChromaDB returns nearest (most similar) first; distance is a cosine
-    # distance (0 = identical, larger = less similar). Surface it as a
-    # bounded-ish "higher is better" score instead, so consumers don't have
-    # to know chroma's convention or re-derive one themselves.
+    # ChromaDB returns nearest (most similar) first. See _similarity_score for
+    # what the raw distance means and how it's converted.
     distances = results.get("distances", [[]])[0]
 
     yeti_objects = []
@@ -119,7 +136,7 @@ def _semantic_search_one_type(
         obj = cls.get(meta["id"])
         if obj:
             obj_dict = obj.model_dump()
-            obj_dict["semantic_score"] = round(1 - distance, 4)
+            obj_dict["semantic_score"] = _similarity_score(distance)
             yeti_objects.append(obj_dict)
 
     type_name = next(

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 from unittest import mock
 
@@ -426,6 +427,79 @@ uuid: 00000000-0000-4000-8000-000000000004
             indexer.run()
 
         self.assertEqual(collection.count(), 2)
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_semantic_scores_stay_within_zero_and_one(self, mock_get_client):
+        """Scores are advertised as a 0-1 similarity, and clients are expected
+        to threshold on them. A weak-but-real match must land inside that
+        range rather than going negative, which is what the previous
+        distance-to-score conversion did.
+        """
+        mock_get_client.return_value = self.chroma_client
+
+        entity.save(name="Trickbot", type="malware", description="A banking trojan")
+        entity.save(
+            name="RandomUnrelated",
+            type="malware",
+            description="Completely unrelated fnord",
+        )
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        response = client.post(
+            "/api/v2/search/semantic",
+            json={"query": "credential stealing banking trojan", "count": 10},
+        )
+        data = response.json()
+        results = sections_by_type(data)["entity"]["results"]
+
+        self.assertEqual(len(results), 2, data)
+        for result in results:
+            self.assertGreaterEqual(result["semantic_score"], 0.0, result)
+            self.assertLessEqual(result["semantic_score"], 1.0, result)
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_index_uses_the_distance_metric_the_score_assumes(self, mock_get_client):
+        """_similarity_score converts a *squared euclidean* distance over
+        unit-length vectors. Both properties come from ChromaDB defaults we
+        never set explicitly, so pin them here: if an upgrade changes either,
+        scores would silently become wrong rather than fail.
+        """
+        mock_get_client.return_value = self.chroma_client
+
+        entity.save(name="Trickbot", type="malware", description="A banking trojan")
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        collection = self.chroma_client.get_collection("yeti_semantic_search")
+        self.assertEqual(collection.configuration_json["hnsw"]["space"], "l2")
+
+        embeddings = collection.get(include=["embeddings"])["embeddings"]
+        for embedding in embeddings:
+            norm = math.sqrt(sum(value * value for value in embedding))
+            self.assertAlmostEqual(norm, 1.0, places=5)
+
+
+class SimilarityScoreTest(unittest.TestCase):
+    def test_converts_squared_l2_distance_to_a_bounded_similarity(self):
+        from core.web.apiv2.search import _similarity_score
+
+        # Unit vectors: ||a-b||^2 == 2 - 2*cos(a, b), so 0 -> identical,
+        # 2 -> orthogonal, 4 -> opposite.
+        self.assertEqual(_similarity_score(0.0), 1.0)
+        self.assertEqual(_similarity_score(1.0), 0.5)
+        self.assertEqual(_similarity_score(2.0), 0.0)
+
+        # Anti-correlated embeddings clamp to 0 rather than going negative.
+        self.assertEqual(_similarity_score(3.0), 0.0)
+        self.assertEqual(_similarity_score(4.0), 0.0)
+
+    def test_is_monotonically_decreasing_in_distance(self):
+        from core.web.apiv2.search import _similarity_score
+
+        scores = [_similarity_score(d / 10) for d in range(0, 21)]
+        self.assertEqual(scores, sorted(scores, reverse=True))
 
 
 class ChromaDBClientTest(unittest.TestCase):


### PR DESCRIPTION
## Problem

`semantic_score` was computed as `1 - distance`, with a comment stating the distance was cosine. It isn't. The collection is created without an explicit `hnsw:space`, so it uses ChromaDB's default **`l2`** — a *squared* euclidean distance over the default embedding function's unit-length vectors, bounded to `[0, 4]`, not `[0, 2]`.

Verified against the live index:
```
{'hnsw': {'space': 'l2', ...}, 'embedding_function': {'name': 'default'}}
```

The practical effect was **negative scores for perfectly good matches**. On live data, `"credential stealing banking trojan"` returned:

| distance | old score | new score |
|---:|---:|---:|
| 0.735 | 0.2648 | **0.6324** |
| 1.108 | **−0.1083** | 0.4458 |
| 1.122 | **−0.1220** | 0.4390 |
| 1.143 | **−0.1427** | 0.4286 |
| 1.146 | **−0.1464** | 0.4268 |

Those are all genuinely related results. A client filtering on `score > 0` would have discarded four of five.

## Fix

For unit vectors `||a-b||² == 2 - 2·cos(a, b)`, so the distance inverts cleanly to a cosine similarity, clamped to `[0, 1]`.

Clamping only discards the anti-correlated half of the cosine range, which for text embeddings means nothing more specific than "unrelated" — the same thing `0` already conveys — so no usable signal is lost.

This makes the field mean what its name implies and gives clients a scale they can threshold on directly, which is the intended way to filter: the endpoint deliberately has no `min_score` parameter, since a server-side cutoff can only be guessed at. (Earlier testing found genuinely correct matches scoring very low with this embedding model, which is exactly why the decision was to let clients decide.)

## Behaviour change

`semantic_score` values change for every result. Nothing persists them — `yeti-python` and the agent tool both pass the field straight through — so there's no migration, but anyone who has hand-tuned a client-side threshold against the old scale will need to retune. Worth a changelog mention.

## Test plan
- [x] `test_semantic_scores_stay_within_zero_and_one` — **confirmed it fails without the fix** (stashed and re-ran)
- [x] `SimilarityScoreTest` — conversion across the range (0→1.0, 1→0.5, 2→0.0, 3 and 4 clamped), and monotonicity
- [x] `test_index_uses_the_distance_metric_the_score_assumes` — pins both assumptions the conversion depends on (`hnsw.space == "l2"`, unit-length embeddings). Both are ChromaDB defaults we never set, so if an upgrade changes either, this fails rather than scores silently becoming wrong.
- [x] Full `tests/core_tests/chromadb_test.py` — 13 passed
- [x] `ruff check` / `ruff format --check` / `ty check` clean

Stacked conceptually on #1352 (index pruning) but touches different code; either can land first.