### PR TITLE
Allow ChromaDB to run as a shared server

### DIFF
--- a/core/chromadb_client.py
+++ b/core/chromadb_client.py
@@ -1,4 +1,5 @@
 import os
+import urllib.parse
 
 import chromadb
 from chromadb.api.shared_system_client import SharedSystemClient
@@ -6,15 +7,61 @@ from chromadb.config import Settings
 
 from core.config.config import yeti_config
 
+SEMANTIC_COLLECTION_NAME = "yeti_semantic_search"
 
-def get_client() -> chromadb.ClientAPI:
-    """Returns a configurable ChromaDB client.
+# ChromaDB's own default when a URL carries no port.
+DEFAULT_SERVER_PORT = 8000
+
+
+def _settings() -> Settings:
+    """Builds the Settings a Yeti-owned client is constructed with.
+
+    Returned fresh each time rather than shared: HttpClient *writes* the host,
+    port and api_impl it was given into the Settings object it is handed, and
+    refuses a second connection whose host disagrees with what it finds there.
+
+    chromadb posts anonymized usage events to PostHog by default. Yeti is
+    deployed on networks with no outbound internet access, where those calls
+    only cost latency and log noise.
+    """
+    return Settings(anonymized_telemetry=False)
+
+
+def _server_client(http_root: str) -> chromadb.ClientAPI:
+    """Connects to a ChromaDB server that owns the index.
+
+    The server is the single source of truth, so the per-process snapshot the
+    embedded client keeps -- and has to be told to drop -- cannot form here.
+
+    HttpClient wants a host and a port and uses whatever string it is handed
+    verbatim, so the URL is split up here instead: that lets this setting be
+    written like every other service Yeti points at (see the `agents` section)
+    rather than being the one that silently misbehaves if given a scheme.
+    """
+    parsed = urllib.parse.urlparse(http_root)
+    if not parsed.hostname:
+        raise ValueError(
+            f"chromadb.http_root is not a URL Yeti can connect to: {http_root!r}. "
+            "Expected something like http://chromadb:8000"
+        )
+
+    ssl = parsed.scheme == "https"
+    return chromadb.HttpClient(
+        host=parsed.hostname,
+        port=parsed.port or (443 if ssl else DEFAULT_SERVER_PORT),
+        ssl=ssl,
+        settings=_settings(),
+    )
+
+
+def _embedded_client() -> chromadb.ClientAPI:
+    """Opens the on-disk index directly, in this process.
 
     PersistentClient caches its underlying connection per Python process
     (SharedSystemClient._identifier_to_system, a process-wide dict): once a
     process has constructed one, later PersistentClient(...) calls in that
     *same* process reuse it rather than re-reading disk. That's fine for a
-    single writer, but the indexer (celery worker) and this endpoint's
+    single writer, but the indexer (celery worker) and the search endpoint's
     caller (the API server) are separate long-running processes -- without
     clearing the cache first, the API process would keep serving whatever
     snapshot it had cached at its own startup, oblivious to anything the
@@ -28,16 +75,28 @@ def get_client() -> chromadb.ClientAPI:
     if not os.path.exists(path):
         os.makedirs(path, exist_ok=True)
 
-    # chromadb posts anonymized usage events to PostHog by default. Yeti is
-    # deployed on networks with no outbound internet access, where those calls
-    # only cost latency and log noise.
-    client = chromadb.PersistentClient(
-        path=path, settings=Settings(anonymized_telemetry=False)
-    )
-    return client
+    return chromadb.PersistentClient(path=path, settings=_settings())
 
 
-SEMANTIC_COLLECTION_NAME = "yeti_semantic_search"
+def get_client() -> chromadb.ClientAPI:
+    """Returns a client for whichever ChromaDB backend is configured.
+
+    Embedded by default, which requires every process touching the index to
+    see the same filesystem. That holds on a single host and stops holding the
+    moment the API and the indexer are scheduled apart: each opens its own copy,
+    so writes land in one and reads come back empty from the other with no error
+    raised on either side. It is also SQLite, whose locking is unreliable on
+    shared network filesystems, so a common volume is not a fix.
+
+    Setting `chromadb.http_root` points every process at one server instead.
+    Embeddings are still computed in this process either way -- the server
+    stores and searches vectors, it is never handed text -- so a deployment
+    without internet access needs the model available here, not there.
+    """
+    http_root = yeti_config.get("chromadb", "http_root")
+    if http_root:
+        return _server_client(http_root)
+    return _embedded_client()
 
 
 def get_semantic_collection(client: chromadb.ClientAPI | None = None):
