### PR TITLE
Index objects as several focused documents instead of one fat one

### DIFF
--- a/core/schemas/dfiq.py
+++ b/core/schemas/dfiq.py
@@ -391,6 +391,38 @@ class DFIQQuestion(DFIQBase):
     type: Literal[DFIQType.question] = DFIQType.question
     approaches: list["DFIQApproach"] = []
 
+    def semantic_documents(self) -> list[tuple[str, str]]:
+        """Embeds each approach separately, on top of the question itself.
+
+        A question's approaches are where the actionable detail lives -- the
+        artifacts, tooling and queries used to answer it -- and they are the
+        only place that vocabulary appears. Folding them into the question's
+        own document would bury it: approaches are long enough to be cut by
+        the embedding model's input limit, and averaging several unrelated
+        collection methods into one vector matches none of them well.
+
+        Approaches are not objects of their own, so these documents still
+        resolve back to this question; they only give it more ways to match.
+        """
+        documents = super().semantic_documents()
+
+        for index, approach in enumerate(self.approaches):
+            parts = [f"Approach: {approach.name}"]
+            if approach.description:
+                parts.append(approach.description)
+            if approach.tags:
+                parts.append(f"Tags: {', '.join(approach.tags)}")
+            for step in approach.steps:
+                details = [
+                    detail
+                    for detail in (step.name, step.type, step.value, step.description)
+                    if detail
+                ]
+                parts.append("Step: " + " | ".join(details))
+            documents.append((f"approach:{index}", "\n".join(parts)))
+
+        return documents
+
     @classmethod
     def from_yaml(cls, yaml_string: str) -> "DFIQQuestion":
         yaml_data = cls.parse_yaml(yaml_string)

--- a/core/schemas/model.py
+++ b/core/schemas/model.py
@@ -55,6 +55,38 @@ class YetiBaseModel(BaseModel):
         @property
         def extended_id(self) -> str: ...
 
+    def semantic_documents(self) -> list[tuple[str, str]]:
+        """Returns the texts to embed for semantic search, as (suffix, text).
+
+        One object can produce several documents. That matters because an
+        embedding encodes a single meaning: concatenating everything an object
+        knows into one text yields a vector sitting at the average of those
+        topics, matching none of them well. Embedding models also truncate --
+        the default one silently cuts at roughly 110 words -- so a long
+        combined document mostly gets discarded anyway.
+
+        The suffix distinguishes an object's documents from each other; the
+        indexer combines it with the object's extended_id to form the vector's
+        id, and search groups the results back per object. Overrides should
+        keep each document focused on one thing and return "self" first.
+        """
+        parts = []
+        for label, field in (("Name", "name"), ("Value", "value")):
+            value = getattr(self, field, None)
+            if value:
+                parts.append(f"{label}: {value}")
+
+        description = getattr(self, "description", None)
+        if description:
+            parts.append(f"Description: {description}")
+
+        tags = getattr(self, "tags", None) or getattr(self, "dfiq_tags", None) or []
+        tag_names = [getattr(t, "name", None) or str(t) for t in tags]
+        if tag_names:
+            parts.append(f"Tags: {', '.join(tag_names)}")
+
+        return [("self", "\n".join(parts))]
+
 
 class YetiContextModel(YetiBaseModel):
     context: list[dict] = []

