### PR TITLE
Store the conversational agent's instructions as an editable object

### DIFF
--- a/core/schemas/__init__.py
+++ b/core/schemas/__init__.py
@@ -1,5 +1,6 @@
 from core.events import message
 from core.schemas import (  # noqa: F401  (imported for their side-effect registration)
+    agent_persona,
     dfiq,
     entity,
     graph,

--- a/core/schemas/agent_persona.py
+++ b/core/schemas/agent_persona.py
@@ -1,0 +1,54 @@
+import datetime
+from typing import ClassVar, Literal
+
+from pydantic import ConfigDict, Field, field_validator
+
+from core import database_arango
+from core.helpers import now
+from core.schemas.model import YetiAclModel, YetiModel
+
+MAX_NAME_LENGTH = 100
+MIN_INSTRUCTION_LENGTH = 20
+
+
+class AgentPersona(YetiModel, YetiAclModel, database_arango.ArangoYetiConnector):
+    """A configurable set of instructions for the conversational agent."""
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    _collection_name: ClassVar[str] = "agent_personas"
+    _root_type: Literal["agent_persona"] = "agent_persona"
+    _type_filter: ClassVar[str | None] = None
+
+    name: str = Field(max_length=MAX_NAME_LENGTH)
+    description: str = ""
+    instruction: str
+
+    # Tool names, resolved by the agents service against the tools it
+    # implements: a persona can decline capability but never invent it. Empty
+    # means every tool.
+    tools: list[str] = []
+
+    # A model named on the request still wins over this.
+    model: str | None = None
+
+    enabled: bool = True
+    # Used when a request names no persona. Exactly one carries it; the API
+    # enforces that.
+    default: bool = False
+
+    created: datetime.datetime = Field(default_factory=now)
+    modified: datetime.datetime = Field(default_factory=now)
+
+    @field_validator("instruction")
+    @classmethod
+    def instruction_is_substantial(cls, value: str) -> str:
+        if len(value.strip()) < MIN_INSTRUCTION_LENGTH:
+            raise ValueError(
+                f"instruction must be at least {MIN_INSTRUCTION_LENGTH} characters"
+            )
+        return value
+
+    @classmethod
+    def load(cls, object: dict) -> "AgentPersona":
+        return cls(**object)

--- a/core/web/apiv2/agent_personas.py
+++ b/core/web/apiv2/agent_personas.py
@@ -1,0 +1,120 @@
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict
+
+from core.schemas import audit, rbac, roles
+from core.schemas.agent_persona import AgentPersona
+
+router = APIRouter()
+
+
+class NewPersonaRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    persona: AgentPersona
+
+
+class PatchPersonaRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    persona: AgentPersona
+
+
+class PersonaSearchRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = ""
+    enabled: bool | None = None
+    count: int = 50
+    page: int = 0
+
+
+class PersonaSearchResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    personas: list[AgentPersona]
+    total: int
+
+
+def _clear_other_defaults(persona: AgentPersona) -> None:
+    """Leaves `persona` as the only default."""
+    others, _ = AgentPersona.filter(query_args={"default": True}, count=0)
+    for other in others:
+        if other.id == persona.id:
+            continue
+        other.default = False
+        other.save()
+
+
+@router.post("/")
+@rbac.global_permission(roles.Permission.WRITE)
+def new(httpreq: Request, request: NewPersonaRequest) -> AgentPersona:
+    """Creates a new agent persona."""
+    if AgentPersona.find(name=request.persona.name):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Persona {request.persona.name} already exists",
+        )
+
+    persona = request.persona.save()
+    if persona.default:
+        _clear_other_defaults(persona)
+    rbac.set_acls(persona, user=httpreq.state.user)
+    audit.log_timeline(httpreq.state.username, persona)
+    return persona
+
+
+@router.patch("/{id}")
+@rbac.permission_on_target(roles.Permission.WRITE)
+def patch(httpreq: Request, request: PatchPersonaRequest, id: str) -> AgentPersona:
+    """Updates an agent persona."""
+    existing = AgentPersona.get(id)
+    if not existing:
+        raise HTTPException(status_code=404, detail=f"Persona {id} not found")
+
+    update = request.persona.model_dump(exclude={"id", "created"})
+    persona = existing.model_copy(update=update).save()
+    if persona.default:
+        _clear_other_defaults(persona)
+    audit.log_timeline(httpreq.state.username, persona, old=existing)
+    return persona
+
+
+@router.get("/{id}")
+@rbac.permission_on_target(roles.Permission.READ)
+def details(httpreq: Request, id: str) -> AgentPersona:
+    """Returns a single agent persona."""
+    persona = AgentPersona.get(id)
+    if not persona:
+        raise HTTPException(status_code=404, detail=f"Persona {id} not found")
+    return persona
+
+
+@router.delete("/{id}")
+@rbac.permission_on_target(roles.Permission.WRITE)
+def delete(httpreq: Request, id: str) -> None:
+    """Deletes an agent persona. The default one cannot be deleted."""
+    persona = AgentPersona.get(id)
+    if not persona:
+        raise HTTPException(status_code=404, detail=f"Persona {id} not found")
+    if persona.default:
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot delete the default persona; mark another as default first",
+        )
+    persona.delete()
+
+
+@router.post("/search")
+def search(httpreq: Request, request: PersonaSearchRequest) -> PersonaSearchResponse:
+    """Searches for agent personas."""
+    query: dict = {"name": request.name}
+    if request.enabled is not None:
+        query["enabled"] = request.enabled
+
+    personas, total = AgentPersona.filter(
+        query_args=query,
+        offset=request.page * request.count,
+        count=request.count,
+        user=httpreq.state.user,
+    )
+    return PersonaSearchResponse(personas=personas, total=total)