@@ -46,7 +105,7 @@ def get_semantic_collection(client: chromadb.ClientAPI | None = None):
     Callers that also need client-level information -- the write batch limit,
     say -- should build the client once and pass it in rather than calling
     get_client() a second time, since each call clears the process-wide system
-    cache that an already-returned collection resolves through.
+    cache that an already-returned embedded collection resolves through.
     """
     client = client or get_client()
     return client.get_or_create_collection(name=SEMANTIC_COLLECTION_NAME)

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -1,5 +1,6 @@
 import contextlib
 import math
+import os
 import unittest
 from unittest import mock
 
@@ -761,3 +762,74 @@ class ChromaDBClientTest(unittest.TestCase):
         get_client()
 
         mock_clear_cache.assert_called_once()
+
+    @mock.patch("core.chromadb_client.chromadb.PersistentClient")
+    @mock.patch("os.path.exists", return_value=True)
+    def test_embedded_client_is_the_default(self, mock_exists, mock_persistent):
+        """With no http_root configured, the index is opened in-process."""
+        from core.chromadb_client import get_client
+
+        get_client()
+
+        mock_persistent.assert_called_once()
+
+    @mock.patch("core.chromadb_client.chromadb.HttpClient")
+    def test_http_root_selects_the_server_client(self, mock_http):
+        """http_root moves every process onto one server, which is what makes
+        the API and the indexer agree when they are scheduled apart."""
+        from core.chromadb_client import get_client
+
+        with mock.patch.dict(
+            os.environ, {"YETI_CHROMADB_HTTP_ROOT": "http://chromadb:8000"}
+        ):
+            get_client()
+
+        kwargs = mock_http.call_args.kwargs
+        self.assertEqual(kwargs["host"], "chromadb")
+        self.assertEqual(kwargs["port"], 8000)
+        self.assertFalse(kwargs["ssl"])
+
+    @mock.patch("core.chromadb_client.chromadb.HttpClient")
+    def test_http_root_url_forms_are_split_into_host_port_and_ssl(self, mock_http):
+        """HttpClient takes a host and a port and uses the string it is given
+        verbatim, so a URL has to be taken apart before it gets there -- a
+        scheme left on the host would otherwise fail as a DNS lookup.
+        """
+        from core.chromadb_client import get_client
+
+        cases = {
+            "http://chromadb:9000": ("chromadb", 9000, False),
+            "http://chromadb": ("chromadb", 8000, False),
+            "https://chroma.internal": ("chroma.internal", 443, True),
+            "https://chroma.internal:8443": ("chroma.internal", 8443, True),
+        }
+        for http_root, (host, port, ssl) in cases.items():
+            with self.subTest(http_root=http_root):
+                mock_http.reset_mock()
+                with mock.patch.dict(
+                    os.environ, {"YETI_CHROMADB_HTTP_ROOT": http_root}
+                ):
+                    get_client()
+                kwargs = mock_http.call_args.kwargs
+                self.assertEqual(
+                    (kwargs["host"], kwargs["port"], kwargs["ssl"]), (host, port, ssl)
+                )
+
+    def test_unusable_http_root_fails_loudly(self):
+        """A value with no hostname would otherwise reach HttpClient and be
+        reported as a connection failure against a nonsense host."""
+        from core.chromadb_client import get_client
+
+        with mock.patch.dict(os.environ, {"YETI_CHROMADB_HTTP_ROOT": "chromadb:8000"}):
+            with self.assertRaises(ValueError):
+                get_client()
+
+    def test_each_client_gets_its_own_settings(self):
+        """HttpClient writes the host and port it was given into the Settings
+        object it is handed, and rejects a later connection whose host
+        disagrees with what it finds there, so one shared instance would break
+        every client after the first.
+        """
+        from core.chromadb_client import _settings
+
+        self.assertIsNot(_settings(), _settings())

--- a/yeti.conf.sample
+++ b/yeti.conf.sample
@@ -131,10 +131,23 @@ websocket_root = ws://agents:8888
 [chromadb]
 
 ##
-## ChromaDB local storage path
+## ChromaDB local storage path. Used when http_root is unset.
+##
+## Every process that touches the index must see this same directory, so this
+## only works while the API and the task workers share a filesystem. Set
+## http_root instead if they can be scheduled onto different hosts.
 ##
 
 path = /data/chromadb
+
+##
+## URL of a ChromaDB server to use instead of the local path above.
+##
+## Embeddings are computed by Yeti either way; the server only stores and
+## searches vectors, and is never sent text to embed.
+##
+
+# http_root = http://chromadb:8000
 
 [misp]
 


### PR DESCRIPTION
## Problem

Semantic search returns empty results whenever the API and the task workers do
not share a filesystem. Observed in a live deployment:

```
api:   0
tasks: 9206
```

No error on either side. `PersistentClient` opens the index in-process, so each
container simply has its own copy — the indexer writes to one, the endpoint
reads from another, and an empty result set is indistinguishable from "nothing
matched".

Sharing a volume is not the fix. The embedded backend is SQLite, whose advisory
locking is unreliable on network filesystems, so an RWX volume trades silent
emptiness for a corruption risk.

## Fix

Make the backend selectable. Setting `chromadb.http_root` connects to a
ChromaDB server that owns the index, so every process sees the same data:

```
                    api   ──HTTP──┐
                                  ├──> chromadb ──> volume
                    tasks ──HTTP──┘
```

Opt-in: with `http_root` unset the embedded path is byte-for-byte what it was,
so single-host and dev deployments are unaffected.

## Notes

- **Embeddings stay client-side.** `CollectionCommon._embed` runs in the calling
  process and the server is sent vectors, never text. So the server needs no
  model and a stock `chromadb/chroma` image works offline — but the model baked
  in by #1356 is still required wherever Yeti runs.
- **`get_max_batch_size()` follows the backend.** On `HttpClient` it comes from
  the server's pre-flight checks rather than the local SQLite variable limit, so
  the batching added in #1359 adapts instead of being pinned to 5461.
- **`http_root` is parsed here.** `HttpClient` takes a host and a port and uses
  the string verbatim, so a scheme left attached would fail as a DNS lookup.
  Parsing means this setting can be written like every other service Yeti points
  at (`agents` uses the same `http_root` form).
- **Settings are built per client.** `HttpClient` *writes* the host and port it
  was given into the `Settings` object it is handed and rejects a later
  connection that disagrees, so a shared instance would break every client after
  the first.
- **The client connects eagerly** — `HttpClient()` raises if the server is
  unreachable. In server mode a ChromaDB outage therefore surfaces as an
  exception on the search endpoint rather than as empty results. That is the
  better failure mode of the two, but it is a new way for search to fail and is
  worth watching once deployed.

## Migration

None. The index is derived from Arango, so the first indexer run after the
switch rebuilds it into the server. Search returns nothing for one cycle, and
the change rolls back by unsetting `http_root`.

The compose service is a follow-up in `yeti-docker`.

## Tests

```
63 passed, 14 subtests passed
```

New coverage for backend selection: embedded by default, `http_root` selecting
the server client, URL forms split correctly into host/port/ssl (including the
https and default-port cases), an unusable `http_root` failing loudly rather
than as a connection error against a nonsense host, and settings not being
shared between clients.
