### PR TITLE
Return the document that matched, not the object that contains it

### DIFF
--- a/core/web/apiv2/search.py
+++ b/core/web/apiv2/search.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from core.database_arango import ArangoYetiConnector
+from core.schemas.dfiq import DFIQApproach
 
 # API endpoints
 router = APIRouter()
@@ -52,6 +53,57 @@ class SemanticSearchRequest(BaseModel):
     root_type: Literal["entity", "indicator", "dfiq"] | None = None
 
 
+class ObjectSummary(BaseModel):
+    """Enough of an object to judge a hit and fetch the rest by id.
+
+    Search returns this rather than the whole object because a hit is a
+    pointer, not the payload. For DFIQ the difference is an order of
+    magnitude, and half of what it saves is `dfiq_yaml` -- a verbatim copy
+    of fields already present here.
+    """
+
+    id: str
+    root_type: str
+    type: str
+    name: str
+    description: str | None = None
+    tags: list[str] = []
+
+
+class SemanticMatch(BaseModel):
+    """Which of an object's indexed documents matched.
+
+    An object is embedded as several documents (see
+    YetiBaseModel.semantic_documents), so a score belongs to one of them
+    rather than to the object as a whole. Returning the document that
+    matched is what makes the score explainable, and what keeps a
+    question's other approaches -- which did not match -- out of the
+    response.
+    """
+
+    kind: Literal["self", "approach"]
+    # Null when the object no longer has the approach that was indexed.
+    # The hit is still real, but the reason for it has since been edited
+    # away and pruning has not caught up.
+    approach: DFIQApproach | None = None
+
+
+class SemanticSearchResult(BaseModel):
+    """One hit: what matched, how well, and what it belongs to."""
+
+    score: float
+    matched: SemanticMatch
+    object_summary: ObjectSummary
+
+
+class SemanticSearchResultSection(BaseModel):
+    """One type's bucket of semantic results."""
+
+    type: str
+    results: list[SemanticSearchResult]
+    total: int = 0
+
+
 class SemanticSearchResponse(BaseModel):
     """Semantic Search Response, bucketed by type like grouped exact-match
     search: each type gets its own independently-bounded slice of nearest
@@ -60,7 +112,7 @@ class SemanticSearchResponse(BaseModel):
     type (not a corpus-wide count) -- ANN search doesn't have a cheap way
     to count "everything within the top-K" beyond what was fetched."""
 
-    sections: list[SearchResultSection]
+    sections: list[SemanticSearchResultSection]
 
 
 @router.post("/")
@@ -105,9 +157,52 @@ def _similarity_score(distance: float) -> float:
     return round(max(0.0, min(1.0, cosine_similarity)), 4)
 
 
