### PR TITLE
Reject non-positive result counts in the search endpoints

### DIFF
--- a/core/web/apiv2/search.py
+++ b/core/web/apiv2/search.py
@@ -8,6 +8,11 @@ from core.database_arango import ArangoYetiConnector
 # API endpoints
 router = APIRouter()
 
+# Both search endpoints bucket results per type, so this bounds each bucket
+# independently -- a request with no root_type can still return this many
+# results for every type it searches.
+MAX_RESULTS_PER_TYPE = 50
+
 
 class SearchRequest(BaseModel):
     """Global search request message."""
@@ -15,7 +20,7 @@ class SearchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     query: str
-    count_per_type: int = Field(default=5, ge=1)
+    count_per_type: int = Field(default=5, ge=1, le=MAX_RESULTS_PER_TYPE)
 
 
 class SearchResultSection(BaseModel):
@@ -39,8 +44,11 @@ class SemanticSearchRequest(BaseModel):
 
     query: str
     # ChromaDB rejects a non-positive n_results, so an unconstrained count
-    # turns a client mistake into a server error. Reject it at the boundary.
-    count: int = Field(default=10, ge=1)
+    # turns a client mistake into a server error. The ceiling bounds work
+    # rather than payload: count is overfetched into n_results (see
+    # _semantic_search_one_type) and each surviving candidate costs an ACL
+    # check and a database read, per type queried.
+    count: int = Field(default=10, ge=1, le=MAX_RESULTS_PER_TYPE)
     root_type: Literal["entity", "indicator", "dfiq"] | None = None
 
 

--- a/core/web/apiv2/search.py
+++ b/core/web/apiv2/search.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from fastapi import APIRouter, Request
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from core.database_arango import ArangoYetiConnector
 
@@ -15,7 +15,7 @@ class SearchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     query: str
-    count_per_type: int = 5
+    count_per_type: int = Field(default=5, ge=1)
 
 
 class SearchResultSection(BaseModel):
@@ -38,7 +38,9 @@ class SemanticSearchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     query: str
-    count: int = 10
+    # ChromaDB rejects a non-positive n_results, so an unconstrained count
+    # turns a client mistake into a server error. Reject it at the boundary.
+    count: int = Field(default=10, ge=1)
     root_type: Literal["entity", "indicator", "dfiq"] | None = None
 
 

--- a/tests/apiv2/search.py
+++ b/tests/apiv2/search.py
@@ -165,6 +165,18 @@ class searchTest(unittest.TestCase):
         self.assertEqual(sections["entity"]["total"], 3, data)
         self.assertEqual(len(sections["entity"]["results"]), 2, data)
 
+    def test_search_rejects_non_positive_count_per_type(self) -> None:
+        """A non-positive count_per_type used to be accepted and silently
+        return no results, which reads as "nothing matched" rather than
+        "your request was wrong"."""
+        for count_per_type in (0, -1):
+            with self.subTest(count_per_type=count_per_type):
+                response = client.post(
+                    "/api/v2/search",
+                    json={"query": "test", "count_per_type": count_per_type},
+                )
+                self.assertEqual(response.status_code, 422, response.text)
+
 
 class searchRbacTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/apiv2/search.py
+++ b/tests/apiv2/search.py
@@ -8,6 +8,7 @@ from core import database_arango
 from core.schemas import dfiq, entity, indicator, observable, rbac, roles, user
 from core.schemas.user import UserSensitive
 from core.web import webapp
+from core.web.apiv2.search import MAX_RESULTS_PER_TYPE
 
 client = TestClient(webapp.app)
 
@@ -165,17 +166,25 @@ class searchTest(unittest.TestCase):
         self.assertEqual(sections["entity"]["total"], 3, data)
         self.assertEqual(len(sections["entity"]["results"]), 2, data)
 
-    def test_search_rejects_non_positive_count_per_type(self) -> None:
+    def test_search_rejects_count_per_type_outside_the_allowed_range(self) -> None:
         """A non-positive count_per_type used to be accepted and silently
         return no results, which reads as "nothing matched" rather than
         "your request was wrong"."""
-        for count_per_type in (0, -1):
+        for count_per_type in (0, -1, MAX_RESULTS_PER_TYPE + 1):
             with self.subTest(count_per_type=count_per_type):
                 response = client.post(
                     "/api/v2/search",
                     json={"query": "test", "count_per_type": count_per_type},
                 )
                 self.assertEqual(response.status_code, 422, response.text)
+
+        for count_per_type in (1, MAX_RESULTS_PER_TYPE):
+            with self.subTest(count_per_type=count_per_type):
+                response = client.post(
+                    "/api/v2/search",
+                    json={"query": "test", "count_per_type": count_per_type},
+                )
+                self.assertEqual(response.status_code, 200, response.text)
 
 
 class searchRbacTest(unittest.TestCase):

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 from core import database_arango
 from core.schemas import entity, rbac, roles, user
 from core.web import webapp
+from core.web.apiv2.search import MAX_RESULTS_PER_TYPE
 from plugins.analytics.public.chromadb_indexer import ChromaDBIndexer
 
 client = TestClient(webapp.app)
