### PR TITLE
Build on python:3.13-slim instead of the full image

### DIFF
--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,10 +1,18 @@
 # Actual Yeti container
-FROM python:3.13 AS yeti
+#
+# -slim rather than the full python image: the latter descends from
+# buildpack-deps, which drags in development headers for software Yeti does not
+# use -- libpq among them, so every PostgreSQL advisory shows up in scans of an
+# image that has no PostgreSQL server and talks to ArangoDB. Slim carries 223
+# packages instead of 487. git is needed because a dependency is a git+https
+# URL; no compiler is required, every C extension resolves to a wheel.
+FROM python:3.13-slim AS yeti
 
 # Python
 RUN apt-get update && apt-get install -y \
     python3-pip \
     libmagic-dev \
+    git \
     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 ADD . /app

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -3,15 +3,19 @@
 # -slim rather than the full python image: the latter descends from
 # buildpack-deps, which drags in development headers for software Yeti does not
 # use -- libpq among them, so every PostgreSQL advisory shows up in scans of an
-# image that has no PostgreSQL server and talks to ArangoDB. Slim carries 223
-# packages instead of 487. git is needed because a dependency is a git+https
-# URL; no compiler is required, every C extension resolves to a wheel.
+# image that has no PostgreSQL server and talks to ArangoDB.
 FROM python:3.13-slim AS yeti
 
-# Python
+# gcc and libc6-dev build yara-python, which publishes no wheel for this
+# platform. They used to arrive by accident: the python3-pip package pulled a
+# compiler in as a dependency, so removing it broke the build in a way that
+# had nothing to do with pip. The image's own pip is what actually gets used.
+#
+# git is here because one dependency is a git+https URL and uv needs it to
+# resolve.
 RUN apt-get update && apt-get install -y \
-    python3-pip \
-    libmagic-dev \
+    gcc \
+    libc6-dev \
     git \
     && apt-get clean && rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -1,18 +1,12 @@
 # Actual Yeti container
 #
-# -slim rather than the full python image: the latter descends from
-# buildpack-deps, which drags in development headers for software Yeti does not
-# use -- libpq among them, so every PostgreSQL advisory shows up in scans of an
-# image that has no PostgreSQL server and talks to ArangoDB.
+# -slim avoids buildpack-deps, whose development headers (libpq among them) are
+# unused by Yeti and only add size and scan surface.
 FROM python:3.13-slim AS yeti
 
-# gcc and libc6-dev build yara-python, which publishes no wheel for this
-# platform. They used to arrive by accident: the python3-pip package pulled a
-# compiler in as a dependency, so removing it broke the build in a way that
-# had nothing to do with pip. The image's own pip is what actually gets used.
-#
-# git is here because one dependency is a git+https URL and uv needs it to
-# resolve.
+# gcc and libc6-dev are required to compile yara-python, which publishes no
+# wheel for this platform. git is required to resolve a dependency pinned to a
+# git+https URL.
 RUN apt-get update && apt-get install -y \
     gcc \
     libc6-dev \


### PR DESCRIPTION
## Why

Prompted by a scan flagging **CVE-2026-6473** against the published image. That finding is a false positive twice over:

- The vulnerability is in the PostgreSQL **core server**; the image only has `libpq5` (client library) and `libpq-dev` (headers), and Yeti talks to ArangoDB.
- The 17.x fix is **17.10**, and every published image already ships a patched version — `2.6.0` and `2.7.1` at `17.10-0+deb13u1`, `:dev` at `17.11-0+deb13u1`.

Scanners flag it because Debian builds `libpq5`/`libpq-dev` from the `postgresql-17` source package, and many match on source package without checking version or which component is installed.

But the packages shouldn't be in the image at all. They're there only because `python:3.13` descends from `buildpack-deps`, which installs development headers for a lot of software Yeti never uses. Bumping the base wouldn't help — it's already Debian 13 trixie and already patched. Removing the surface does.

## Changes

**1. Build on `python:3.13-slim`.** Drops the buildpack-deps inheritance, and with it libpq.

**2. Declare build dependencies explicitly.** This came out of trying to remove `python3-pip` as redundant — the build then failed with `error: [Errno 2] No such file or directory: 'gcc'`. `yara-python` publishes no wheel for this platform and must compile; the compiler had been arriving purely as a transitive dependency of `python3-pip`. The image ships its own pip, so that package was otherwise doing nothing. `gcc` and `libc6-dev` are now named directly.

**3. Drop `libmagic-dev`.** Nothing imports `magic`; `python-magic` appears in neither `pyproject.toml` nor `uv.lock`; and no installed package references `libmagic` (checked across site-packages — the only hit was the word "semi-magic" in a numpy comment).

`git` is retained: one dependency is a `git+https` URL and uv needs it to resolve.

| | before | after |
|---|---|---|
| libpq/postgres packages | 2 | **0** |
| total packages | 487 | **179** |
| image size | 1.75 GB | **1.0 GB** (−43%) |

Both published tags (`:latest` and `:dev`) build from this Dockerfile, so both are covered.

## Test plan
- [x] Builds clean from the committed Dockerfile
- [x] `import core.web.webapp` succeeds in the built image
- [x] `yara`, `plyara`, `idstools`, `artifacts` all import — this is the check that catches the missing-compiler case, since `yara` is the one that compiles
- [x] `/docker-entrypoint.sh` and the generated `/app/yeti.conf` both present
- [x] `yetictl` fails identically in old and new images (missing `auth.secret_key`) — no behavioural difference
- [x] `.git` still absent, confirming the `.dockerignore` from #1350 still applies
- [x] `libpq`/`postgres` package count is 0 in the result

## Note on verification
The compiler dependency was previously implicit, and an earlier revision of this PR incorrectly claimed no compiler was needed — it built only because `python3-pip` happened to supply one. Worth reviewing that `gcc`/`libc6-dev` is the right minimal set rather than assuming; `build-essential` would be the safer-but-larger alternative if anything else turns out to need compiling later.