### PR TITLE
Split ChromaDB index writes to fit the backend batch limit

### DIFF
--- a/core/chromadb_client.py
+++ b/core/chromadb_client.py
@@ -37,6 +37,16 @@ def get_client() -> chromadb.ClientAPI:
     return client
 
 
-def get_semantic_collection():
-    client = get_client()
-    return client.get_or_create_collection(name="yeti_semantic_search")
+SEMANTIC_COLLECTION_NAME = "yeti_semantic_search"
+
+
+def get_semantic_collection(client: chromadb.ClientAPI | None = None):
+    """Returns the collection every semantically-indexed object lives in.
+
+    Callers that also need client-level information -- the write batch limit,
+    say -- should build the client once and pass it in rather than calling
+    get_client() a second time, since each call clears the process-wide system
+    cache that an already-returned collection resolves through.
+    """
+    client = client or get_client()
+    return client.get_or_create_collection(name=SEMANTIC_COLLECTION_NAME)

--- a/plugins/analytics/public/chromadb_indexer.py
+++ b/plugins/analytics/public/chromadb_indexer.py
@@ -2,8 +2,7 @@ import logging
 from datetime import timedelta
 from typing import Literal
 
-from core import taskmanager
-from core.chromadb_client import get_semantic_collection
+from core import chromadb_client, taskmanager
 from core.schemas import task
 from core.schemas.dfiq import DFIQBase
 from core.schemas.entity import Entity