@@ -621,16 +622,14 @@ approaches:
         self.assertEqual(remaining, {"self", "approach:0"})
 
     @mock.patch("core.chromadb_client.get_client")
-    def test_non_positive_count_is_rejected_before_querying_chroma(
-        self, mock_get_client
-    ):
-        """count is multiplied into ChromaDB's n_results, which raises on any
-        non-positive value. Without a bound on the field that surfaces as a
-        500; the request is a client error and must be refused at the
-        boundary."""
+    def test_count_outside_the_allowed_range_is_rejected(self, mock_get_client):
+        """count is overfetched into ChromaDB's n_results, which raises on any
+        non-positive value -- unbounded, that surfaces as a 500 for what is a
+        client error. The upper bound caps the ACL checks and database reads a
+        single request can trigger."""
         mock_get_client.return_value = self.chroma_client
 
-        for count in (0, -1):
+        for count in (0, -1, MAX_RESULTS_PER_TYPE + 1):
             with self.subTest(count=count):
                 response = client.post(
                     "/api/v2/search/semantic",
@@ -638,10 +637,13 @@ approaches:
                 )
                 self.assertEqual(response.status_code, 422, response.json())
 
-        response = client.post(
-            "/api/v2/search/semantic", json={"query": "russian actor", "count": 1}
-        )
-        self.assertEqual(response.status_code, 200, response.json())
+        for count in (1, MAX_RESULTS_PER_TYPE):
+            with self.subTest(count=count):
+                response = client.post(
+                    "/api/v2/search/semantic",
+                    json={"query": "russian actor", "count": count},
+                )
+                self.assertEqual(response.status_code, 200, response.json())
 
 
 class SimilarityScoreTest(unittest.TestCase):

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -620,6 +620,29 @@ approaches:
         }
         self.assertEqual(remaining, {"self", "approach:0"})
 
+    @mock.patch("core.chromadb_client.get_client")
+    def test_non_positive_count_is_rejected_before_querying_chroma(
+        self, mock_get_client
+    ):
+        """count is multiplied into ChromaDB's n_results, which raises on any
+        non-positive value. Without a bound on the field that surfaces as a
+        500; the request is a client error and must be refused at the
+        boundary."""
+        mock_get_client.return_value = self.chroma_client
+
+        for count in (0, -1):
+            with self.subTest(count=count):
+                response = client.post(
+                    "/api/v2/search/semantic",
+                    json={"query": "russian actor", "count": count},
+                )
+                self.assertEqual(response.status_code, 422, response.json())
+
+        response = client.post(
+            "/api/v2/search/semantic", json={"query": "russian actor", "count": 1}
+        )
+        self.assertEqual(response.status_code, 200, response.json())
+
 
 class SimilarityScoreTest(unittest.TestCase):
     def test_converts_squared_l2_distance_to_a_bounded_similarity(self):


### PR DESCRIPTION
Fixes #1357.

Reproduced before changing anything. `POST /api/v2/search/semantic` with
`count` of `0` or `-1` returns **500** on `main`: the value is overfetched into
`n_results` and ChromaDB raises
`TypeError: Number of requested results 0, cannot be negative, or zero.`,
which nothing catches. Bounding the field moves the rejection to pydantic, so
it is a 422 before any backend query.

Both fields are now `ge=1, le=50` (`MAX_RESULTS_PER_TYPE`).

### Why an upper bound, and why 50

Not payload size — work. `count` is overfetched (`count * 3` under ACL
enforcement, `* 2` otherwise) into `n_results`, and each candidate that
survives dedup and the ACL check costs an ACL graph traversal and an ArangoDB
read. That is per *type*, and a request without `root_type` queries three, so
the bound applies to each bucket independently.

Measured on a 20-document index (instrumented `Entity.get`):

| case | `count` | results | `Entity.get()` calls |
|---|---|---|---|
| every candidate resolves | 2 | 2 | **2** |
| every candidate is an orphan | 2 | 0 | **4** (= the overfetch) |

So the common case resolves exactly `count` objects and stops. The overfetch
is the ceiling, not the norm — but it *is* reachable whenever the window fills
with orphans or with several documents belonging to one object, which is
exactly what multi-document indexing made more likely.

### Also found while verifying

`SearchRequest.count_per_type` was unconstrained in the same way. It does not
500 — a non-positive value returns **200 with an empty `results` list and a
non-zero `total`**, which reads to a caller as "nothing matched" when the
request was malformed. Bounded identically for consistency, though the cost
argument is weaker there: grouped search is a single AQL query with a `LIMIT`,
so a large value costs response size rather than round trips. **Say the word
if 50 is too tight for that endpoint** and I will drop the ceiling on it.

No caller sends a value outside the new range today — the frontend's
`GlobalSearch.vue` uses a fixed `5` and the agent's `semantic_search` tool
defaults to `5` — so this rejects nothing that previously worked.

### Verification

- The new tests fail on `main` and pass here.
- `tests/core_tests/chromadb_test.py` + `tests/apiv2/search.py`: 28 passed,
  10 subtests.
- Boundaries are asserted on both sides: `1` and `50` return 200, `0`, `-1`
  and `51` return 422.
