### PR TITLE
Proxy the agent service's tool list

### DIFF
--- a/core/web/apiv2/agents.py
+++ b/core/web/apiv2/agents.py
@@ -27,6 +27,7 @@ AGENT_WEBSOCKET_BASE = yeti_config.get("agents", "websocket_root")
 AGENT_STREAM_ENDPOINT = f"{AGENT_HTTP_BASE}/run_stream"
 AGENT_LIST_SESSIONS_ENDPOINT = f"{AGENT_HTTP_BASE}/sessions/{{user_id}}"
 AGENT_MODELS_ENDPOINT = f"{AGENT_HTTP_BASE}/models"
+AGENT_TOOLS_ENDPOINT = f"{AGENT_HTTP_BASE}/tools"
 AGENT_GET_SESSION_ENDPOINT = f"{AGENT_HTTP_BASE}/sessions/{{user_id}}/{{session_id}}"
 AGENT_WEBSOCKET_ENDPOINT = f"{AGENT_WEBSOCKET_BASE}/ws/chat"
 
@@ -101,6 +102,28 @@ def list_models_proxy(httpreq: Request) -> ModelsResponse:
         if response.status_code != 200:
             raise HTTPException(status_code=response.status_code, detail=response.text)
         return ModelsResponse(**response.json())
+
+
+class ToolInfo(BaseModel):
+    name: str
+    description: str
+
+
+class ToolsResponse(BaseModel):
+    """The tools a persona may select from, as the agent service implements them."""
+
+    tools: List[ToolInfo]
+
+
+@router.get("/tools")
+@global_permission(roles.Permission.READ)
+def list_tools_proxy(httpreq: Request) -> ToolsResponse:
+    """Proxies the list of tools a persona may name."""
+    with httpx.Client(timeout=TIMEOUT) as client:
+        response = client.get(AGENT_TOOLS_ENDPOINT)
+        if response.status_code != 200:
+            raise HTTPException(status_code=response.status_code, detail=response.text)
+        return ToolsResponse(**response.json())
 
 
 @router.delete("/sessions/{session_id}", status_code=204)

--- a/tests/apiv2/agents.py
+++ b/tests/apiv2/agents.py
@@ -171,3 +171,26 @@ class AgentsProxyTest(unittest.TestCase):
 
         sent = agent_service.stream.call_args.kwargs["json"]
         self.assertEqual(sent["user_id"], "test")
+
+    @mock.patch("core.web.apiv2.agents.httpx.Client")
+    def test_list_tools_forwards_names_and_descriptions(self, mock_client_cls):
+        """The persona editor offers these as the tool names this build
+        implements, so a description dropped here would leave the name
+        unexplained rather than merely undocumented."""
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "tools": [
+                {"name": "semantic_search", "description": "Searches Yeti by meaning."}
+            ]
+        }
+        mock_client_cls.return_value.__enter__.return_value.get.return_value = (
+            mock_response
+        )
+
+        response = client.get("/api/v2/agents/tools")
+        self.assertEqual(response.status_code, 200, response.text)
+
+        tools = response.json()["tools"]
+        self.assertEqual(tools[0]["name"], "semantic_search")
+        self.assertEqual(tools[0]["description"], "Searches Yeti by meaning.")


### PR DESCRIPTION
Adds `GET /api/v2/agents/tools`, proxying the agent service's new `/tools` endpoint.

The persona editor currently offers a free-text field for tool names. A name the agent build does not implement is dropped silently when the agent is constructed, so a typo costs the persona a capability with nothing to show for it. This gives the UI the names this deployment actually implements, plus a description of each.

Pairs with yeti-platform/yeti-agents#12, which serves `/tools`, and yeti-platform/yeti-feeds-frontend#315, which consumes it. The frontend degrades to the current free-text behaviour if this endpoint is unavailable, so the three are independent at runtime.

Test: `test_list_tools_forwards_names_and_descriptions`, covering the same field-dropping trap that bit `ADKSession`.