+def _summarize(obj) -> ObjectSummary:
+    """Reduces a Yeti object to the fields a caller needs to act on a hit."""
+    data = obj.model_dump()
+
+    # Entities and indicators carry tag objects; DFIQ carries plain strings
+    # under a different field. Callers of search want neither shape, only
+    # the names.
+    raw_tags = data.get("tags") or data.get("dfiq_tags") or []
+    tags = [t.get("name") if isinstance(t, dict) else str(t) for t in raw_tags]
+
+    # DFIQ types are enums, whose str() is the member and not the value.
+    obj_type = data.get("type")
+    return ObjectSummary(
+        id=data["id"],
+        root_type=data["root_type"],
+        type=str(getattr(obj_type, "value", obj_type)),
+        name=data.get("name") or data.get("value") or "",
+        description=data.get("description"),
+        tags=[t for t in tags if t],
+    )
+
+
+def _matched_document(obj, chunk: str) -> SemanticMatch:
+    """Resolves the id of the document that matched into the document itself.
+
+    The indexer names an object's documents "self" and "approach:N", where N
+    indexes the approach at the time it was indexed. Returning the approach
+    rather than that identifier is the difference between a caller being told
+    the score belongs to something it cannot see, and being able to read it.
+    """
+    if not chunk.startswith("approach:"):
+        return SemanticMatch(kind="self")
+
+    approaches = getattr(obj, "approaches", None) or []
+    try:
+        index = int(chunk.split(":", 1)[1])
+    except ValueError:
+        return SemanticMatch(kind="approach")
+    if index >= len(approaches):
+        return SemanticMatch(kind="approach")
+    return SemanticMatch(kind="approach", approach=approaches[index])
+
+
 def _semantic_search_one_type(
     collection, query: str, count: int, collection_name: str, cls, user, enforce_acls
-) -> SearchResultSection:
+) -> SemanticSearchResultSection:
     """Queries ChromaDB for nearest neighbors within a single type's
     collection (via a metadata filter), so this type's results are bounded
     independently of how many candidates other types produce -- mirrors
@@ -135,18 +230,18 @@ def _semantic_search_one_type(
     # what the raw distance means and how it's converted.
     distances = results.get("distances", [[]])[0]
 
-    yeti_objects = []
+    hits = []
     seen_objects = set()
     for meta, distance in zip(object_metadatas, distances):
-        if len(yeti_objects) >= count:
+        if len(hits) >= count:
             break
         if "id" not in meta:
             continue
         # An object is indexed as several documents (its own text, plus one per
         # DFIQ approach), any of which can match. Results are already ordered
         # best-first, so the first document seen for an object is its best one
-        # and the rest are dropped -- the object is what's being returned, not
-        # the document that happened to match.
+        # and the rest are dropped -- an object is reported once, by whichever
+        # of its documents matched best.
         extended_id = meta.get("extended_id", "")
         if extended_id in seen_objects:
             continue
@@ -157,19 +252,18 @@ def _semantic_search_one_type(
         obj = cls.get(meta["id"])
         if obj:
             seen_objects.add(extended_id)
-            obj_dict = obj.model_dump()
-            obj_dict["semantic_score"] = _similarity_score(distance)
-            # Which document matched: "self" for the object's own text, or
-            # "approach:N". Useful for explaining *why* something was returned.
-            obj_dict["matched_on"] = meta.get("chunk", "self")
-            yeti_objects.append(obj_dict)
+            hits.append(
+                SemanticSearchResult(
+                    score=_similarity_score(distance),
+                    matched=_matched_document(obj, meta.get("chunk", "self")),
+                    object_summary=_summarize(obj),
+                )
+            )
 
     type_name = next(
         t for t, c in SEMANTIC_TYPE_TO_COLLECTION.items() if c == collection_name
     )
-    return SearchResultSection(
-        type=type_name, results=yeti_objects, total=len(yeti_objects)
-    )
+    return SemanticSearchResultSection(type=type_name, results=hits, total=len(hits))
 
 
 @router.post("/semantic")

--- a/tests/core_tests/chromadb_test.py
+++ b/tests/core_tests/chromadb_test.py
@@ -72,7 +72,9 @@ class ChromaDBTest(unittest.TestCase):
         sections = sections_by_type(data)
 
         self.assertEqual(sections["entity"]["total"], 1, data)
-        self.assertEqual(sections["entity"]["results"][0]["name"], "APT28")
+        self.assertEqual(
+            sections["entity"]["results"][0]["object_summary"]["name"], "APT28"
+        )
 
     @mock.patch("core.chromadb_client.get_client")
     def test_indexing_multiple_entities(self, mock_get_client):
@@ -97,8 +99,10 @@ class ChromaDBTest(unittest.TestCase):
         sections = sections_by_type(data)
 
         self.assertEqual(sections["entity"]["total"], 1, data)
-        self.assertEqual(sections["entity"]["results"][0]["name"], "Trickbot")
-        self.assertIn("semantic_score", sections["entity"]["results"][0])
+        self.assertEqual(
+            sections["entity"]["results"][0]["object_summary"]["name"], "Trickbot"
+        )
+        self.assertIn("score", sections["entity"]["results"][0])
 
     @mock.patch("core.chromadb_client.get_client")
     def test_semantic_score_ranks_results_most_to_least_similar(self, mock_get_client):
@@ -126,12 +130,12 @@ class ChromaDBTest(unittest.TestCase):
         sections = sections_by_type(data)
         results = sections["entity"]["results"]
 
-        scores = [r["semantic_score"] for r in results]
+        scores = [r["score"] for r in results]
         # Higher score first (most similar), and the trojan -- an
         # near-exact match to the query -- should score above the
         # unrelated entity.
         self.assertEqual(scores, sorted(scores, reverse=True))
-        self.assertEqual(results[0]["name"], "Trickbot")
+        self.assertEqual(results[0]["object_summary"]["name"], "Trickbot")
 
     @mock.patch("core.chromadb_client.get_client")
     def test_dfiq_scenario_indexing(self, mock_get_client):
@@ -178,7 +182,9 @@ parent_ids:
         data = response.json()
         sections = sections_by_type(data)
 
-        returned_names = [r["name"] for r in sections["dfiq"]["results"]]
+        returned_names = [
+            r["object_summary"]["name"] for r in sections["dfiq"]["results"]
+        ]
         self.assertIn("Ransomware Investigation", returned_names)
         self.assertIn("Initial Access Vector", returned_names)
 
@@ -216,7 +222,7 @@ parent_ids:
             )
             data = response.json()
             sections = sections_by_type(data)
-            names = [r["name"] for r in sections["entity"]["results"]]
+            names = [r["object_summary"]["name"] for r in sections["entity"]["results"]]
 
             self.assertIn("VisibleMalware", names)
             self.assertNotIn("HiddenMalware", names)
@@ -255,7 +261,7 @@ parent_ids:
             )
             data = response.json()
             sections = sections_by_type(data)
-            names = [r["name"] for r in sections["entity"]["results"]]
+            names = [r["object_summary"]["name"] for r in sections["entity"]["results"]]
 
             self.assertIn("UnownedMalware", names)
         finally:
@@ -300,7 +306,7 @@ uuid: 00000000-0000-4000-8000-000000000003
 
         self.assertEqual(len(data["sections"]), 1, data)
         self.assertEqual(data["sections"][0]["type"], "dfiq")
-        names = [r["name"] for r in data["sections"][0]["results"]]
+        names = [r["object_summary"]["name"] for r in data["sections"][0]["results"]]
         self.assertIn("Suspicious DNS Query", names)
         self.assertNotIn("Suspicious DNS Malware", names)
 
@@ -343,7 +349,10 @@ uuid: 00000000-0000-4000-8000-000000000004
         # The single DFIQ match is present regardless of how many entity
         # matches exist -- it isn't sharing a page with them.
         self.assertEqual(sections["dfiq"]["total"], 1, data)
-        self.assertEqual(sections["dfiq"]["results"][0]["name"], "Suspicious DNS Query")
+        self.assertEqual(
+            sections["dfiq"]["results"][0]["object_summary"]["name"],
+            "Suspicious DNS Query",
+        )
         self.assertEqual(len(sections["entity"]["results"]), 1, data)
 
     @mock.patch("core.chromadb_client.get_client")
@@ -374,8 +383,8 @@ uuid: 00000000-0000-4000-8000-000000000004
 
         self.assertEqual(len(results), 2, data)
         for result in results:
-            self.assertGreaterEqual(result["semantic_score"], 0.0, result)
-            self.assertLessEqual(result["semantic_score"], 1.0, result)
+            self.assertGreaterEqual(result["score"], 0.0, result)
+            self.assertLessEqual(result["score"], 1.0, result)
 
     @mock.patch("core.chromadb_client.get_client")
     def test_index_uses_the_distance_metric_the_score_assumes(self, mock_get_client):
@@ -426,7 +435,9 @@ uuid: 00000000-0000-4000-8000-000000000004
         data = response.json()
         sections = sections_by_type(data)
         self.assertEqual(sections["entity"]["total"], 1, data)
-        self.assertEqual(sections["entity"]["results"][0]["name"], "Emotet")
+        self.assertEqual(
+            sections["entity"]["results"][0]["object_summary"]["name"], "Emotet"
+        )
 
     @mock.patch("core.chromadb_client.get_client")
     def test_upserts_are_split_to_fit_the_backend_write_limit(self, mock_get_client):
@@ -526,7 +537,9 @@ uuid: 00000000-0000-4000-8000-000000000004
         data = response.json()
         sections = sections_by_type(data)
         self.assertEqual(sections["entity"]["total"], 1, data)
-        self.assertEqual(sections["entity"]["results"][0]["name"], "Dridex")
+        self.assertEqual(
+            sections["entity"]["results"][0]["object_summary"]["name"], "Dridex"
+        )
 
     @mock.patch("core.chromadb_client.get_client")
     def test_pruning_ignores_objects_whose_document_failed_to_build(
@@ -610,9 +623,23 @@ approaches:
 
         self.assertEqual(len(results), 1, data)
         self.assertEqual(
-            results[0]["name"], "What files were downloaded using a web browser?"
+            results[0]["object_summary"]["name"],
+            "What files were downloaded using a web browser?",
         )
-        self.assertEqual(results[0]["matched_on"], "approach:0")
+        self.assertEqual(results[0]["matched"]["kind"], "approach")
+
+        # The approach itself comes back, not just a reference to it. Without
+        # this the score belongs to something the caller cannot see: the
+        # question's own name and description say nothing about USN journals.
+        approach = results[0]["matched"]["approach"]
+        self.assertIsNotNone(approach, results[0])
+        self.assertEqual(
+            approach["name"], "Detect browser downloads via change journal records"
+        )
+        self.assertEqual(
+            [step["value"] for step in approach["steps"]],
+            ["NTFSUSNJournal", "Plaso"],
+        )
 
     @mock.patch("core.chromadb_client.get_client")
     def test_an_object_is_returned_once_however_many_documents_match(
@@ -651,7 +678,9 @@ approaches:
         results = sections_by_type(data)["dfiq"]["results"]
 
         self.assertEqual(len(results), 1, data)
-        self.assertEqual(results[0]["name"], "What browser downloads happened?")
+        self.assertEqual(
+            results[0]["object_summary"]["name"], "What browser downloads happened?"
+        )
 
     @mock.patch("core.chromadb_client.get_client")
     def test_documents_an_object_stops_producing_are_pruned(self, mock_get_client):
@@ -833,3 +862,119 @@ class ChromaDBClientTest(unittest.TestCase):
         from core.chromadb_client import _settings
 
         self.assertIsNot(_settings(), _settings())
+
+
+class SemanticResultShapeTest(unittest.TestCase):
+    """The response contract: what a hit carries, and what it deliberately
+    does not."""
+
+    def setUp(self) -> None:
+        database_arango.db.connect(database="yeti_test")
+        database_arango.db.truncate()
+        self.chroma_client = chromadb.EphemeralClient()
+
+        u = user.UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = u.create_api_key("default")
+        token_data = client.post(
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
+        ).json()
+        client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
+
+    def index_and_search(self, query, **kwargs):
+        indexer = ChromaDBIndexer(name="ChromaDBIndexer", enabled=True)
+        indexer.run()
+        response = client.post(
+            "/api/v2/search/semantic", json={"query": query, "count": 5, **kwargs}
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        return response.json()
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_search_metadata_is_not_mixed_into_the_object(self, mock_get_client):
+        """Score and match live outside the object so a caller can tell an
+        object's own fields from search bookkeeping -- and so neither can be
+        shadowed by a field an object grows later.
+        """
+        mock_get_client.return_value = self.chroma_client
+        entity.save(name="Trickbot", type="malware", description="A banking trojan")
+
+        result = sections_by_type(self.index_and_search("banking trojan"))["entity"][
+            "results"
+        ][0]
+
+        self.assertCountEqual(result, ["score", "matched", "object_summary"])
+        self.assertNotIn("score", result["object_summary"])
+        self.assertNotIn("matched", result["object_summary"])
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_dfiq_yaml_is_not_returned(self, mock_get_client):
+        """dfiq_yaml is a verbatim copy of fields already in the response and
+        was half the payload of a question. A search hit is a pointer; the
+        full object is one GET away."""
+        mock_get_client.return_value = self.chroma_client
+        from core.schemas.dfiq import DFIQScenario
+
+        DFIQScenario.from_yaml("""
+type: scenario
+id: S0301
+dfiq_version: 1.0.0
+name: Ransomware Investigation
+description: Overall scenario for ransomware.
+uuid: 00000000-0000-4000-8000-000000000301
+""").save()
+
+        result = sections_by_type(self.index_and_search("ransomware"))["dfiq"][
+            "results"
+        ][0]
+
+        self.assertNotIn("dfiq_yaml", result["object_summary"])
+        self.assertEqual(result["object_summary"]["name"], "Ransomware Investigation")
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_object_summary_carries_what_is_needed_to_act_on_a_hit(
+        self, mock_get_client
+    ):
+        """A caller has to be able to identify the hit and fetch the rest, so
+        the id and type are not optional."""
+        mock_get_client.return_value = self.chroma_client
+        saved = entity.save(
+            name="Emotet", type="malware", description="Botnet", tags=["banker"]
+        )
+
+        summary = sections_by_type(self.index_and_search("botnet"))["entity"][
+            "results"
+        ][0]["object_summary"]
+
+        self.assertEqual(summary["id"], saved.id)
+        self.assertEqual(summary["root_type"], "entity")
+        self.assertEqual(summary["type"], "malware")
+        self.assertEqual(summary["description"], "Botnet")
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_tags_are_reported_as_names(self, mock_get_client):
+        """Entities carry tag objects and DFIQ carries plain strings under a
+        different field; a caller of search should see neither shape."""
+        mock_get_client.return_value = self.chroma_client
+        entity.save(name="Dridex", type="malware", description="A banking trojan").tag(
+            ["banker", "ecrime"]
+        )
+
+        summary = sections_by_type(self.index_and_search("banking trojan"))["entity"][
+            "results"
+        ][0]["object_summary"]
+
+        self.assertCountEqual(summary["tags"], ["banker", "ecrime"])
+
+    @mock.patch("core.chromadb_client.get_client")
+    def test_matched_self_carries_no_approach(self, mock_get_client):
+        """Nothing to return for "self": that document is the name and
+        description the summary already has."""
+        mock_get_client.return_value = self.chroma_client
+        entity.save(name="APT28", type="threat-actor", description="A threat actor")
+
+        result = sections_by_type(self.index_and_search("threat actor"))["entity"][
+            "results"
+        ][0]
+
+        self.assertEqual(result["matched"]["kind"], "self")
+        self.assertIsNone(result["matched"]["approach"])


### PR DESCRIPTION
Reshapes `POST /api/v2/search/semantic` before anything depends on it. The only consumer today is the agents tool (via yeti-python), and it already discards most of what it receives.

## What was wrong

**1. Metadata written into the object.**

```python
obj_dict["semantic_score"] = _similarity_score(distance)
obj_dict["matched_on"] = meta.get("chunk", "self")
```

A caller could not distinguish an object's own fields from search bookkeeping, the response could not be typed beyond `list[dict]`, and any object growing a field of either name would silently collide.

**2. `matched_on` was unusable.** It named the document that matched — `"self"` or `"approach:N"` — but that index means nothing without re-fetching the object and counting approaches. The single field that explained *why* something scored was the one field nothing could read, and `_summarize()` in yeti-agents dropped it entirely.

**3. Matching one approach returned all of them.** A question found through its cookie-reuse approach came back with three unrelated approaches attached. Measured on a real DFIQ question:

| field | bytes | |
| --- | --- | --- |
| `dfiq_yaml` | 10,375 | 50% — verbatim copy of fields already in the response |
| `approaches` | 9,709 | 47% — one matched, the rest is noise |
| everything else | ~500 | 2.5% |

## What it returns now

```json
{
  "score": 0.5205,
  "matched": {
    "kind": "approach",
    "approach": {
      "name": "Detect browser downloads via change journal records",
      "description": "Uses NTFS USN journal records...",
      "steps": [{"type": "ForensicArtifact", "value": "NTFSUSNJournal"}, ...]
    }
  },
  "object": {
    "id": "...", "root_type": "dfiq", "type": "question",
    "name": "What files were downloaded using a web browser?",
    "description": "...", "tags": [...]
  }
}
```

Returning the matched approach rather than a reference to it is what makes the score explainable: the question's own name and description say nothing about USN journals, so `0.52` is meaningless without the approach in hand. It is also the answer to the query — "how do I investigate X" is answered by the approach's steps, and making that a second round-trip would add latency to the most common DFIQ query.

The shape is deliberately asymmetric: `kind: "self"` carries no approach, because that document *is* the name and description the summary already has.

`approach` is null when the object no longer has the approach that was indexed — the hit is real but the reason has been edited away and pruning has not caught up.

## Measured against production data

Query `"cookie theft"`, `count=5`, same corpus:

| | before | after |
| --- | --- | --- |
| total | 19,845 B | **2,836 B** |
| results | same | same, same order |

A query that matches through an approach (`"NTFS USN change journal records for downloads"`) returns the matching approach with its 4 steps, and the question's other three approaches are not sent at all.

## Not included

`dfiq_yaml` is still returned by the regular DFIQ endpoints. Removing it there — loading it only for the edit view — is a separate change.

## Breaking change for yeti-agents

`_summarize()` in `agents/tools/yeti_api.py` reads the old flat shape and must be updated alongside; it also becomes largely redundant, since the API now returns a summary. Companion PR to follow. yeti-python passes `["sections"]` through untouched so it keeps working, though its docstring now describes a field that no longer exists.

## Tests

40 passing. New coverage: the matched approach is returned with its steps, `dfiq_yaml` is absent, score/matched live outside the object, tags are normalised to names across both tag shapes, and `kind: "self"` carries no approach.