@@ -53,8 +52,29 @@ class ChromaDBIndexer(task.AnalyticsTask):
         """
         return yeti_obj.semantic_documents()
 
+    def write_in_batches(self, collection, batch_size: int, ids, docs, metadatas):
+        """Upserts documents in chunks no larger than ChromaDB will accept.
+
+        ChromaDB's SQLite backend binds a fixed number of host parameters per
+        record, so a write is capped at SQLITE_MAX_VARIABLE_NUMBER divided by
+        that -- 5461 documents on current SQLite. It is a hard limit of the
+        storage layer rather than a tunable, and exceeding it raises instead of
+        writing anything, so the whole index goes stale rather than degrading.
+        The cap is read from the client because the divisor is ChromaDB's
+        internal detail and the numerator differs on older SQLite builds.
+        """
+        for start in range(0, len(ids), batch_size):
+            end = start + batch_size
+            collection.upsert(
+                documents=docs[start:end],
+                ids=ids[start:end],
+                metadatas=metadatas[start:end],
+            )
+
     def run(self, params: dict = {}):
-        collection = get_semantic_collection()
+        client = chromadb_client.get_client()
+        collection = chromadb_client.get_semantic_collection(client)
+        batch_size = client.get_max_batch_size()
         objects_to_index = []
         for cls in [Entity, Indicator, DFIQBase]:
             objects, _ = cls.filter({})
@@ -88,10 +108,11 @@ class ChromaDBIndexer(task.AnalyticsTask):
 
         if ids:
             logging.info(f"Upserting {len(ids)} documents into ChromaDB...")
-            collection.upsert(documents=docs, ids=ids, metadatas=metadatas)
+            self.write_in_batches(collection, batch_size, ids, docs, metadatas)
 
         self.prune_deleted(
             collection,
+            batch_size=batch_size,
             live_object_ids={obj.extended_id for obj in objects_to_index},
             live_document_ids=set(ids),
             documented_object_ids=documented,
@@ -100,6 +121,7 @@ class ChromaDBIndexer(task.AnalyticsTask):
     def prune_deleted(
         self,
         collection,
+        batch_size: int,
         live_object_ids: set[str],
         live_document_ids: set[str],
         documented_object_ids: set[str],
@@ -148,7 +170,9 @@ class ChromaDBIndexer(task.AnalyticsTask):
             return 0
 
         logging.info(f"Pruning {len(stale_ids)} stale documents from ChromaDB...")
-        collection.delete(ids=stale_ids)
+        # Deletes are written through the same batch-limited path as upserts.
+        for start in range(0, len(stale_ids), batch_size):
+            collection.delete(ids=stale_ids[start : start + batch_size])
         return len(stale_ids)
 
 

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -1,8 +1,10 @@
+import contextlib
 import math
 import unittest
 from unittest import mock
 
 import chromadb
+from chromadb.api.models.Collection import Collection
 from fastapi.testclient import TestClient
 
 from core import database_arango
@@ -424,6 +426,76 @@ uuid: 00000000-0000-4000-8000-000000000004
         sections = sections_by_type(data)
         self.assertEqual(sections["entity"]["total"], 1, data)
         self.assertEqual(sections["entity"]["results"][0]["name"], "Emotet")
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_upserts_are_split_to_fit_the_backend_write_limit(self, mock_get_client):
+        """ChromaDB caps how many documents a single write may carry and
+        raises past it instead of writing what fits, so one oversized run
+        leaves the entire index frozen at its last good state.
+        """
+        mock_get_client.return_value = self.chroma_client
+
+        for i in range(7):
+            entity.save(name=f"malware_{i}", type="malware", description=f"Sample {i}")
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        with self.limited_writes("upsert", limit=2) as batch_sizes:
+            indexer.run()
+
+        self.assertGreater(len(batch_sizes), 1)
+        collection = self.chroma_client.get_collection("yeti_semantic_search")
+        self.assertEqual(collection.count(), 7)
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_pruning_is_split_to_fit_the_backend_write_limit(self, mock_get_client):
+        """Deletes are written through the same batch-limited path, so a
+        large enough cleanup hits the same ceiling as a large enough index.
+        """
+        mock_get_client.return_value = self.chroma_client
+
+        entities = [
+            entity.save(name=f"malware_{i}", type="malware", description=f"Sample {i}")
+            for i in range(7)
+        ]
+
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+        collection = self.chroma_client.get_collection("yeti_semantic_search")
+        self.assertEqual(collection.count(), 7)
+
+        for obj in entities:
+            obj.delete()
+        with self.limited_writes("delete", limit=2) as batch_sizes:
+            indexer.run()
+
+        self.assertGreater(len(batch_sizes), 1)
+        self.assertEqual(collection.count(), 0)
+
+    @contextlib.contextmanager
+    def limited_writes(self, method_name: str, limit: int):
+        """Makes a Collection write refuse oversized batches, the way the
+        SQLite backend does, and records the sizes it was handed.
+
+        Patched at the class rather than on an instance because the indexer
+        resolves its own collection object, and the batch ceiling is faked
+        rather than reached for real: the true limit is in the thousands, and
+        standing up a corpus that large per test would cost far more than it
+        proves.
+        """
+        real_method = getattr(Collection, method_name)
+        batch_sizes: list[int] = []
+
+        def limited(collection_self, *args, ids, **kwargs):
+            if len(ids) > limit:
+                raise RuntimeError(f"Cannot submit more than {limit} embeddings")
+            batch_sizes.append(len(ids))
+            return real_method(collection_self, *args, ids=ids, **kwargs)
+
+        with mock.patch.object(
+            self.chroma_client, "get_max_batch_size", return_value=limit
+        ):
+            with mock.patch.object(Collection, method_name, limited):
+                yield batch_sizes
 
     @mock.patch("core.chromadb_client.get_client")
     def test_orphans_no_longer_consume_the_result_window(self, mock_get_client):


### PR DESCRIPTION
## Problem

Indexing fails outright on any corpus past ~5.4k documents:

```
batch size of 9206 is greater than max batch size of 5461
```

ChromaDB's SQLite backend binds a fixed number of host parameters per record, so
one write is capped at `SQLITE_MAX_VARIABLE_NUMBER // VARIABLES_PER_RECORD`
(`32766 // 6` = 5461 on current SQLite). It is a hard limit of the storage layer,
not a tunable.

The failure mode is worse than a slow index. `collection.upsert()` raises rather
than writing what fits, and it raises *before* `prune_deleted()` runs, so a
single oversized run does nothing at all. Every subsequent run fails the same
way, and the index stays frozen at whatever it held when the corpus crossed the
cap — while semantic search keeps answering from it, with no indication the data
is stale.

## Fix

Split both writes into chunks the backend will accept. The cap is read from the
client (`get_max_batch_size()`) rather than hardcoded: the divisor is ChromaDB's
internal detail, and the numerator drops to 999 on SQLite < 3.32.

Deletes are submitted through the same batch-limited path, so `prune_deleted()`
is chunked too — a large enough cleanup hits the same ceiling as a large enough
index.

`get_semantic_collection()` now takes an optional client so the indexer can build
one and read both the collection and the batch limit from it. Calling
`get_client()` twice would clear the process-wide system cache out from under the
collection it had just handed back.

## Tests

Two tests, both of which fail on `main`:

- `test_upserts_are_split_to_fit_the_backend_write_limit`
- `test_pruning_is_split_to_fit_the_backend_write_limit`

They patch `Collection.upsert`/`Collection.delete` to refuse oversized batches
the way the backend does, and assert both that more than one batch was submitted
and that the resulting index is correct. The ceiling is faked rather than reached
for real — the true limit is in the thousands, and building a corpus that large
per test would cost far more than it proves.

```
30 passed, 10 subtests passed
```