--- a/core/web/apiv2/search.py
+++ b/core/web/apiv2/search.py
@@ -107,11 +107,13 @@ def _semantic_search_one_type(
     """
     from core.schemas import roles
 
-    # ACL filtering happens after the nearest-neighbor search, so overfetch to
-    # absorb candidates the user can't see and still have a shot at `count`
-    # results -- not a guarantee: if visibility is narrow enough, fewer than
-    # `count` results can still come back even after overfetching.
-    fetch_count = count * 3 if enforce_acls else count
+    # Two things shrink the candidate list after the nearest-neighbour search:
+    # ACL filtering, and rolling several documents belonging to one object back
+    # into a single result. Overfetch to absorb both and still have a shot at
+    # `count` results -- not a guarantee: if visibility is narrow enough, or one
+    # object dominates the window with many of its own documents, fewer than
+    # `count` can still come back.
+    fetch_count = count * 3 if enforce_acls else count * 2
     results = collection.query(
         query_texts=[query],
         n_results=fetch_count,
@@ -124,19 +126,32 @@ def _semantic_search_one_type(
     distances = results.get("distances", [[]])[0]
 
     yeti_objects = []
+    seen_objects = set()
     for meta, distance in zip(object_metadatas, distances):
         if len(yeti_objects) >= count:
             break
         if "id" not in meta:
             continue
+        # An object is indexed as several documents (its own text, plus one per
+        # DFIQ approach), any of which can match. Results are already ordered
+        # best-first, so the first document seen for an object is its best one
+        # and the rest are dropped -- the object is what's being returned, not
+        # the document that happened to match.
+        extended_id = meta.get("extended_id", "")
+        if extended_id in seen_objects:
+            continue
         if enforce_acls and not user.has_permissions(
-            meta.get("extended_id", ""), roles.Permission.READ
+            extended_id, roles.Permission.READ
         ):
             continue
         obj = cls.get(meta["id"])
         if obj:
+            seen_objects.add(extended_id)
             obj_dict = obj.model_dump()
             obj_dict["semantic_score"] = _similarity_score(distance)
+            # Which document matched: "self" for the object's own text, or
+            # "approach:N". Useful for explaining *why* something was returned.
+            obj_dict["matched_on"] = meta.get("chunk", "self")
             yeti_objects.append(obj_dict)
 
     type_name = next(

--- a/plugins/analytics/public/chromadb_indexer.py
+++ b/plugins/analytics/public/chromadb_indexer.py
@@ -32,36 +32,26 @@ class ChromaDBIndexer(task.AnalyticsTask):
         "dfiq-facet",
     ]
 
-    def build_object_document(self, yeti_obj) -> str:
-        """Builds a semantic representation of a yeti object including neighbors."""
-        parts = []
-        if getattr(yeti_obj, "name", None):
-            parts.append(f"Name: {yeti_obj.name}")
-        if getattr(yeti_obj, "value", None):
-            parts.append(f"Value: {yeti_obj.value}")
-        if getattr(yeti_obj, "description", None):
-            parts.append(f"Description: {yeti_obj.description}")
+    def build_object_documents(self, yeti_obj) -> list[tuple[str, str]]:
+        """Returns the (suffix, text) documents to embed for an object.
 
-        tags = getattr(yeti_obj, "tags", [])
-        if tags:
-            tag_names = [t.name if hasattr(t, "name") else str(t) for t in tags]
-            parts.append(f"Tags: {', '.join(tag_names)}")
+        The object decides how it wants to be represented -- see
+        YetiBaseModel.semantic_documents() -- so type-specific knowledge
+        (a DFIQ question emitting one document per approach, say) lives with
+        the type rather than here.
 
-        try:
-            vertices, _, _ = yeti_obj.neighbors()
-            neighbor_names = []
-            for neighbor in vertices.values():
-                val = getattr(neighbor, "name", "") or getattr(neighbor, "value", "")
-                desc = getattr(neighbor, "description", "")
-                n_str = f"{val} ({desc})" if desc else val
-                if n_str:
-                    neighbor_names.append(n_str)
-            if neighbor_names:
-                parts.append("Neighbors: " + " | ".join(neighbor_names))
-        except Exception as e:
-            logging.error(f"Failed to get neighbors for {yeti_obj.id}: {e}")
-
-        return "\n".join(parts)
+        Neighbour text is deliberately not included. It used to be appended to
+        every document, on the theory that an object should be findable by the
+        things it links to. Measured against real data it did the opposite: it
+        pulled each vector toward the average of its neighbourhood, so objects
+        ranked *worse* for queries matching their own name and description.
+        Removing it moved the "Suspicious DNS Query" scenario from second place
+        to first for a query naming it almost exactly, and raised an unrelated
+        question's score for its own subject matter from 0.36 to 0.61. The
+        graph already answers "what is this related to" precisely, and callers
+        who want that can traverse it.
+        """
+        return yeti_obj.semantic_documents()
 
     def run(self, params: dict = {}):
         collection = get_semantic_collection()
@@ -73,19 +63,26 @@ class ChromaDBIndexer(task.AnalyticsTask):
         docs = []
         ids = []
         metadatas = []
+        documented = set()
 
         for obj in objects_to_index:
             try:
-                docs.append(self.build_object_document(obj))
-                ids.append(obj.extended_id)
-                metadatas.append(
-                    {
-                        "id": obj.id,
-                        "extended_id": obj.extended_id,
-                        "collection": obj._collection_name,
-                        "type": getattr(obj, "type", "unknown"),
-                    }
-                )
+                for suffix, document in self.build_object_documents(obj):
+                    docs.append(document)
+                    # One object can produce several vectors, so the id is
+                    # namespaced per document; extended_id in the metadata is
+                    # what ties them back together for search and pruning.
+                    ids.append(f"{obj.extended_id}#{suffix}")
+                    metadatas.append(
+                        {
+                            "id": obj.id,
+                            "extended_id": obj.extended_id,
+                            "chunk": suffix,
+                            "collection": obj._collection_name,
+                            "type": getattr(obj, "type", "unknown"),
+                        }
+                    )
+                documented.add(obj.extended_id)
             except Exception as e:
                 logging.error(f"Error building document for {obj.id}: {e}")
 
@@ -93,36 +90,65 @@ class ChromaDBIndexer(task.AnalyticsTask):
             logging.info(f"Upserting {len(ids)} documents into ChromaDB...")
             collection.upsert(documents=docs, ids=ids, metadatas=metadatas)
 
-        # Prune against every object that exists, not just the ones documented
-        # successfully above -- an object whose document failed to build still
-        # exists, and must not have its previously-indexed embedding evicted
-        # because of a transient error.
-        self.prune_deleted(collection, {obj.extended_id for obj in objects_to_index})
+        self.prune_deleted(
+            collection,
+            live_object_ids={obj.extended_id for obj in objects_to_index},
+            live_document_ids=set(ids),
+            documented_object_ids=documented,
+        )
 
-    def prune_deleted(self, collection, live_ids: set[str]) -> int:
-        """Removes embeddings whose Yeti object no longer exists.
+    def prune_deleted(
+        self,
+        collection,
+        live_object_ids: set[str],
+        live_document_ids: set[str],
+        documented_object_ids: set[str],
+    ) -> int:
+        """Removes embeddings that no longer correspond to anything.
 
-        Indexing is upsert-only, so deleting an object in Yeti leaves its
-        embedding behind. Those orphans are invisible in results -- the
-        endpoint drops any hit it can't load from the database -- but they
-        still occupy slots in the fixed-size nearest-neighbour window, so a
-        query asking for N results can quietly come back with fewer.
+        Indexing is upsert-only, so anything that disappears from Yeti leaves
+        its embedding behind. Those orphans never surface in results -- the
+        endpoint drops any hit it can't load -- but they still occupy slots in
+        the fixed-size nearest-neighbour window, so a query asking for N
+        results can quietly come back with fewer.
 
-        Reconciling against the full live set (rather than reacting to
-        delete events) means this also repairs drift from any cause: a
-        missed event, an object removed while the indexer was down, or an
-        index restored from an older snapshot.
+        Reconciling against the live set (rather than reacting to delete
+        events) also repairs drift from any cause: a missed event, an object
+        removed while the indexer was down, or an index restored from an
+        older snapshot.
+
+        Two different things can go stale, because one object owns several
+        documents:
+
+        - the whole object is gone, so every document under it should go;
+        - the object remains but no longer produces a given document, e.g. a
+          DFIQ question that dropped an approach. Its id simply stops being
+          generated, and nothing else would ever clean it up.
+
+        Objects whose documents failed to build this run are deliberately left
+        alone: they still exist, and a transient error must not evict what was
+        indexed for them previously.
 
         Returns:
-            The number of stale embeddings removed.
+            The number of stale documents removed.
         """
-        indexed_ids = set(collection.get(include=[])["ids"])
-        stale_ids = indexed_ids - live_ids
+        indexed = collection.get(include=["metadatas"])
+
+        stale_ids = []
+        for document_id, metadata in zip(indexed["ids"], indexed["metadatas"]):
+            owner = (metadata or {}).get("extended_id")
+            if owner not in live_object_ids:
+                stale_ids.append(document_id)
+            elif (
+                owner in documented_object_ids and document_id not in live_document_ids
+            ):
+                stale_ids.append(document_id)
+
         if not stale_ids:
             return 0
 
         logging.info(f"Pruning {len(stale_ids)} stale documents from ChromaDB...")
-        collection.delete(ids=list(stale_ids))
+        collection.delete(ids=stale_ids)
         return len(stale_ids)
 
 

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -162,8 +162,11 @@ parent_ids:
         indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
         indexer.run()
 
-        # 4. Search for the description of the *question*
-        # Because we index neighbors, the scenario's text document should include the question's text
+        # 4. Both objects are indexed and searchable in their own right.
+        # (They used to be linked through neighbour text embedded into the
+        # scenario's document; that was removed because it dragged every
+        # vector toward its neighbourhood and hurt ranking. Relationships are
+        # the graph's job, not the embedding's.)
         response = client.post(
             "/api/v2/search/semantic",
             json={"query": "How did they get in exactly?", "count": 10},
@@ -171,8 +174,6 @@ parent_ids:
         data = response.json()
         sections = sections_by_type(data)
 
-        # We expect the scenario to be returned because it has the question as a neighbor
-        # And the question too!
         returned_names = [r["name"] for r in sections["dfiq"]["results"]]
         self.assertIn("Ransomware Investigation", returned_names)
         self.assertIn("Initial Access Vector", returned_names)
@@ -342,6 +343,58 @@ uuid: 00000000-0000-4000-8000-000000000004
         self.assertEqual(len(sections["entity"]["results"]), 1, data)
 
     @mock.patch("core.chromadb_client.get_client")
+    def test_semantic_scores_stay_within_zero_and_one(self, mock_get_client):
+        """Scores are advertised as a 0-1 similarity, and clients are expected
+        to threshold on them. A weak-but-real match must land inside that
+        range rather than going negative, which is what the previous
+        distance-to-score conversion did.
+        """
+        mock_get_client.return_value = self.chroma_client
+
+        entity.save(name="Trickbot", type="malware", description="A banking trojan")
+        entity.save(
+            name="RandomUnrelated",
+            type="malware",
+            description="Completely unrelated fnord",
+        )
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        response = client.post(
+            "/api/v2/search/semantic",
+            json={"query": "credential stealing banking trojan", "count": 10},
+        )
+        data = response.json()
+        results = sections_by_type(data)["entity"]["results"]
+
+        self.assertEqual(len(results), 2, data)
+        for result in results:
+            self.assertGreaterEqual(result["semantic_score"], 0.0, result)
+            self.assertLessEqual(result["semantic_score"], 1.0, result)
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_index_uses_the_distance_metric_the_score_assumes(self, mock_get_client):
+        """_similarity_score converts a *squared euclidean* distance over
+        unit-length vectors. Both properties come from ChromaDB defaults we
+        never set explicitly, so pin them here: if an upgrade changes either,
+        scores would silently become wrong rather than fail.
+        """
+        mock_get_client.return_value = self.chroma_client
+
+        entity.save(name="Trickbot", type="malware", description="A banking trojan")
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        collection = self.chroma_client.get_collection("yeti_semantic_search")
+        self.assertEqual(collection.configuration_json["hnsw"]["space"], "l2")
+
+        embeddings = collection.get(include=["embeddings"])["embeddings"]
+        for embedding in embeddings:
+            norm = math.sqrt(sum(value * value for value in embedding))
+            self.assertAlmostEqual(norm, 1.0, places=5)
+
+    @mock.patch("core.chromadb_client.get_client")
     def test_deleted_objects_are_pruned_from_the_index(self, mock_get_client):
         mock_get_client.return_value = self.chroma_client
 
@@ -422,63 +475,150 @@ uuid: 00000000-0000-4000-8000-000000000004
 
         # Nothing was deleted, but every document build now fails.
         with mock.patch.object(
-            ChromaDBIndexer, "build_object_document", side_effect=RuntimeError("boom")
+            ChromaDBIndexer, "build_object_documents", side_effect=RuntimeError("boom")
         ):
             indexer.run()
 
         self.assertEqual(collection.count(), 2)
 
     @mock.patch("core.chromadb_client.get_client")
-    def test_semantic_scores_stay_within_zero_and_one(self, mock_get_client):
-        """Scores are advertised as a 0-1 similarity, and clients are expected
-        to threshold on them. A weak-but-real match must land inside that
-        range rather than going negative, which is what the previous
-        distance-to-score conversion did.
+    def test_question_approaches_are_indexed_as_their_own_documents(
+        self, mock_get_client
+    ):
+        """Approach content -- artifacts, tooling, queries -- only exists
+        inside a question's approaches, and is the vocabulary someone
+        searching "how do I collect X" actually uses. Each approach gets its
+        own vector so it can match without being averaged into the
+        question's own text.
         """
         mock_get_client.return_value = self.chroma_client
+        from core.schemas.dfiq import DFIQQuestion
 
-        entity.save(name="Trickbot", type="malware", description="A banking trojan")
-        entity.save(
-            name="RandomUnrelated",
-            type="malware",
-            description="Completely unrelated fnord",
-        )
+        DFIQQuestion.from_yaml("""
+type: question
+id: Q0201
+dfiq_version: 1.0.0
+name: What files were downloaded using a web browser?
+description: Downloads question.
+uuid: 00000000-0000-4000-8000-000000000101
+parent_ids: []
+approaches:
+  - name: Detect browser downloads via change journal records
+    description: Uses NTFS USN journal records.
+    steps:
+      - name: Collect ForensicArtifact data
+        stage: collection
+        type: ForensicArtifact
+        value: NTFSUSNJournal
+      - name: Process data with Plaso
+        stage: processing
+        type: command
+        value: Plaso
+""").save()
 
-        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
-        indexer.run()
-
-        response = client.post(
-            "/api/v2/search/semantic",
-            json={"query": "credential stealing banking trojan", "count": 10},
-        )
-        data = response.json()
-        results = sections_by_type(data)["entity"]["results"]
-
-        self.assertEqual(len(results), 2, data)
-        for result in results:
-            self.assertGreaterEqual(result["semantic_score"], 0.0, result)
-            self.assertLessEqual(result["semantic_score"], 1.0, result)
-
-    @mock.patch("core.chromadb_client.get_client")
-    def test_index_uses_the_distance_metric_the_score_assumes(self, mock_get_client):
-        """_similarity_score converts a *squared euclidean* distance over
-        unit-length vectors. Both properties come from ChromaDB defaults we
-        never set explicitly, so pin them here: if an upgrade changes either,
-        scores would silently become wrong rather than fail.
-        """
-        mock_get_client.return_value = self.chroma_client
-
-        entity.save(name="Trickbot", type="malware", description="A banking trojan")
         indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
         indexer.run()
 
         collection = self.chroma_client.get_collection("yeti_semantic_search")
-        self.assertEqual(collection.configuration_json["hnsw"]["space"], "l2")
+        chunks = {
+            m["chunk"] for m in collection.get(include=["metadatas"])["metadatas"]
+        }
+        self.assertEqual(chunks, {"self", "approach:0"})
 
-        embeddings = collection.get(include=["embeddings"])["embeddings"]
-        for embedding in embeddings:
-            norm = math.sqrt(sum(value * value for value in embedding))
-            self.assertAlmostEqual(norm, 1.0, places=5)
+        # The artifact/tooling vocabulary appears nowhere in the question's
+        # own name or description, so this only matches via the approach.
+        response = client.post(
+            "/api/v2/search/semantic",
+            json={"query": "NTFS USN journal records with Plaso", "count": 5},
+        )
+        data = response.json()
+        results = sections_by_type(data)["dfiq"]["results"]
+
+        self.assertEqual(len(results), 1, data)
+        self.assertEqual(
+            results[0]["name"], "What files were downloaded using a web browser?"
+        )
+        self.assertEqual(results[0]["matched_on"], "approach:0")
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_an_object_is_returned_once_however_many_documents_match(
+        self, mock_get_client
+    ):
+        mock_get_client.return_value = self.chroma_client
+        from core.schemas.dfiq import DFIQQuestion
+
+        DFIQQuestion.from_yaml("""
+type: question
+id: Q0202
+dfiq_version: 1.0.0
+name: What browser downloads happened?
+description: Browser downloads.
+uuid: 00000000-0000-4000-8000-000000000102
+parent_ids: []
+approaches:
+  - name: Browser download history
+    description: Look at browser download history.
+    steps: []
+  - name: Browser download artifacts on disk
+    description: Look at browser download artifacts.
+    steps: []
+""").save()
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        # All three documents are strong matches for this query; the object
+        # must still come back once.
+        response = client.post(
+            "/api/v2/search/semantic",
+            json={"query": "browser downloads", "count": 5},
+        )
+        data = response.json()
+        results = sections_by_type(data)["dfiq"]["results"]
+
+        self.assertEqual(len(results), 1, data)
+        self.assertEqual(results[0]["name"], "What browser downloads happened?")
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_documents_an_object_stops_producing_are_pruned(self, mock_get_client):
+        """Chunking adds a second way to go stale: the object survives but
+        stops emitting one of its documents. Nothing else would clean that
+        up, and the orphan would keep matching.
+        """
+        mock_get_client.return_value = self.chroma_client
+        from core.schemas.dfiq import DFIQQuestion
+
+        question = DFIQQuestion.from_yaml("""
+type: question
+id: Q0203
+dfiq_version: 1.0.0
+name: A question with approaches
+description: Has two approaches to start with.
+uuid: 00000000-0000-4000-8000-000000000103
+parent_ids: []
+approaches:
+  - name: First approach
+    description: The first one.
+    steps: []
+  - name: Second approach
+    description: The second one.
+    steps: []
+""").save()
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+
+        collection = self.chroma_client.get_collection("yeti_semantic_search")
+        self.assertEqual(collection.count(), 3)
+
+        question.approaches = question.approaches[:1]
+        question.save()
+        indexer.run()
+
+        remaining = {
+            m["chunk"] for m in collection.get(include=["metadatas"])["metadatas"]
+        }
+        self.assertEqual(remaining, {"self", "approach:0"})
 
 
 class SimilarityScoreTest(unittest.TestCase):


### PR DESCRIPTION
Rebased onto `main` now that #1352 and #1353 have merged: this PR is a single commit containing only the multi-vector change.

## Problem

Every object was embedded as one document: its own text plus the name and description of every neighbour. Measured against the live index, that was wrong three ways.

**It diluted.** An embedding encodes a single meaning, so averaging an object's text with its neighbourhood pulls the vector toward the neighbourhood and away from the object. Removing neighbour text, on real data:

| query | before | after |
|---|---|---|
| "investigate a suspicious DNS query" | wrong facet 1st, scenario 2nd | **scenario 1st** |
| "opensearch query to find browser downloads" | 0.364, ranked 2nd | **0.609, ranked 1st** |

Same object, same query — the only change is not burying it under its neighbours.

**It was silently truncated.** The default model cuts at ~110 words; **11.9% of documents exceeded it**. Neighbours are appended last, so for well-connected objects an arbitrary subset — whatever order `neighbors()` returned — decided the embedding and the rest was discarded. The vector also shifted whenever any neighbour changed.

**DFIQ approaches were not indexed at all.** They're nested inside a question rather than being objects, and nothing read them. So this question's entire embedded document was:

```
Name: What files were downloaded using a web browser?
Neighbors: <text from two unrelated sibling questions>
```

`NTFSUSNJournal`, `Plaso`, the `opensearch-query` — absent. The "how do I collect X" query mode could not work, because that vocabulary was never indexed.

## Approach

Objects describe themselves via `semantic_documents()` → `list[(suffix, text)]`. Default returns one focused document; `DFIQQuestion` overrides to add one per approach. Type-specific knowledge lives with the type rather than in the indexer.

Vector ids become `<extended_id>#<suffix>`; `extended_id` in metadata ties them back. Search groups by object, keeps the best-scoring document, and reports which one matched via a new **`matched_on`** field (`"self"` or `"approach:N"`) — so a result can explain *why* it came back.

Neighbours are dropped. The graph already answers "what is this related to" precisely and explainably; approximating it by smearing text into vectors cost ranking quality and bought nothing.

## Results on the live index

| | before | after |
|---|---|---|
| vectors | 2010 | 2026 (+0.8%) |
| documents over truncation limit | 11.9% | **0.5%** |
| "NTFS USN journal using Plaso" | no match | **0.345 via `approach:3`** |

## Pruning

Chunking adds a second staleness case, so #1352's reconcile is extended here: an object can survive but stop producing one of its documents (a question that dropped an approach). Its id stops being generated and nothing else would clean it up. Objects whose documents failed to build are still left alone, so a transient error can't evict prior work.

## Test plan
- [x] `test_question_approaches_are_indexed_as_their_own_documents` — approach-only vocabulary matches, returns the question, `matched_on == "approach:0"`
- [x] `test_an_object_is_returned_once_however_many_documents_match` — no duplicates when several documents of one object match
- [x] `test_documents_an_object_stops_producing_are_pruned` — dropped approach's vector removed, `self` + remaining approach kept
- [x] Existing prune/score/ACL/crowding tests still pass — 19 total
- [x] `ruff check` / `format` / `ty check` clean
- [x] Live-verified end to end through the real API after a full reindex

## Note
`acts_on` still lists `dfiq-approach`, which was never a real object type, and `run()` ignores `acts_on` entirely. Left alone to keep this reviewable, but it's misleading and worth a follow-up.
