### PR TITLE
Proxy the agent service's model list and session deletion

### DIFF
--- a/core/web/apiv2/agents.py
+++ b/core/web/apiv2/agents.py
@@ -26,6 +26,7 @@ AGENT_WEBSOCKET_BASE = yeti_config.get("agents", "websocket_root")
 
 AGENT_STREAM_ENDPOINT = f"{AGENT_HTTP_BASE}/run_stream"
 AGENT_LIST_SESSIONS_ENDPOINT = f"{AGENT_HTTP_BASE}/sessions/{{user_id}}"
+AGENT_MODELS_ENDPOINT = f"{AGENT_HTTP_BASE}/models"
 AGENT_GET_SESSION_ENDPOINT = f"{AGENT_HTTP_BASE}/sessions/{{user_id}}/{{session_id}}"
 AGENT_WEBSOCKET_ENDPOINT = f"{AGENT_WEBSOCKET_BASE}/ws/chat"
 
@@ -78,6 +79,43 @@ def get_session_proxy(httpreq: Request, session_id: str) -> ADKSession:
         return ADKSession(**response.json())
 
 
+class ModelsResponse(BaseModel):
+    """The models the agent service will accept for a chat request."""
+
+    provider: str
+    models: List[str]
+    default: str
+
+
+@router.get("/models")
+@global_permission(roles.Permission.READ)
+def list_models_proxy(httpreq: Request) -> ModelsResponse:
+    """Proxies the list of models the Agent Service is configured to offer."""
+    with httpx.Client(timeout=TIMEOUT) as client:
+        response = client.get(AGENT_MODELS_ENDPOINT)
+        if response.status_code != 200:
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+        return ModelsResponse(**response.json())
+
+
+@router.delete("/sessions/{session_id}", status_code=204)
+@global_permission(roles.Permission.READ)
+def delete_session_proxy(httpreq: Request, session_id: str) -> None:
+    """Deletes one of the calling user's chat sessions.
+
+    The user id comes from the request rather than the caller, as it does for
+    reads, so a session can only be deleted by the user it belongs to.
+    """
+    user_id = httpreq.state.username
+    agent_url = AGENT_GET_SESSION_ENDPOINT.format(
+        user_id=user_id, session_id=session_id
+    )
+    with httpx.Client(timeout=TIMEOUT) as client:
+        response = client.delete(agent_url)
+        if response.status_code not in (204, 200):
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+
+
 @router.post("/stream")
 @global_permission(roles.Permission.READ)
 def chat_proxy(httpreq: Request, message: dict):
@@ -88,6 +126,7 @@ def chat_proxy(httpreq: Request, message: dict):
         "user_id": username,
         "session_id": message.get("session_id"),
         "text": message.get("text"),
+        "model": message.get("model"),
     }
 
     async def proxy_stream():


### PR DESCRIPTION
Yeti-side pass-throughs for yeti-platform/yeti-agents#10, so the chat UI can offer a model picker and a delete button. Frontend PR follows.

## Endpoints

| | |
| --- | --- |
| `GET /api/v2/agents/models` | the models the agent service will accept, with its default |
| `DELETE /api/v2/agents/sessions/{session_id}` | 204, or 404 if it does not exist |
| `POST /api/v2/agents/stream` | now carries `model` through to the agent service |

Deletion takes the user id from `httpreq.state.username` rather than from the caller, matching the existing reads, so a user can only delete their own sessions.

## Verified against a live agent service

Ran `yeti-agents:dev` on the dev network with `GEMINI_MODELS` configured and drove the proxy:

```
GET /agents/models -> 200 {'provider': 'gemini',
                           'models': ['gemini-3.7-flash', 'gemini-3.6-flash'],
                           'default': 'gemini-3.7-flash'}
DELETE missing     -> 404
sessions before: ['proxy-test']
DELETE          -> 204
sessions after : []
```

## Requires

yeti-agents at or after #10 — earlier images have no `/models` and no `DELETE /sessions/...`, so those two routes would 404 through the proxy.