### PR TITLE
Match boolean filter values exactly instead of by substring

### DIFF
--- a/core/database_arango.py
+++ b/core/database_arango.py
@@ -1304,6 +1304,10 @@ class ArangoYetiConnector(AbstractYetiConnector):
                 else:
                     conditions.append(f"({key_condition})")
                 aql_args[f"arg{i}_key"] = key
+            elif isinstance(value, bool):
+                aql_args[f"arg{i}_key"] = key
+                aql_args[f"arg{i}_value"] = value
+                conditions.append(f"o.@arg{i}_key == @arg{i}_value")
             else:
                 aql_args[f"arg{i}_key"] = key
                 if using_regex:

--- a/tests/schemas/user.py
+++ b/tests/schemas/user.py
@@ -59,3 +59,33 @@ class UserTest(unittest.TestCase):
         user.save()
         user = UserSensitive.find(username="tomchop")
         self.assertEqual(len(user.api_keys), 0)
+
+
+class FilterBooleanValuesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        database_arango.db.connect(database="yeti_test")
+        database_arango.db.truncate()
+        UserSensitive(username="admin-enabled", admin=True, enabled=True).save()
+        UserSensitive(username="plain-enabled", admin=False, enabled=True).save()
+        UserSensitive(username="plain-disabled", admin=False, enabled=False).save()
+
+    def names(self, **query_args) -> list[str]:
+        users, _ = UserSensitive.filter(query_args=query_args)
+        return sorted(u.username for u in users)
+
+    def test_filtering_on_true_matches_only_true(self) -> None:
+        self.assertEqual(self.names(admin=True), ["admin-enabled"])
+
+    def test_filtering_on_false_matches_only_false(self) -> None:
+        self.assertEqual(
+            self.names(enabled=False),
+            ["plain-disabled"],
+        )
+
+    def test_booleans_combine_with_other_filters(self) -> None:
+        self.assertEqual(self.names(username="plain", enabled=True), ["plain-enabled"])
+
+    def test_string_filters_still_substring_match(self) -> None:
+        self.assertEqual(
+            self.names(username="enabled"), ["admin-enabled", "plain-enabled"]
+        )


### PR DESCRIPTION
Follow-up to a trap found while building #1365.

## The bug

`filter()` builds a `LIKE` pattern from any value it has no specific handling for:

```python
aql_args[f"arg{i}_value"] = f"%{value}%"
conditions.append(f"LIKE(o.@arg{i}_key, @arg{i}_value)")
```

For a boolean that produces `"%True%"`. ArangoDB stringifies the stored value as `"true"`, so the case never matches:

```
LIKE(true, "%True%")  ->  false      <- what we generate
LIKE(true, "%true%")  ->  true
LIKE(5,    "%5%")     ->  true       <- numbers were never affected
```

The query returns an empty list. **No error** — the same answer as "nothing matches".

Before:

```
{'admin': True}   ->  0 results
{'admin': False}  ->  0 results
```

After:

```
{'admin': True}       ->  ['admin-enabled']
{'admin': False}      ->  ['plain-enabled', 'plain-disabled']
{'enabled': False}    ->  ['plain-disabled']
```

`False` was wrong in the same way and is the easier one to miss: an empty result reads as *"none are disabled"* rather than as a failed query.

## The change

Booleans are compared for equality — substring-matching one means nothing. Everything else is untouched: strings keep their `LIKE` behaviour, and numbers never had the problem.

## Blast radius

`filter()` backs 29 call sites, so worth being explicit: **no caller passed a boolean value before**, because doing so returned nothing. The only `True`/`False` in existing call sites are keyword arguments (`wildcard=False`, `links_count=True`), not query values. So this cannot change the result of any query that previously worked.

## Tests

Four new, in `tests/schemas/user.py` — `True`, `False`, combining a boolean with a string filter, and a guard that strings still substring-match so the new branch is not over-applied.

Full suite: **476 passed**. The 3 failures in `tests/apiv2/tasks.py` and `tests/core_tests/taskscheduler.py` are pre-existing on `main` — verified by stashing and re-running. The 3 collection errors are missing optional plugin dependencies (`OTXv2`, `timesketch`), also pre-existing.

`ruff` and `ty` clean.

## Effect on #1365

That PR filters `enabled` in Python and paginates afterwards, specifically to work around this. Once this lands it can use the query directly; I will simplify it rather than leave the workaround in place.
