### PR TITLE
Bake the embedding model into the image and disable chromadb telemetry

### DIFF
--- a/core/chromadb_client.py
+++ b/core/chromadb_client.py
@@ -2,6 +2,7 @@ import os
 
 import chromadb
 from chromadb.api.shared_system_client import SharedSystemClient
+from chromadb.config import Settings
 
 from core.config.config import yeti_config
 
@@ -27,7 +28,12 @@ def get_client() -> chromadb.ClientAPI:
     if not os.path.exists(path):
         os.makedirs(path, exist_ok=True)
 
-    client = chromadb.PersistentClient(path=path)
+    # chromadb posts anonymized usage events to PostHog by default. Yeti is
+    # deployed on networks with no outbound internet access, where those calls
+    # only cost latency and log noise.
+    client = chromadb.PersistentClient(
+        path=path, settings=Settings(anonymized_telemetry=False)
+    )
     return client
 
 

--- a/extras/docker/Dockerfile
+++ b/extras/docker/Dockerfile
@@ -25,6 +25,20 @@ RUN pip3 install --upgrade pip && pip3 install uv
 # Install yeti
 RUN uv sync --group plugins
 
+# Bake in the embedding model chromadb's default embedding function uses.
+# It is otherwise fetched from the network on first use, which fails on
+# deployments without internet access. Warming it through chromadb rather than
+# downloading the archive directly verifies the SHA256 chromadb pins and keeps
+# the model in step with the resolved chromadb version. Only the extracted
+# files are looked up at runtime, so the archive is dropped: keeping it would
+# double the ~88MB cost for nothing.
+#
+# The cache path is derived from $HOME with no override, so this must be
+# written by the same user that runs Yeti.
+RUN uv run python -c \
+    "from chromadb.utils.embedding_functions import DefaultEmbeddingFunction; DefaultEmbeddingFunction()(['warmup'])" \
+    && rm -f /root/.cache/chroma/onnx_models/all-MiniLM-L6-v2/onnx.tar.gz
+
 ENV PYTHONPATH /app
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Semantic search is unusable on deployments without outbound internet access.
chromadb's default embedding function (`ONNXMiniLM_L6_V2`) fetches
all-MiniLM-L6-v2 from S3 lazily on its first `__call__`, so the failure lands
at index or query time rather than at startup:

```
MODEL_DOWNLOAD_URL = "https://chroma-onnx-models.s3.amazonaws.com/all-MiniLM-L6-v2/onnx.tar.gz"
DOWNLOAD_PATH      = Path.home() / ".cache" / "chroma" / "onnx_models" / "all-MiniLM-L6-v2"
```

The build now warms that cache. Warming it *through chromadb*, rather than
curling the archive, verifies the SHA256 chromadb pins and keeps the model in
step with whatever chromadb version resolves — there is no URL or checksum
duplicated here to drift.

`_download_model_if_not_exists()` only stats the extracted files, so the 83MB
archive is deleted afterwards; keeping it would double the cost for nothing.
Measured: the layer adds 102MB to a ~1.0GB image (~10%).

The same deployments have a second, quieter problem: `anonymized_telemetry`
defaults to `True` and posts to PostHog. Disabled on the client.

### Verification

- Built the image and ran it with `--network none`: embedding succeeds,
  384 dims. On `main` this path needs the network.
- Ran the exact `RUN` command against a cold cache to confirm it downloads,
  extracts, and survives deletion of the archive.
- `tests/core_tests/chromadb_test.py`: 19 passed.
- Confirmed `get_client().get_settings().anonymized_telemetry is False`, and
  that a live `query()` against the existing dev index still returns
  sensibly-ordered results.

Note that neither Docker publish workflow runs on pull requests, so CI here
does not build this image.

### Out of scope

Whether all-MiniLM-L6-v2 is the right model at all — its 256-word-piece limit
is what forced the chunking in #1354, and a hosted embedding API would lift
it. That is a search-quality decision, not an airgap one, and it would mean a
full reindex plus re-validating the unit-norm assumption behind
`semantic_score` (#1353). Worth revisiting after the DFIQ test data is cleaned
up and quality can actually be measured.