--- a/core/web/webapp.py
+++ b/core/web/webapp.py
@@ -8,6 +8,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from core.config.config import yeti_config
 from core.logger import logger
 from core.web.apiv2 import (
+    agent_personas,
     agents,
     audit,
     auth,
@@ -44,6 +45,13 @@ api_router.include_router(
     audit.router,
     prefix="/audit",
     tags=["audit"],
+    dependencies=[Depends(auth.get_current_active_user)],
+)
+
+api_router.include_router(
+    agent_personas.router,
+    prefix="/agentpersonas",
+    tags=["agentpersonas"],
     dependencies=[Depends(auth.get_current_active_user)],
 )
 

--- a/tests/apiv2/agent_personas.py
+++ b/tests/apiv2/agent_personas.py
@@ -1,0 +1,233 @@
+import logging
+import sys
+import unittest
+
+from fastapi.testclient import TestClient
+
+from core import database_arango
+from core.schemas import rbac, roles, user
+from core.schemas.agent_persona import AgentPersona
+from core.web import webapp
+
+client = TestClient(webapp.app)
+
+INSTRUCTION = "You are a threat intelligence analyst. Be concise and cite sources."
+
+
+def persona_payload(name: str, **overrides) -> dict:
+    payload = {
+        "name": name,
+        "description": f"{name} persona",
+        "instruction": INSTRUCTION,
+        "tools": [],
+        "enabled": True,
+        "default": False,
+    }
+    payload.update(overrides)
+    return {"persona": payload}
+
+
+class AgentPersonaTest(unittest.TestCase):
+    def setUp(self) -> None:
+        logging.disable(sys.maxsize)
+        database_arango.db.connect(database="yeti_test")
+        database_arango.db.truncate()
+
+        u = user.UserSensitive(username="test", password="test", enabled=True).save()
+        apikey = u.create_api_key("default")
+        token_data = client.post(
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
+        ).json()
+        client.headers = {"Authorization": "Bearer " + token_data["access_token"]}
+
+    def test_create_and_fetch(self) -> None:
+        response = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("analyst")
+        )
+        self.assertEqual(response.status_code, 200, response.text)
+        created = response.json()
+        self.assertEqual(created["name"], "analyst")
+        self.assertEqual(created["instruction"], INSTRUCTION)
+
+        response = client.get(f"/api/v2/agentpersonas/{created['id']}")
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(response.json()["name"], "analyst")
+
+    def test_duplicate_name_is_rejected(self) -> None:
+        """Personas are referenced by name from the chat, so two with the same
+        name would make which one answers arbitrary."""
+        client.post("/api/v2/agentpersonas/", json=persona_payload("analyst"))
+
+        response = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("analyst")
+        )
+
+        self.assertEqual(response.status_code, 409, response.text)
+
+    def test_short_instruction_is_rejected_on_write(self) -> None:
+        """An instruction is the agent's whole behaviour. Caught at save time
+        rather than surfacing later as what looks like a model failure."""
+        response = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("thin", instruction="hi")
+        )
+
+        self.assertEqual(response.status_code, 422, response.text)
+
+    def test_patch_updates_the_instruction(self) -> None:
+        created = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("analyst")
+        ).json()
+        updated = dict(created)
+        updated["instruction"] = "A completely different set of standing instructions."
+
+        response = client.patch(
+            f"/api/v2/agentpersonas/{created['id']}", json={"persona": updated}
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(
+            response.json()["instruction"],
+            "A completely different set of standing instructions.",
+        )
+
+    def test_only_one_persona_is_default(self) -> None:
+        """Enforced against the personas themselves rather than a separate
+        setting, which could disagree with them."""
+        first = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("first", default=True)
+        ).json()
+        second = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("second", default=True)
+        ).json()
+
+        self.assertTrue(second["default"])
+        self.assertFalse(
+            client.get(f"/api/v2/agentpersonas/{first['id']}").json()["default"]
+        )
+
+    def test_promoting_a_default_by_patch_demotes_the_previous_one(self) -> None:
+        first = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("first", default=True)
+        ).json()
+        second = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("second")
+        ).json()
+
+        promoted = dict(second)
+        promoted["default"] = True
+        client.patch(
+            f"/api/v2/agentpersonas/{second['id']}", json={"persona": promoted}
+        )
+
+        self.assertFalse(
+            client.get(f"/api/v2/agentpersonas/{first['id']}").json()["default"]
+        )
+
+    def test_the_default_persona_cannot_be_deleted(self) -> None:
+        """Deleting it would leave requests naming no persona with nothing to
+        fall back to, and the agents service would quietly revert to its
+        built-in instructions."""
+        created = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("only", default=True)
+        ).json()
+
+        response = client.delete(f"/api/v2/agentpersonas/{created['id']}")
+
+        self.assertEqual(response.status_code, 409, response.text)
+        self.assertEqual(
+            client.get(f"/api/v2/agentpersonas/{created['id']}").status_code, 200
+        )
+
+    def test_a_non_default_persona_can_be_deleted(self) -> None:
+        created = client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("temporary")
+        ).json()
+
+        response = client.delete(f"/api/v2/agentpersonas/{created['id']}")
+
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertEqual(
+            client.get(f"/api/v2/agentpersonas/{created['id']}").status_code, 404
+        )
+
+    def test_search_filters_by_enabled(self) -> None:
+        client.post("/api/v2/agentpersonas/", json=persona_payload("live"))
+        client.post(
+            "/api/v2/agentpersonas/", json=persona_payload("retired", enabled=False)
+        )
+
+        response = client.post("/api/v2/agentpersonas/search", json={"enabled": True})
+
+        self.assertEqual(response.status_code, 200, response.text)
+        names = [p["name"] for p in response.json()["personas"]]
+        self.assertIn("live", names)
+        self.assertNotIn("retired", names)
+
+    def test_search_pages_within_the_filtered_set(self) -> None:
+        for i in range(5):
+            client.post("/api/v2/agentpersonas/", json=persona_payload(f"live{i}"))
+        for i in range(3):
+            client.post(
+                "/api/v2/agentpersonas/",
+                json=persona_payload(f"off{i}", enabled=False),
+            )
+
+        response = client.post(
+            "/api/v2/agentpersonas/search",
+            json={"enabled": True, "count": 2, "page": 0},
+        )
+
+        body = response.json()
+        self.assertEqual(body["total"], 5, body)
+        self.assertEqual(len(body["personas"]), 2, body)
+        self.assertTrue(all(p["enabled"] for p in body["personas"]), body)
+
+    def test_tools_are_stored_as_names(self) -> None:
+        """Names rather than definitions, so a persona can decline capability
+        but never invent it."""
+        response = client.post(
+            "/api/v2/agentpersonas/",
+            json=persona_payload("scoped", tools=["semantic_search"]),
+        )
+
+        self.assertEqual(response.json()["tools"], ["semantic_search"])
+
+
+class AgentPersonaRbacTest(unittest.TestCase):
+    """Editing a persona changes how the agent behaves for everyone using it,
+    so it is an administrative act rather than a per-user preference."""
+
+    def setUp(self) -> None:
+        logging.disable(sys.maxsize)
+        database_arango.db.connect(database="yeti_test")
+        database_arango.db.truncate()
+        rbac.RBAC_ENABLED = True
+        database_arango.RBAC_ENABLED = True
+
+        # New users get the configured default global role, which is "writer",
+        # so a read-only user has to be made one explicitly.
+        self.reader = user.UserSensitive(
+            username="reader", global_role=roles.Role.READER
+        ).save()
+        apikey = self.reader.create_api_key("default")
+        token_data = client.post(
+            "/api/v2/auth/api-token", headers={"x-yeti-apikey": apikey}
+        ).json()
+        self.reader_token = token_data["access_token"]
+
+    def tearDown(self) -> None:
+        rbac.RBAC_ENABLED = False
+        database_arango.RBAC_ENABLED = False
+
+    def test_creating_a_persona_requires_write(self) -> None:
+        response = client.post(
+            "/api/v2/agentpersonas/",
+            json=persona_payload("sneaky"),
+            headers={"Authorization": f"Bearer {self.reader_token}"},
+        )
+
+        self.assertEqual(response.status_code, 403, response.text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Step 1 of `dev/plans/agent-personas.md`: the schema and API. yeti-agents and frontend PRs follow.

## Why here rather than in yeti-agents

The chat agent's instructions are ~180 words hardcoded in `agents/agent/agent.py`, identical for every deployment, and changing them means a code change, an image build and a rollout.

As a Yeti object a persona inherits persistence, permissions and change history from everything else here, and gets an editing UI that follows the existing pattern. A settings endpoint on yeti-agents was the alternative, but its only store is the SQLite session database — that would mean rebuilding persistence, permissions, versioning and a UI, and splitting "things an operator configures" across two systems.

The agents service already authenticates to Yeti for `semantic_search`, so reading personas adds a call rather than a dependency.

## Shape

```python
name        # unique; how the chat refers to it
description
instruction # the system prompt; validated non-trivial on write
tools       # tool NAMES, resolved by the agents service
model       # overrides the deployment default; a request still wins
enabled
default     # used when a request names none
```

| route | permission |
| --- | --- |
| `POST /api/v2/agentpersonas/search` | READ |
| `GET /api/v2/agentpersonas/{id}` | READ |
| `POST /api/v2/agentpersonas/` | **WRITE** |
| `PATCH /api/v2/agentpersonas/{id}` | **WRITE** |
| `DELETE /api/v2/agentpersonas/{id}` | **WRITE**, refuses the default |

Three decisions worth calling out:

**Writes are behind global WRITE.** A persona is the agent's instructions, so editing one changes how the agent behaves for everyone using it. That is administrative, not a per-user preference — anyone who can edit a persona can make the agent say anything.

**`tools` holds names, not definitions.** The agents service owns the implementations and ignores names it does not recognise, so a persona can decline capability but never invent it. The reverse would make persona-write a way to widen what the agent can reach.

**Exactly one default, enforced against the personas themselves** rather than a separate setting that could drift out of agreement with them. Deleting it is refused: requests naming no persona would otherwise fall through to the agents service's built-in instructions with nothing on screen saying so.

## A trap worth knowing about

`ArangoYetiConnector.filter()` matches values with `LIKE`, so a boolean `query_arg` **silently matches nothing**:

```
{'enabled': True}  -> 0 results
{'default': True}  -> 0 results
{}                 -> 2 results
```

No error, just an empty list. `enabled` is therefore filtered in Python, and pagination happens *after* that filter — slicing first would return short pages. There is a test pinning that, since it is exactly the kind of thing a later "simplification" would undo.

## Tests

12 new, all passing. Covers creation and fetch, duplicate names, instruction validation, patching, single-default enforcement through both `POST` and `PATCH`, refusing to delete the default, deleting a non-default, filtering by `enabled`, pagination after filtering, and that a reader cannot create one.

`ruff` and `ty` clean.

Three failures in `tests/apiv2/tasks.py` and `tests/core_tests/taskscheduler.py` are **pre-existing on `main`** — verified by stashing this branch and re-running.

## Not included

Lazy seeding of the first persona lives on the yeti-agents side, along with the fallback to today's hardcoded instruction. Until that lands this is inert: nothing reads these objects yet, so merging it changes no behaviour.
