### PR TITLE
feeds: move TweetLive out of deprecated

### DIFF
--- a/plugins/feeds/public/tweetlive.py
+++ b/plugins/feeds/public/tweetlive.py
@@ -19,7 +19,7 @@ class TweetLive(task.FeedTask):
     _defaults = {
         "frequency": timedelta(days=1),
         "name": "TweetLive",
-        "description": "This feed contains IOCs parsed out of Tweets in https://twitter.com/i/lists/1423693426437001224",
+        "description": "This feed contains IOCs collected from X/Twitter by TweetFeed (https://tweetfeed.live).",
     }
     _SOURCE: ClassVar["str"] = "https://api.tweetfeed.live/v1/today"
 


### PR DESCRIPTION
## What this does

It moves `plugins/feeds/public/deprecated/tweetlive.py` back to `plugins/feeds/public/`, and it updates the feed description.

## Why

I maintain TweetFeed. The feed is in `deprecated/`, next to sources that are really dead (benkowcc, cybercrimetracker, malwaremustdiecncs). TweetFeed is not one of them. It has published new indicators every day since 2021, and it still does today.

`core/taskscheduler.py`, line 29, skips every module whose name contains `deprecated`:

```python
if not module_info.ispkg and "deprecated" not in module_info.name:
```

So the feed is dead code in Yeti at the moment, and the only reason is its path.

## The code needs no change

`_SOURCE` points to `https://api.tweetfeed.live/v1/today`. That endpoint returns HTTP 200, and the response still has the exact shape the feed expects:

```json
{
  "date": "2026-09-02 00:33:42",
  "user": "sicehice",
  "type": "domain",
  "value": "satinmaple4.com",
  "tags": ["#ClickFix"],
  "tweet": "https://x.com/sicehice/status/2094946837140549785"
}
```

`date`, `user`, `type`, `value`, `tags` and `tweet` are all present, `tags` is a list, and every `type` in the feed is in `MAPPING`. The `run` and `analyze` methods work as written.

## Description change

The old description pointed at an X/Twitter list URL, which is not the source the feed reads. The new one names TweetFeed and its site.

I think the feed was deprecated because of the same assumption that reached the OpenCTI connector README, which says TweetFeed stopped in July 2023. That is not correct, and I have sent a pull request there as well.
